### PR TITLE
Add approximate option for apocenter and pericenter

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python==3.6
-  - astropy>=2
+  - astropy>=3
   - astropy-helpers
   - numpy
   - cython
@@ -17,4 +17,4 @@ dependencies:
   - notebook
   - ipykernel
   - pip:
-    - nbsphinx
+    - nbsphinx==0.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - CONDA_DEPENDENCIES='cython jinja2 scipy matplotlib pyyaml h5py sympy qt ipython jupyter notebook ipykernel' # SEE PANDOC HACK BELOW
-        - PIP_DEPENDENCIES='nbsphinx'
+        - PIP_DEPENDENCIES='nbsphinx==0.3.1'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
 
     matrix:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,18 @@ New Features
 ------------
 
 - Added a ``NullPotential`` class that has 0 mass and serves as a placeholder.
+- Added a new ``zmax()`` method on the ``Orbit`` class to compute the maximum z
+  heights and times, or the mean maximum z height. Similar to ``apocenter()``
+  and ``pericenter()``.
+- Added a new generator method on the ``Orbit`` class for easy iteration over
+  orbits.
 
-API-breaking changes
---------------------
+Bug fixes
+---------
+
+- ``Orbit.norbits`` now works...oops.
+- ``apocenter()`` and ``pericenter()`` now work when more than one orbit is
+  stored in an ``Orbit`` class.
 
 0.2.2 (2017-10-07)
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ except ImportError:
             sys.path.insert(1, a_h_path)
 
 # Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
+from sphinx_astropy.conf import *
 
 # Get configuration information from setup.cfg
 try:

--- a/docs/examples/Milky-Way-model.ipynb
+++ b/docs/examples/Milky-Way-model.ipynb
@@ -19,9 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Some imports we'll need later:\n",
@@ -53,9 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "potential = gp.MilkyWayPotential()"
@@ -71,9 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "icrs = coord.ICRS(ra=coord.Angle('17h 20m 12.4s'), \n",
@@ -99,9 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "v_sun = coord.CartesianDifferential([11.1, 250, 7.25]*u.km/u.s)\n",
@@ -120,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "gc = icrs.transform_to(gc_frame)"
@@ -138,9 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w0 = gd.PhaseSpacePosition(gc.data)\n",
@@ -157,9 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = orbit.plot()"
@@ -175,9 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "orbit.pericenter(), orbit.apocenter(), orbit.eccentricity()"
@@ -193,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.plot(orbit.t, orbit.spherical.distance, marker='None')\n",
@@ -223,9 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "n_samples = 256\n",
@@ -250,9 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "icrs_samples = coord.ICRS(ra=ra, dec=dec, distance=dist,\n",
@@ -263,9 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "icrs_samples.shape"
@@ -274,9 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "gc_samples = icrs_samples.transform_to(gc_frame)"
@@ -285,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w0_samples = gd.PhaseSpacePosition(gc_samples.data)\n",
@@ -297,9 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "orbit_samples.shape"
@@ -308,9 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pers = []\n",
@@ -330,9 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, axes = plt.subplots(1, 3, figsize=(12, 4))\n",
@@ -365,7 +331,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/gala/dynamics/orbit.py
+++ b/gala/dynamics/orbit.py
@@ -568,7 +568,7 @@ class Orbit(PhaseSpacePosition):
         Parameters
         ----------
         func : func (optional)
-            A function to evaluate on all of the identified |z| maximum times.
+            A function to evaluate on all of the identified z maximum times.
         return_times : bool (optional)
             Also return the times of maximum.
         interp_kwargs : dict (optional)
@@ -582,7 +582,7 @@ class Orbit(PhaseSpacePosition):
         Returns
         -------
         zs : float, :class:`~numpy.ndarray`
-            Either a single number or an array of maximum |z| heights.
+            Either a single number or an array of maximum z heights.
         times : :class:`~numpy.ndarray` (optional, see ``return_times``)
             If ``return_times=True``, also returns an array of the apocenter
             times.

--- a/gala/dynamics/orbit.py
+++ b/gala/dynamics/orbit.py
@@ -212,7 +212,7 @@ class Orbit(PhaseSpacePosition):
         if self.xyz.ndim < 3:
             return 1
         else:
-            return self.shape[2]
+            return self.shape[1]
 
     # ------------------------------------------------------------------------
     # Input / output
@@ -297,6 +297,17 @@ class Orbit(PhaseSpacePosition):
         return cls(pos=pos, vel=vel, t=time,
                    frame=frame, potential=potential)
 
