### PR TITLE
Fix time support in potential and other classes

### DIFF
--- a/gala/dynamics/tests/test_nonlinear.py
+++ b/gala/dynamics/tests/test_nonlinear.py
@@ -246,7 +246,7 @@ class TestLogarithmic(object):
 
         def F(t, w):
             w_T = np.ascontiguousarray(w.T)
-            return self.hamiltonian._gradient(w_T, t).T
+            return self.hamiltonian._gradient(w_T, np.array([t])).T
 
         integrator = DOPRI853Integrator(F)
         for ii,w0 in enumerate(self.w0s):

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -33,7 +33,7 @@ def test_compare_to_py(Integrator, integrate_func):
 
     def F(t, w):
         w_T = np.ascontiguousarray(w.T)
-        return H._gradient(w_T).T
+        return H._gradient(w_T, np.array([0.])).T
 
     cy_w0 = np.array([[0.,10.,0.,0.2,0.,0.],
                       [10.,0.,0.,0.,0.2,0.],
@@ -63,7 +63,7 @@ def test_scaling(tmpdir, Integrator, integrate_func):
 
     def F(t,w):
         dq = w[3:]
-        dp = -p._gradient(w[:3])
+        dp = -p._gradient(w[:3], t=np.array([0.]))
         return np.vstack((dq,dp))
 
     step_bins = np.logspace(2,np.log10(25000),7)

--- a/gala/potential/common.py
+++ b/gala/potential/common.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 
 # Third-party
 import astropy.units as u
+from astropy.utils import isiterable
 import numpy as np
 
 # Project
@@ -62,6 +63,25 @@ class CommonBase(object):
         orig_shape = x.shape
         x = np.ascontiguousarray(x.reshape(orig_shape[0], -1).T)
         return orig_shape, x
+
+    def _validate_prepare_time(self, t, pos_c):
+        """
+        Make sure that t is a 1D array and compatible with the C position array.
+        """
+        if hasattr(t, 'unit'):
+            t = t.decompose(self.units).value
+
+        if not isiterable(t):
+            t = np.atleast_1d(t)
+
+        t = np.ascontiguousarray(t.ravel())
+
+        if len(t) > 1:
+            if len(t) != pos_c.shape[0]:
+                raise ValueError("If passing in an array of times, it must have a shape "
+                                 "compatible with the input position(s).")
+
+        return t
 
     # For comparison operations
     def __eq__(self, other):

--- a/gala/potential/frame/cframe.pxd
+++ b/gala/potential/frame/cframe.pxd
@@ -5,7 +5,7 @@ cdef extern from "frame/src/cframe.h":
 cdef class CFrameWrapper:
     cdef CFrame cframe
     cdef double[::1] _params
-    cpdef energy(self, double[:,::1] w, double t=?)
-    cpdef gradient(self, double[:,::1] w, double t=?)
-    cpdef hessian(self, double[:,::1] w, double t=?)
+    cpdef energy(self, double[:,::1] w, double[::1] t)
+    cpdef gradient(self, double[:,::1] w, double[::1] t)
+    cpdef hessian(self, double[:,::1] w, double[::1] t)
 

--- a/gala/potential/hamiltonian/tests/helpers.py
+++ b/gala/potential/hamiltonian/tests/helpers.py
@@ -98,6 +98,11 @@ class _TestBase(object):
             assert v.shape == shp
             assert v.unit.is_equivalent(self.E_unit)
 
+            t = np.zeros(np.array(arr).shape[1:]) + 0.1
+            self.obj.energy(arr, t=0.1)
+            self.obj.energy(arr, t=t)
+            self.obj.energy(arr, t=0.1*self.obj.units['time'])
+
     def test_gradient(self):
         for arr,shp in zip(self.w0s, self.gradient_return_shapes):
             if self.E_unit.is_equivalent(u.one) and hasattr(arr, 'pos') and \
@@ -107,6 +112,11 @@ class _TestBase(object):
             v = self.obj.gradient(arr)
             assert v.shape == shp
             # TODO: check return units
+
+            t = np.zeros(np.array(arr).shape[1:]) + 0.1
+            self.obj.gradient(arr, t=0.1)
+            self.obj.gradient(arr, t=t)
+            self.obj.gradient(arr, t=0.1*self.obj.units['time'])
 
     def test_hessian(self):
         for arr,shp in zip(self.w0s, self.hessian_return_shapes):

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -86,6 +86,16 @@ class PotentialBase(CommonBase):
         x = atleast_2d(x, insert_axis=1).astype(np.float64)
         return x
 
+    def _validate_prepare_time(self, t, pos):
+        # TODO: do I want to make this an array even if input is scalar?
+        if hasattr(t, 'unit'):
+            t = t.decompose(self.units).value
+
+        if not isiterable(t):
+            t = np.atleast_1d(t)
+
+        return t
+
     # ========================================================================
     # Core methods that use the above implemented functions
     #
@@ -105,6 +115,7 @@ class PotentialBase(CommonBase):
         E : `~astropy.units.Quantity`
             The potential energy per unit mass or value of the potential.
         """
+        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
         ret_unit = self.units['energy'] / self.units['mass']
@@ -128,6 +139,7 @@ class PotentialBase(CommonBase):
             The gradient of the potential. Will have the same shape as
             the input position.
         """
+        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
         ret_unit = self.units['length'] / self.units['time']**2
@@ -151,6 +163,7 @@ class PotentialBase(CommonBase):
             position has shape ``q.shape``, the output energy will have
             shape ``q.shape[1:]``.
         """
+        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
         ret_unit = self.units['mass'] / self.units['length']**3
@@ -175,6 +188,7 @@ class PotentialBase(CommonBase):
             ``(q.shape[0],q.shape[0]) + q.shape[1:]``. That is, an ``n_dim`` by
             ``n_dim`` array (matrix) for each position.
         """
+        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
         ret_unit = 1 / self.units['time']**2
@@ -218,6 +232,7 @@ class PotentialBase(CommonBase):
             has shape ``q.shape``, the output energy will have shape
             ``q.shape[1:]``.
         """
+        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
 
@@ -261,11 +276,12 @@ class PotentialBase(CommonBase):
             ``q.shape[1:]``.
 
         """
+        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
 
         # Radius
         r = np.sqrt(np.sum(q**2, axis=0)) * self.units['length']
-        dPhi_dxyz = self.gradient(q)
+        dPhi_dxyz = self.gradient(q, t=t)
         dPhi_dr = np.sum(dPhi_dxyz * q/r.value, axis=0)
 
         return self.units.decompose(np.sqrt(r * np.abs(dPhi_dr)))

--- a/gala/potential/potential/cpotential.pxd
+++ b/gala/potential/potential/cpotential.pxd
@@ -10,11 +10,11 @@ cdef class CPotentialWrapper:
     cdef int[::1] _n_params
     cdef list _potentials # HACK: for CCompositePotentialWrapper
 
-    cpdef energy(self, double[:,::1] q, double t=?)
-    cpdef density(self, double[:,::1] q, double t=?)
-    cpdef gradient(self, double[:,::1] q, double t=?)
-    cpdef hessian(self, double[:,::1] q, double t=?)
+    cpdef energy(self, double[:,::1] q, double[::1] t)
+    cpdef density(self, double[:,::1] q, double[::1] t)
+    cpdef gradient(self, double[:,::1] q, double[::1] t)
+    cpdef hessian(self, double[:,::1] q, double[::1] t)
 
-    cpdef d_dr(self, double[:,::1] q, double G, double t=?)
-    cpdef d2_dr2(self, double[:,::1] q, double G, double t=?)
-    cpdef mass_enclosed(self, double[:,::1] q, double G, double t=?)
+    cpdef d_dr(self, double[:,::1] q, double G, double[::1] t)
+    cpdef d2_dr2(self, double[:,::1] q, double G, double[::1] t)
+    cpdef mass_enclosed(self, double[:,::1] q, double G, double[::1] t)

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -77,7 +77,7 @@ cdef class CPotentialWrapper:
     given potential. This provides a Cython wrapper around this C implementation.
     """
 
-    cpdef energy(self, double[:,::1] q, double t=0.):
+    cpdef energy(self, double[:,::1] q, double[::1] t):
         """
         CAUTION: Interpretation of axes is different here! We need the
         arrays to be C ordered and easy to iterate over, so here the
@@ -87,12 +87,17 @@ cdef class CPotentialWrapper:
         n,ndim = _validate_pos_arr(q)
 
         cdef double [::1] pot = np.zeros(n)
-        for i in range(n):
-            pot[i] = c_potential(&(self.cpotential), t, &q[i,0])
+
+        if len(t) == 1:
+            for i in range(n):
+                pot[i] = c_potential(&(self.cpotential), t[0], &q[i,0])
+        else:
+            for i in range(n):
+                pot[i] = c_potential(&(self.cpotential), t[i], &q[i,0])
 
         return np.array(pot)
 
-    cpdef density(self, double[:,::1] q, double t=0.):
+    cpdef density(self, double[:,::1] q, double[::1] t):
         """
         CAUTION: Interpretation of axes is different here! We need the
         arrays to be C ordered and easy to iterate over, so here the
@@ -102,12 +107,17 @@ cdef class CPotentialWrapper:
         n,ndim = _validate_pos_arr(q)
 
         cdef double [::1] dens = np.zeros(n)
-        for i in range(n):
-            dens[i] = c_density(&(self.cpotential), t, &q[i,0])
+
+        if len(t) == 1:
+            for i in range(n):
+                dens[i] = c_density(&(self.cpotential), t[0], &q[i,0])
+        else:
+            for i in range(n):
+                dens[i] = c_density(&(self.cpotential), t[i], &q[i,0])
 
         return np.array(dens)
 
-    cpdef gradient(self, double[:,::1] q, double t=0.):
+    cpdef gradient(self, double[:,::1] q, double[::1] t):
         """
         CAUTION: Interpretation of axes is different here! We need the
         arrays to be C ordered and easy to iterate over, so here the
@@ -117,12 +127,17 @@ cdef class CPotentialWrapper:
         n,ndim = _validate_pos_arr(q)
 
         cdef double[:,::1] grad = np.zeros((n, ndim))
-        for i in range(n):
-            c_gradient(&(self.cpotential), t, &q[i,0], &grad[i,0])
+
+        if len(t) == 1:
+            for i in range(n):
+                c_gradient(&(self.cpotential), t[0], &q[i,0], &grad[i,0])
+        else:
+            for i in range(n):
+                c_gradient(&(self.cpotential), t[i], &q[i,0], &grad[i,0])
 
         return np.array(grad)
 
-    cpdef hessian(self, double[:,::1] q, double t=0.):
+    cpdef hessian(self, double[:,::1] q, double[::1] t):
         """
         CAUTION: Interpretation of axes is different here! We need the
         arrays to be C ordered and easy to iterate over, so here the
@@ -133,15 +148,19 @@ cdef class CPotentialWrapper:
 
         cdef double[:,:,::1] hess = np.zeros((n, ndim, ndim))
 
-        for i in range(n):
-            c_hessian(&(self.cpotential), t, &q[i,0], &hess[i,0,0])
+        if len(t) == 1:
+            for i in range(n):
+                c_hessian(&(self.cpotential), t[0], &q[i,0], &hess[i,0,0])
+        else:
+            for i in range(n):
+                c_hessian(&(self.cpotential), t[i], &q[i,0], &hess[i,0,0])
 
         return np.array(hess)
 
     # ------------------------------------------------------------------------
     # Other functionality
     #
-    cpdef d_dr(self, double[:,::1] q, double G, double t=0.):
+    cpdef d_dr(self, double[:,::1] q, double G, double[::1] t):
         """
         CAUTION: Interpretation of axes is different here! We need the
         arrays to be C ordered and easy to iterate over, so here the
@@ -153,12 +172,16 @@ cdef class CPotentialWrapper:
         cdef double [::1] dr = np.zeros(n, dtype=np.float64)
         cdef double [::1] epsilon = np.zeros(ndim, dtype=np.float64)
 
-        for i in range(n):
-            dr[i] = c_d_dr(&(self.cpotential), t, &q[i,0], &epsilon[0])
+        if len(t) == 1:
+            for i in range(n):
+                dr[i] = c_d_dr(&(self.cpotential), t[0], &q[i,0], &epsilon[0])
+        else:
+            for i in range(n):
+                dr[i] = c_d_dr(&(self.cpotential), t[i], &q[i,0], &epsilon[0])
 
         return np.array(dr)
 
-    cpdef d2_dr2(self, double[:,::1] q, double G, double t=0.):
+    cpdef d2_dr2(self, double[:,::1] q, double G, double[::1] t):
         """
         CAUTION: Interpretation of axes is different here! We need the
         arrays to be C ordered and easy to iterate over, so here the
@@ -170,12 +193,16 @@ cdef class CPotentialWrapper:
         cdef double [::1] dr2 = np.zeros(n, dtype=np.float64)
         cdef double [::1] epsilon = np.zeros(ndim, dtype=np.float64)
 
-        for i in range(n):
-            dr2[i] = c_d2_dr2(&(self.cpotential), t, &q[i,0], &epsilon[0])
+        if len(t) == 1:
+            for i in range(n):
+                dr2[i] = c_d2_dr2(&(self.cpotential), t[0], &q[i,0], &epsilon[0])
+        else:
+            for i in range(n):
+                dr2[i] = c_d2_dr2(&(self.cpotential), t[i], &q[i,0], &epsilon[0])
 
         return np.array(dr2)
 
-    cpdef mass_enclosed(self, double[:,::1] q, double G, double t=0.):
+    cpdef mass_enclosed(self, double[:,::1] q, double G, double[::1] t):
         """
         CAUTION: Interpretation of axes is different here! We need the
         arrays to be C ordered and easy to iterate over, so here the
@@ -187,8 +214,12 @@ cdef class CPotentialWrapper:
         cdef double [::1] mass = np.zeros(n, dtype=np.float64)
         cdef double [::1] epsilon = np.zeros(ndim, dtype=np.float64)
 
-        for i in range(n):
-            mass[i] = c_mass_enclosed(&(self.cpotential), t, &q[i,0], G, &epsilon[0])
+        if len(t) == 1:
+            for i in range(n):
+                mass[i] = c_mass_enclosed(&(self.cpotential), t[0], &q[i,0], G, &epsilon[0])
+        else:
+            for i in range(n):
+                mass[i] = c_mass_enclosed(&(self.cpotential), t[i], &q[i,0], G, &epsilon[0])
 
         return np.array(mass)
 
@@ -220,16 +251,16 @@ class CPotentialBase(PotentialBase):
 
         self.c_instance = Wrapper(self.G, self.c_parameters)
 
-    def _energy(self, q, t=0.):
+    def _energy(self, q, t):
         return self.c_instance.energy(q, t=t)
 
-    def _gradient(self, q, t=0.):
+    def _gradient(self, q, t):
         return self.c_instance.gradient(q, t=t)
 
-    def _density(self, q, t=0.):
+    def _density(self, q, t):
         return self.c_instance.density(q, t=t)
 
-    def _hessian(self, q, t=0.):
+    def _hessian(self, q, t):
         return self.c_instance.hessian(q, t=t)
 
     # ----------------------------------------------------------
@@ -247,7 +278,7 @@ class CPotentialBase(PotentialBase):
         q : array_like, numeric
             Position to compute the mass enclosed.
         """
-
+        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
 

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -278,9 +278,9 @@ class CPotentialBase(PotentialBase):
         q : array_like, numeric
             Position to compute the mass enclosed.
         """
-        t = self._validate_prepare_time(t)
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
+        t = self._validate_prepare_time(t, q)
 
         try:
             menc = self.c_instance.mass_enclosed(q, self.G, t=t)

--- a/gala/potential/potential/setup_package.py
+++ b/gala/potential/potential/setup_package.py
@@ -44,5 +44,5 @@ def get_package_data():
             ['*.h', '*.pyx', '*.pxd', '*/*.pyx', '*/*.pxd',
              'builtin/builtin_potentials.h',
              'builtin/builtin_potentials.c'
-             'src/cpotential.h', 'src/potential.c',
+             'src/cpotential.h', 'src/cpotential.c',
              'tests/*.yml']}

--- a/gala/potential/potential/tests/helpers.py
+++ b/gala/potential/potential/tests/helpers.py
@@ -42,6 +42,8 @@ class PotentialTestBase(object):
         cls.w0 = np.array(cls.w0)
         cls.ndim = cls.w0.size // 2
 
+        # TODO: need to test also quantity objects and phasespacepositions!
+
         # these are arrays we will test the methods on:
         w0_2d = np.repeat(cls.w0[:,None], axis=1, repeats=16)
         w0_3d = np.repeat(w0_2d[...,None], axis=2, repeats=8)
@@ -70,21 +72,62 @@ class PotentialTestBase(object):
             v = self.potential.energy(arr[:self.ndim])
             assert v.shape == shp
 
+            g = self.potential.energy(arr[:self.ndim], t=0.1)
+            g = self.potential.energy(arr[:self.ndim], t=0.1*self.potential.units['time'])
+
+            t = np.zeros(np.array(arr).shape[1:]) + 0.1
+            g = self.potential.energy(arr[:self.ndim], t=t)
+            g = self.potential.energy(arr[:self.ndim], t=t*self.potential.units['time'])
+
     def test_gradient(self):
         for arr,shp in zip(self.w0s, self._grad_return_shapes):
             g = self.potential.gradient(arr[:self.ndim])
             assert g.shape == shp
+
+            g = self.potential.gradient(arr[:self.ndim], t=0.1)
+            g = self.potential.gradient(arr[:self.ndim], t=0.1*self.potential.units['time'])
+
+            t = np.zeros(np.array(arr).shape[1:]) + 0.1
+            g = self.potential.gradient(arr[:self.ndim], t=t)
+            g = self.potential.gradient(arr[:self.ndim], t=t*self.potential.units['time'])
 
     def test_hessian(self):
         for arr,shp in zip(self.w0s, self._hess_return_shapes):
             g = self.potential.hessian(arr[:self.ndim])
             assert g.shape == shp
 
+            g = self.potential.hessian(arr[:self.ndim], t=0.1)
+            g = self.potential.hessian(arr[:self.ndim], t=0.1*self.potential.units['time'])
+
+            t = np.zeros(np.array(arr).shape[1:]) + 0.1
+            g = self.potential.hessian(arr[:self.ndim], t=t)
+            g = self.potential.hessian(arr[:self.ndim], t=t*self.potential.units['time'])
+
     def test_mass_enclosed(self):
         for arr,shp in zip(self.w0s, self._valu_return_shapes):
             g = self.potential.mass_enclosed(arr[:self.ndim])
             assert g.shape == shp
             assert np.all(g > 0.)
+
+            g = self.potential.mass_enclosed(arr[:self.ndim], t=0.1)
+            g = self.potential.mass_enclosed(arr[:self.ndim], t=0.1*self.potential.units['time'])
+
+            t = np.zeros(np.array(arr).shape[1:]) + 0.1
+            g = self.potential.mass_enclosed(arr[:self.ndim], t=t)
+            g = self.potential.mass_enclosed(arr[:self.ndim], t=t*self.potential.units['time'])
+
+    def test_circular_velocity(self):
+        for arr,shp in zip(self.w0s, self._valu_return_shapes):
+            g = self.potential.circular_velocity(arr[:self.ndim])
+            assert g.shape == shp
+            assert np.all(g > 0.)
+
+            g = self.potential.circular_velocity(arr[:self.ndim], t=0.1)
+            g = self.potential.circular_velocity(arr[:self.ndim], t=0.1*self.potential.units['time'])
+
+            t = np.zeros(np.array(arr).shape[1:]) + 0.1
+            g = self.potential.circular_velocity(arr[:self.ndim], t=t)
+            g = self.potential.circular_velocity(arr[:self.ndim], t=t*self.potential.units['time'])
 
     def test_repr(self):
         pot_repr = repr(self.potential)
@@ -163,13 +206,13 @@ class PotentialTestBase(object):
 
         def energy_wrap(xyz):
             xyz = np.ascontiguousarray(xyz[None])
-            return self.potential._energy(xyz, t=0.)[0]
+            return self.potential._energy(xyz, t=np.array([0.]))[0]
 
         num_grad = np.zeros_like(xyz)
         for i in range(xyz.shape[0]):
             num_grad[i] = np.squeeze([partial_derivative(energy_wrap, xyz[i], dim_ix=dim_ix, n=1, dx=dx, order=5)
                                       for dim_ix in range(self.w0.size//2)])
-        grad = self.potential._gradient(xyz)
+        grad = self.potential._gradient(xyz, t=np.array([0.]))
 
         assert np.allclose(num_grad, grad, rtol=self.tol)
 

--- a/gala/potential/setup_package.py
+++ b/gala/potential/setup_package.py
@@ -57,9 +57,6 @@
 
 #     return exts
 
-# def get_package_data():
-#     return {'gala.potential': ['*.h', '*.pyx', '*.pxd', '*/*.pyx', '*/*.pxd',
-#                                'builtin/src/*.h', 'src/*.h',
-#                                'builtin/src/*.c', 'src/*.c',
-#                                'tests/*.yml']}
+def get_package_data():
+    return {'gala.potential': ['src/funcdefs.h', 'potential/src/cpotential.h']}
 


### PR DESCRIPTION
This addresses #66, but does not fix all cases. Right now, a time can either be passed in as a scalar or as an array with the same total size as the position array. But, for example, we might want to support the case 1 position, many times and get out an `Orbit` object? 