+    def orbit_gen(self):
+        """
+        Generator for iterating over each orbit.
+        """
+        if self.norbits == 1:
+            yield self
+
+        else:
+            for i in range(self.norbits):
+                yield self[:, i]
+
     # ------------------------------------------------------------------------
     # Computed dynamical quantities
     #
@@ -354,8 +365,56 @@ class Orbit(PhaseSpacePosition):
 
         return hamiltonian(self)
 
+    def _max_helper(self, arr, approximate=False,
+                    interp_kwargs=None, minimize_kwargs=None):
+        """
+        Helper function for computing extrema (apocenter, pericenter, z_height)
+        and times of extrema.
+
+        Parameters
+        ----------
+        arr : `numpy.ndarray`
+        """
+        assert self.norbits == 1
+        assert self.t[-1] > self.t[0] # time must increase
+
+        _ix = argrelmax(arr.value, mode='wrap')[0]
+        _ix = _ix[(_ix != 0) & (_ix != (len(arr)-1))] # remove edges
+        t = self.t.value
+
+        approx_arr = arr[_ix]
+        approx_t = t[_ix]
+
+        if approximate:
+            return approx_arr, approx_t * self.t.unit
+
+        if interp_kwargs is None:
+            interp_kwargs = dict()
+
+        if minimize_kwargs is None:
+            minimize_kwargs = dict()
+
+        # default scipy function kwargs
+        interp_kwargs.setdefault('k', 3)
+        interp_kwargs.setdefault('ext', 3) # don't extrapolate, use boundary
+        minimize_kwargs.setdefault('method', 'powell')
+
+        # Interpolating function to upsample array:
+        # Negative sign because we assume we're always finding the maxima
+        interp_func = InterpolatedUnivariateSpline(t, -arr.value,
+                                                   **interp_kwargs)
+
+        better_times = np.zeros(_ix.shape, dtype=float)
+        for i, j in enumerate(_ix):
+            res = minimize(interp_func, t[j], **minimize_kwargs)
+            better_times[i] = res.x
+
+        better_arr = -interp_func(better_times)
+        return better_arr * arr.unit, better_times * self.t.unit
+
     def pericenter(self, return_times=False, func=np.mean,
-                   interp_kwargs=None, minimize_kwargs=None):
+                   interp_kwargs=None, minimize_kwargs=None,
+                   approximate=False):
         """
         Estimate the pericenter(s) of the orbit by identifying local minima in
         the spherical radius and interpolating between timesteps near the
@@ -376,6 +435,8 @@ class Orbit(PhaseSpacePosition):
             :class:`scipy.interpolate.InterpolatedUnivariateSpline`.
         minimize_kwargs : dict (optional)
             Keyword arguments to be passed to :class:`scipy.optimize.minimize`.
+        approximate : bool (optional)
+            Compute an approximate pericenter by skipping interpolation.
 
         Returns
         -------
@@ -393,12 +454,6 @@ class Orbit(PhaseSpacePosition):
                              "you want to return all individual pericenters "
                              "and times.")
 
-        if interp_kwargs is None:
-            interp_kwargs = dict()
-
-        if minimize_kwargs is None:
-            minimize_kwargs = dict()
-
         if func is None:
             func = lambda x: x
 
@@ -406,44 +461,31 @@ class Orbit(PhaseSpacePosition):
         if self.t[-1] < self.t[0]:
             self = self[::-1]
 
-        # default scipy function kwargs
-        interp_kwargs.setdefault('k', 3)
-        interp_kwargs.setdefault('ext', 3) # don't extrapolate, return boundary
-        minimize_kwargs.setdefault('method', 'powell')
-
-        # orbital radius
-        r = self.physicsspherical.r.value
-        t = self.t.value
-        _ix = argrelmin(r, mode='wrap')[0]
-
-        # remove 0'th index and final index, if present, to remove ambiguity
-        _ix = _ix[(_ix != 0) & (_ix != (len(r)-1))]
-
-        # interpolating function to upsample orbit
-        interp_func = InterpolatedUnivariateSpline(t, r, **interp_kwargs)
-
-        refined_times = np.zeros(_ix.shape, dtype=float)
-        for i,j in enumerate(_ix):
-            res = minimize(interp_func, t[j], **minimize_kwargs)
-            refined_times[i] = res.x
-
-        peri = interp_func(refined_times) * self.cartesian.x.unit
+        vals = []
+        times = []
+        for orbit in self.orbit_gen():
+            v, t = orbit._max_helper(-orbit.physicsspherical.r, # pericenter
+                                     interp_kwargs=interp_kwargs,
+                                     minimize_kwargs=minimize_kwargs,
+                                     approximate=approximate)
+            vals.append(func(-v)) # negative for pericenter
+            times.append(t)
 
         if return_times:
-            return peri, refined_times * self.t.unit
-
+            return u.Quantity(vals), u.Quantity(times)
         else:
-            return func(peri)
+            return u.Quantity(vals)
 
     def apocenter(self, return_times=False, func=np.mean,
-                  interp_kwargs=None, minimize_kwargs=None):
+                  interp_kwargs=None, minimize_kwargs=None,
+                  approximate=False):
         """
         Estimate the apocenter(s) of the orbit by identifying local maxima in
         the spherical radius and interpolating between timesteps near the
         maxima.
 
         By default, this returns the mean of all local maxima (apocenters). To
-        get, e.g., the largest apocenter, pass in ``func=np.min``. To get
+        get, e.g., the largest apocenter, pass in ``func=np.max``. To get
         all apocenters, pass in ``func=None``.
 
         Parameters
@@ -457,6 +499,8 @@ class Orbit(PhaseSpacePosition):
             :class:`scipy.interpolate.InterpolatedUnivariateSpline`.
         minimize_kwargs : dict (optional)
             Keyword arguments to be passed to :class:`scipy.optimize.minimize`.
+        approximate : bool (optional)
+            Compute an approximate apocenter by skipping interpolation.
 
         Returns
         -------
@@ -474,11 +518,69 @@ class Orbit(PhaseSpacePosition):
                              "you want to return all individual apocenters "
                              "and times.")
 
-        if interp_kwargs is None:
-            interp_kwargs = dict()
+        if func is None:
+            func = lambda x: x
 
-        if minimize_kwargs is None:
-            minimize_kwargs = dict()
+        # time must increase
+        if self.t[-1] < self.t[0]:
+            self = self[::-1]
+
+        vals = []
+        times = []
+        for orbit in self.orbit_gen():
+            v, t = orbit._max_helper(orbit.physicsspherical.r, # apocenter
+                                     interp_kwargs=interp_kwargs,
+                                     minimize_kwargs=minimize_kwargs,
+                                     approximate=approximate)
+            vals.append(func(v))
+            times.append(t)
+
+        if return_times:
+            return u.Quantity(vals), u.Quantity(times)
+        else:
+            return u.Quantity(vals)
+
+    def zmax(self, return_times=False, func=np.mean,
+             interp_kwargs=None, minimize_kwargs=None,
+             approximate=False):
+        """
+        Estimate the maximum ``z`` height of the orbit by identifying local
+        maxima in the absolute value of the ``z`` position and interpolating
+        between timesteps near the maxima.
+
+        By default, this returns the mean of all local maxima. To get, e.g., the
+        largest ``z`` excursion, pass in ``func=np.max``. To get all ``z``
+        maxima, pass in ``func=None``.
+
+        Parameters
+        ----------
+        func : func (optional)
+            A function to evaluate on all of the identified |z| maximum times.
+        return_times : bool (optional)
+            Also return the times of maximum.
+        interp_kwargs : dict (optional)
+            Keyword arguments to be passed to
+            :class:`scipy.interpolate.InterpolatedUnivariateSpline`.
+        minimize_kwargs : dict (optional)
+            Keyword arguments to be passed to :class:`scipy.optimize.minimize`.
+        approximate : bool (optional)
+            Compute approximate values by skipping interpolation.
+
+        Returns
+        -------
+        zs : float, :class:`~numpy.ndarray`
+            Either a single number or an array of maximum |z| heights.
+        times : :class:`~numpy.ndarray` (optional, see ``return_times``)
+            If ``return_times=True``, also returns an array of the apocenter
+            times.
+
+        """
+
+        if return_times and func is None:
+            raise ValueError("Cannot return times if reducing "
+                             "using an input function. Pass `func=None` if "
+                             "you want to return all individual values "
+                             "and times.")
 
         if func is None:
             func = lambda x: x
@@ -487,36 +589,22 @@ class Orbit(PhaseSpacePosition):
         if self.t[-1] < self.t[0]:
             self = self[::-1]
 
-        # default scipy function kwargs
-        interp_kwargs.setdefault('k', 3)
-        interp_kwargs.setdefault('ext', 3) # don't extrapolate, return boundary
-        minimize_kwargs.setdefault('method', 'powell')
-
-        # orbital radius
-        r = self.physicsspherical.r.value
-        t = self.t.value
-        _ix = argrelmax(r, mode='wrap')[0]
-
-        # remove 0'th index and final index, if present, to remove ambiguity
-        _ix = _ix[(_ix != 0) & (_ix != (len(r)-1))]
-
-        # interpolating function to upsample orbit
-        interp_func = InterpolatedUnivariateSpline(t, r, **interp_kwargs)
-
-        refined_times = np.zeros(_ix.shape, dtype=float)
-        for i,ix in enumerate(_ix):
-            res = minimize(lambda x: -interp_func(x), t[ix], **minimize_kwargs)
-            refined_times[i] = res.x
-
-        apo = interp_func(refined_times) * self.cartesian.x.unit
+        vals = []
+        times = []
+        for orbit in self.orbit_gen():
+            v, t = orbit._max_helper(np.abs(orbit.cylindrical.z),
+                                     interp_kwargs=interp_kwargs,
+                                     minimize_kwargs=minimize_kwargs,
+                                     approximate=approximate)
+            vals.append(func(v))
+            times.append(t)
 
         if return_times:
-            return apo, refined_times * self.t.unit
-
+            return u.Quantity(vals), u.Quantity(times)
         else:
-            return func(apo)
+            return u.Quantity(vals)
 
-    def eccentricity(self):
+    def eccentricity(self, **kw):
         r"""
         Returns the eccentricity computed from the mean apocenter and
         mean pericenter.
@@ -525,14 +613,20 @@ class Orbit(PhaseSpacePosition):
 
             e = \frac{r_{\rm apo} - r_{\rm per}}{r_{\rm apo} + r_{\rm per}}
 
+        Parameters
+        ----------
+        **kw
+            Any keyword arguments passed to ``apocenter()`` and
+            ``pericenter()``. For example, ``approximate=True``.
+
         Returns
         -------
         ecc : float
             The orbital eccentricity.
 
         """
-        ra = self.apocenter()
-        rp = self.pericenter()
+        ra = self.apocenter(**kw)
+        rp = self.pericenter(**kw)
         return (ra - rp) / (ra + rp)
 
     def estimate_period(self, radial=True):

--- a/gala/dynamics/orbit.py
+++ b/gala/dynamics/orbit.py
@@ -412,6 +412,19 @@ class Orbit(PhaseSpacePosition):
         better_arr = -interp_func(better_times)
         return better_arr * arr.unit, better_times * self.t.unit
 
+    def _max_return_helper(self, vals, times, return_times, reduce):
+        if return_times:
+            if len(vals) == 1:
+                return vals[0], times[0]
+            else:
+                return vals, times
+
+        elif reduce:
+            return u.Quantity(vals).reshape(self.shape[1:])
+
+        else:
+            return u.Quantity(vals)
+
     def pericenter(self, return_times=False, func=np.mean,
                    interp_kwargs=None, minimize_kwargs=None,
                    approximate=False):
@@ -474,12 +487,7 @@ class Orbit(PhaseSpacePosition):
             vals.append(func(-v)) # negative for pericenter
             times.append(t)
 
-        if return_times:
-            return vals, times
-        elif reduce:
-            return u.Quantity(vals).reshape(self.shape[1:])
-        else:
-            return u.Quantity(vals)
+        return self._max_return_helper(vals, times, return_times, reduce)
 
     def apocenter(self, return_times=False, func=np.mean,
                   interp_kwargs=None, minimize_kwargs=None,
@@ -543,12 +551,7 @@ class Orbit(PhaseSpacePosition):
             vals.append(func(v))
             times.append(t)
 
-        if return_times:
-            return vals, times
-        elif reduce:
-            return u.Quantity(vals).reshape(self.shape[1:])
-        else:
-            return u.Quantity(vals)
+        return self._max_return_helper(vals, times, return_times, reduce)
 
     def zmax(self, return_times=False, func=np.mean,
              interp_kwargs=None, minimize_kwargs=None,
@@ -612,12 +615,7 @@ class Orbit(PhaseSpacePosition):
             vals.append(func(v))
             times.append(t)
 
-        if return_times:
-            return vals, times
-        elif reduce:
-            return u.Quantity(vals).reshape(self.shape[1:])
-        else:
-            return u.Quantity(vals)
+        return self._max_return_helper(vals, times, return_times, reduce)
 
     def eccentricity(self, **kw):
         r"""

--- a/gala/dynamics/orbit.py
+++ b/gala/dynamics/orbit.py
@@ -455,7 +455,10 @@ class Orbit(PhaseSpacePosition):
                              "and times.")
 
         if func is None:
+            reduce = False
             func = lambda x: x
+        else:
+            reduce = True
 
         # time must increase
         if self.t[-1] < self.t[0]:
@@ -472,7 +475,9 @@ class Orbit(PhaseSpacePosition):
             times.append(t)
 
         if return_times:
-            return u.Quantity(vals), u.Quantity(times)
+            return vals, times
+        elif reduce:
+            return u.Quantity(vals).reshape(self.shape[1:])
         else:
             return u.Quantity(vals)
 
@@ -519,7 +524,10 @@ class Orbit(PhaseSpacePosition):
                              "and times.")
 
         if func is None:
+            reduce = False
             func = lambda x: x
+        else:
+            reduce = True
 
         # time must increase
         if self.t[-1] < self.t[0]:
@@ -536,7 +544,9 @@ class Orbit(PhaseSpacePosition):
             times.append(t)
 
         if return_times:
-            return u.Quantity(vals), u.Quantity(times)
+            return vals, times
+        elif reduce:
+            return u.Quantity(vals).reshape(self.shape[1:])
         else:
             return u.Quantity(vals)
 
@@ -583,7 +593,10 @@ class Orbit(PhaseSpacePosition):
                              "and times.")
 
         if func is None:
+            reduce = False
             func = lambda x: x
+        else:
+            reduce = True
 
         # time must increase
         if self.t[-1] < self.t[0]:
@@ -600,7 +613,9 @@ class Orbit(PhaseSpacePosition):
             times.append(t)
 
         if return_times:
-            return u.Quantity(vals), u.Quantity(times)
+            return vals, times
+        elif reduce:
+            return u.Quantity(vals).reshape(self.shape[1:])
         else:
             return u.Quantity(vals)
 

--- a/gala/dynamics/tests/test_orbit.py
+++ b/gala/dynamics/tests/test_orbit.py
@@ -342,6 +342,9 @@ def test_apocenter_pericenter():
     apo = w.apocenter()
     per = w.pericenter()
     zmax = w.zmax()
+    assert apo.shape == ()
+    assert per.shape == ()
+    assert zmax.shape == ()
 
     assert apo.unit == u.au
     assert per.unit == u.au

--- a/gala/dynamics/tests/test_orbit.py
+++ b/gala/dynamics/tests/test_orbit.py
@@ -336,13 +336,16 @@ def test_apocenter_pericenter():
                             vel=[0.,1.5*np.pi,0.]*u.au/u.yr)
 
     ham = Hamiltonian(pot)
-    w = ham.integrate_orbit(w0, dt=0.01, n_steps=10000, Integrator=DOPRI853Integrator)
+    w = ham.integrate_orbit(w0, dt=0.01, n_steps=10000,
+                            Integrator=DOPRI853Integrator)
 
     apo = w.apocenter()
     per = w.pericenter()
+    zmax = w.zmax()
 
     assert apo.unit == u.au
     assert per.unit == u.au
+    assert zmax.unit == u.au
     assert apo > per
 
     # see if they're where we expect
@@ -361,12 +364,25 @@ def test_apocenter_pericenter():
     # Return all peris, apos
     apos = w.apocenter(func=None)
     pers = w.pericenter(func=None)
+    zmax = w.zmax(func=None)
 
     dapo = np.std(apos) / np.mean(apos)
     assert (dapo > 0) and np.allclose(dapo, 0., atol=1E-5)
 
     dper = np.std(pers) / np.mean(pers)
     assert (dper > 0) and np.allclose(dper, 0., atol=1E-5)
+
+    # Now try for expected behavior when multiple orbits are integrated:
+    w0 = PhaseSpacePosition(pos=([[1,0,0.], [1.1,0,0]]*u.au).T,
+                            vel=([[0.,1.5*np.pi,0.],
+                                  [0.,1.5*np.pi,0.]]*u.au/u.yr).T)
+
+    w = ham.integrate_orbit(w0, dt=0.01, n_steps=10000)
+
+    per = w.pericenter(approximate=True)
+    apo = w.apocenter(approximate=True)
+    zmax = w.zmax(approximate=True)
+    ecc = w.eccentricity(approximate=True)
 
 def test_estimate_period():
     ntimes = 16384


### PR DESCRIPTION
This adds a few new things:

- Added a new ``zmax()`` method on the ``Orbit`` class to compute the maximum z heights and times, or the mean maximum z height. Similar to ``apocenter()`` and ``pericenter()``.
- Added a new generator method on the ``Orbit`` class for easy iteration over orbits.
- ``apocenter()`` and ``pericenter()`` now work when more than one orbit is stored in an ``Orbit`` class.

Fixes #95