### PR TITLE
Add ability to rotate potentials by arbitrary angles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,6 @@ matrix:
           env: NUMPY_VERSION=development
 
         - os: linux
-          env: PYTHON_VERSION=3.5
-
-        - os: linux
           env: PYTHON_VERSION=3.7
 
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New Features
   ``BovyMWPotential2014`` in ``gala``).
 - Added an implementation of the Self-Consistent Field (SCF) basis function
   expansion method for representing potential-density pairs.
+- Most Potential classes now support rotations and origin shifts through the
+  ``R`` and ``origin`` arguments.
 
 Bug fixes
 ---------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,8 @@ rst_epilog += """
 
 # Add sympy to intersphinx mapping
 intersphinx_mapping['sympy'] = ('http://docs.sympy.org/latest/', None)
+intersphinx_mapping['scipy'] = ('http://docs.scipy.org/doc/scipy/reference',
+                                None)
 
 # Show / hide TODO blocks
 todo_include_todos = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ rst_epilog += """
 
 # Add sympy to intersphinx mapping
 intersphinx_mapping['sympy'] = ('http://docs.sympy.org/latest/', None)
-intersphinx_mapping['scipy'] = ('http://docs.scipy.org/doc/scipy/reference',
+intersphinx_mapping['scipy'] = ('https://docs.scipy.org/doc/scipy/reference',
                                 None)
 
 # Show / hide TODO blocks

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -88,15 +88,17 @@ Python Dependencies
 This packages has the following dependencies (note that the version requirements
 below indicate the versions for which Gala is tested with and should work with):
 
-- `Python`_ >= 2.7
+- `Python`_ >= 3.6
 
-- `Numpy`_ >= 1.12
+- `Numpy`_ >= 1.16
 
-- `Cython <http://www.cython.org/>`_: >= 0.25
+- `Cython <http://www.cython.org/>`_: >= 0.28
 
-- `Astropy`_ >= 2
+- `Astropy`_ >= 3
 
 - `PyYAML`_ >= 3.10
+
+- `scipy`_ >= 1.1
 
 You can use ``pip`` or ``conda`` to install these automatically.
 

--- a/docs/potential/define-new-potential.rst
+++ b/docs/potential/define-new-potential.rst
@@ -17,8 +17,8 @@ initial testing. If there is a potential class that you think should be
 included, feel free to suggest the new addition as a `GitHub issue
 <https://github.com/adrn/gala/issues>`_!
 
-For code blocks below and any pages linked below, I assume the following
-imports have already been excuted::
+For code blocks below and any pages linked below, we assume the following
+imports have already been executed::
 
     >>> import numpy as np
     >>> import gala.potential as gp

--- a/docs/potential/index.rst
+++ b/docs/potential/index.rst
@@ -255,6 +255,7 @@ More details are provided in the linked pages below:
 
    define-new-potential
    compositepotential
+   origin-rotation
    hamiltonian-reference-frames
    define-milky-way-model
    scf

--- a/docs/potential/origin-rotation.rst
+++ b/docs/potential/origin-rotation.rst
@@ -38,7 +38,7 @@ these two objects into a `~gala.potential.CCompositePotential` and visualize the
 potential::
 
     >>> pot = gp.CCompositePotential(p1=p1, p2=p2)
-    >>> fig, ax = plt.subplots(1, 1, figsize=(5, 5))
+    >>> fig, ax = plt.subplots(1, 1, figsize=(5, 5)) # doctest: +SKIP
     >>> grid = np.linspace(-5, 5, 100)
     >>> p.plot_contours(grid=(grid, grid, 0.), ax=ax) # doctest: +SKIP
     >>> ax.set_xlabel("$x$ [kpc]") # doctest: +SKIP

--- a/docs/potential/origin-rotation.rst
+++ b/docs/potential/origin-rotation.rst
@@ -1,0 +1,139 @@
+.. _rotate-origin-potential:
+
+For code blocks below, we assume the following imports have already been
+executed::
+
+    >>> import astropy.units as u
+    >>> import numpy as np
+    >>> import gala.potential as gp
+    >>> from gala.units import galactic, solarsystem
+
+**************************************************************
+Specifying rotations or origin shifts to ``Potential`` classes
+**************************************************************
+
+Most of the gravitational potential classes implemented in ``gala`` support
+shifting the origin of the potential relative to the coordinate system, and
+specifying a rotation of the potential relative to the coordinate system.
+By default, the origin is assumed to be at (0,0,0) or (0,0), and there is no
+rotation assumed.
+
+Origin shifts
+=============
+
+For potential classes that support these options, origin shifts are specified by
+passing in a `~astropy.units.Quantity` to set the origin of the potential in the
+given coordinate system. For example, if we are working with two
+`~gala.potential.KeplerPotential` objects, and we want them to be offset from
+one another such that one potential is at ``(1, 0, 0)`` AU and the other is at
+``(-2, 0, 0)`` AU, we would define the two objects as::
+
+    >>> p1 = gp.KeplerPotential(m=1*u.Msun, origin=[1, 0, 0]*u.au,
+    ...                         units=solarsystem)
+    >>> p2 = gp.KeplerPotential(m=0.5*u.Msun, origin=[-2, 0, 0]*u.au,
+    ...                         units=solarsystem)
+
+To see that these are shifted from the coordinate system origin, let's combine
+these two objects into a `~gala.potential.CCompositePotential` and visualize the
+potential::
+
+    >>> pot = gp.CCompositePotential(p1=p1, p2=p2)
+    >>> fig, ax = plt.subplots(1, 1, figsize=(5, 5))
+    >>> grid = np.linspace(-5, 5, 100)
+    >>> p.plot_contours(grid=(grid, grid, 0.), ax=ax) # doctest: +SKIP
+    >>> ax.set_xlabel("$x$ [kpc]") # doctest: +SKIP
+    >>> ax.set_ylabel("$y$ [kpc]") # doctest: +SKIP
+
+.. plot::
+    :align: center
+    :context: close-figs
+
+    import astropy.units as u
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import gala.potential as gp
+    from gala.units import galactic, solarsystem
+
+    p1 = gp.KeplerPotential(m=1*u.Msun, origin=[1, 0, 0]*u.au,
+                            units=solarsystem)
+    p2 = gp.KeplerPotential(m=0.5*u.Msun, origin=[-2, 0, 0]*u.au,
+                            units=solarsystem)
+
+    pot = gp.CCompositePotential(p1=p1, p2=p2)
+    fig, ax = plt.subplots(1, 1, figsize=(5, 5))
+    grid = np.linspace(-5, 5, 100)
+    pot.plot_contours(grid=(grid, grid, 0.), ax=ax) # doctest: +SKIP
+    ax.set_xlabel("$x$ [kpc]") # doctest: +SKIP
+    ax.set_ylabel("$y$ [kpc]") # doctest: +SKIP
+    fig.tight_layout()
+
+
+Rotations
+=========
+
+Rotations can be specified either by passing in a
+`scipy.spatial.transform.Rotation` instance, or by passing in a 2D numpy array
+specifying a rotation matrix. For example, let's see what happens if we rotate a
+bar potential using these two possible inputs. First, we'll define a rotation matrix specifying a 30 degree
+rotation around the z axis (i.e. counter-clockwise) using `astropy.coordinates.matrix_utilities.rotation_matrix`. Next, we'll define a rotation using a scipy `~scipy.spatial.transform.Rotation` object::
+
+    >>> from astropy.coordinates.matrix_utilities import rotation_matrix
+    >>> from scipy.spatial.transform import Rotation
+    >>> R_arr = rotation_matrix(30*u.deg, 'z')
+    >>> R_scipy = Rotation.from_euler('z', 30, degrees=True)
+
+.. warning::
+
+    Note that astropy and scipy have different rotation conventions, so even
+    though both of the above look like identical 30 degree rotations around the
+    z axis, they result in different (i.e. transposed or inverse) rotation
+    matrices::
+
+        >>> R_arr # doctest: +FLOAT_CMP
+        array([[ 0.8660254,  0.5      ,  0.       ],
+               [-0.5      ,  0.8660254,  0.       ],
+               [ 0.       ,  0.       ,  1.       ]])
+        >>> R_scipy.as_dcm()
+        array([[ 0.8660254, -0.5      ,  0.       ],
+               [ 0.5      ,  0.8660254,  0.       ],
+               [ 0.       ,  0.       ,  1.       ]])
+
+Let's see what happens to the bar potential when we specify these rotations::
+
+    >>> bar1 = gp.LongMuraliBarPotential(m=1e10, a=3.5, b=0.5, c=0.5,
+    ...                                  units=galactic)
+    >>> bar2 = gp.LongMuraliBarPotential(m=1e10, a=3.5, b=0.5, c=0.5,
+    ...                                  units=galactic, R=R_arr)
+    >>> bar3 = gp.LongMuraliBarPotential(m=1e10, a=3.5, b=0.5, c=0.5,
+    ...                                  units=galactic, R=R_scipy)
+
+.. plot::
+    :align: center
+    :context: close-figs
+
+    from astropy.coordinates.matrix_utilities import rotation_matrix
+    from scipy.spatial.transform import Rotation
+    R_arr = rotation_matrix(30*u.deg, 'z')
+    R_scipy = Rotation.from_euler('z', 30, degrees=True)
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5), sharex=True, sharey=True)
+
+    grid = np.linspace(-5, 5, 100)
+
+    bar1 = gp.LongMuraliBarPotential(m=1e10, a=3.5, b=0.5, c=0.5,
+                                     units=galactic)
+    bar2 = gp.LongMuraliBarPotential(m=1e10, a=3.5, b=0.5, c=0.5,
+                                     units=galactic, R=R_arr)
+    bar3 = gp.LongMuraliBarPotential(m=1e10, a=3.5, b=0.5, c=0.5,
+                                     units=galactic, R=R_scipy)
+
+    bar1.plot_contours(grid=(grid, grid, 0.), ax=axes[0])
+    bar2.plot_contours(grid=(grid, grid, 0.), ax=axes[1])
+    bar3.plot_contours(grid=(grid, grid, 0.), ax=axes[2])
+
+    axes[0].set_xlabel("$x$ [kpc]") # doctest: +SKIP
+    axes[0].set_ylabel("$y$ [kpc]") # doctest: +SKIP
+    axes[1].set_xlabel("$x$ [kpc]") # doctest: +SKIP
+    axes[2].set_xlabel("$x$ [kpc]") # doctest: +SKIP
+
+    fig.tight_layout()

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -5,3 +5,4 @@
 .. _PyYAML: http://pyyaml.org/
 .. _Sympy: http://docs.sympy.org/
 .. _emcee: http://dan.iel.fm/emcee/current/
+.. _scipy: https://docs.scipy.org

--- a/gala/cconfig.pyx
+++ b/gala/cconfig.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 cdef extern from "extra_compile_macros.h":
     int USE_GSL
 

--- a/gala/potential/potential/builtin/cybuiltin.pyx
+++ b/gala/potential/potential/builtin/cybuiltin.pyx
@@ -115,8 +115,11 @@ __all__ = ['NullPotential', 'HenonHeilesPotential', # Misc. potentials
 
 cdef class HenonHeilesWrapper(CPotentialWrapper):
 
-    def __init__(self, G, _, q0):
-        self.init([G], np.ascontiguousarray(q0), n_dim=2)
+    def __init__(self, G, _, q0, R):
+        self.init([G],
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R),
+                  n_dim=2)
         self.cpotential.value[0] = <energyfunc>(henon_heiles_value)
         self.cpotential.gradient[0] = <gradientfunc>(henon_heiles_gradient)
 
@@ -150,8 +153,10 @@ class HenonHeilesPotential(CPotentialBase):
 #
 cdef class KeplerWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(kepler_value)
         self.cpotential.density[0] = <densityfunc>(kepler_density)
         self.cpotential.gradient[0] = <gradientfunc>(kepler_gradient)
@@ -188,8 +193,10 @@ class KeplerPotential(CPotentialBase):
 
 cdef class IsochroneWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(isochrone_value)
         self.cpotential.density[0] = <densityfunc>(isochrone_density)
         self.cpotential.gradient[0] = <gradientfunc>(isochrone_gradient)
@@ -268,8 +275,10 @@ class IsochronePotential(CPotentialBase):
 
 cdef class HernquistWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(hernquist_value)
         self.cpotential.density[0] = <densityfunc>(hernquist_density)
         self.cpotential.gradient[0] = <gradientfunc>(hernquist_gradient)
@@ -310,8 +319,10 @@ class HernquistPotential(CPotentialBase):
 
 cdef class PlummerWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(plummer_value)
         self.cpotential.density[0] = <densityfunc>(plummer_density)
         self.cpotential.gradient[0] = <gradientfunc>(plummer_gradient)
@@ -351,8 +362,10 @@ class PlummerPotential(CPotentialBase):
 
 cdef class JaffeWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(jaffe_value)
         self.cpotential.density[0] = <densityfunc>(jaffe_density)
         self.cpotential.gradient[0] = <gradientfunc>(jaffe_gradient)
@@ -392,8 +405,10 @@ class JaffePotential(CPotentialBase):
 
 cdef class StoneWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(stone_value)
         self.cpotential.density[0] = <densityfunc>(stone_density)
         self.cpotential.gradient[0] = <gradientfunc>(stone_gradient)
@@ -436,8 +451,10 @@ class StonePotential(CPotentialBase):
 
 cdef class PowerLawCutoffWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
 
         if USE_GSL == 1:
             self.cpotential.value[0] = <energyfunc>(powerlawcutoff_value)
@@ -502,8 +519,10 @@ class PowerLawCutoffPotential(CPotentialBase):
 #
 cdef class SatohWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(satoh_value)
         self.cpotential.density[0] = <densityfunc>(satoh_density)
         self.cpotential.gradient[0] = <gradientfunc>(satoh_gradient)
@@ -547,8 +566,10 @@ class SatohPotential(CPotentialBase):
 
 cdef class MiyamotoNagaiWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(miyamotonagai_value)
         self.cpotential.density[0] = <densityfunc>(miyamotonagai_density)
         self.cpotential.gradient[0] = <gradientfunc>(miyamotonagai_gradient)
@@ -598,8 +619,10 @@ class MiyamotoNagaiPotential(CPotentialBase):
 
 cdef class SphericalNFWWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(sphericalnfw_value)
         self.cpotential.density[0] = <densityfunc>(sphericalnfw_density)
         self.cpotential.gradient[0] = <gradientfunc>(sphericalnfw_gradient)
@@ -607,15 +630,19 @@ cdef class SphericalNFWWrapper(CPotentialWrapper):
 
 cdef class FlattenedNFWWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(flattenednfw_value)
         self.cpotential.gradient[0] = <gradientfunc>(flattenednfw_gradient)
 
 cdef class TriaxialNFWWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(triaxialnfw_value)
         self.cpotential.gradient[0] = <gradientfunc>(triaxialnfw_gradient)
 
@@ -738,8 +765,10 @@ class NFWPotential(CPotentialBase):
 
 cdef class LogarithmicWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(logarithmic_value)
         self.cpotential.gradient[0] = <gradientfunc>(logarithmic_gradient)
 
@@ -798,8 +827,10 @@ class LogarithmicPotential(CPotentialBase):
 
 cdef class LeeSutoTriaxialNFWWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(leesuto_value)
         self.cpotential.density[0] = <densityfunc>(leesuto_density)
         self.cpotential.gradient[0] = <gradientfunc>(leesuto_gradient)
@@ -850,8 +881,10 @@ class LeeSutoTriaxialNFWPotential(CPotentialBase):
 
 cdef class LongMuraliBarWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(longmuralibar_value)
         self.cpotential.gradient[0] = <gradientfunc>(longmuralibar_gradient)
         self.cpotential.density[0] = <densityfunc>(longmuralibar_density)
@@ -901,8 +934,10 @@ class LongMuraliBarPotential(CPotentialBase):
 #
 cdef class NullWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G], np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G],
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         self.cpotential.value[0] = <energyfunc>(null_value)
         self.cpotential.density[0] = <densityfunc>(null_density)
         self.cpotential.gradient[0] = <gradientfunc>(null_gradient)

--- a/gala/potential/potential/builtin/cybuiltin.pyx
+++ b/gala/potential/potential/builtin/cybuiltin.pyx
@@ -172,7 +172,6 @@ class KeplerPotential(CPotentialBase):
     m : :class:`~astropy.units.Quantity`, numeric [mass]
         Point mass value.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass'}
 
@@ -213,7 +212,6 @@ class IsochronePotential(CPotentialBase):
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'b': 'length'}
@@ -286,7 +284,6 @@ class HernquistPotential(CPotentialBase):
     HernquistPotential(m, c, units=None, origin=None, R=None)
 
     Hernquist potential for a spheroid.
-
     See: http://adsabs.harvard.edu/abs/1990ApJ...356..359H
 
     Parameters
@@ -296,7 +293,6 @@ class HernquistPotential(CPotentialBase):
     c : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'c': 'length'}
@@ -335,7 +331,6 @@ class PlummerPotential(CPotentialBase):
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'b': 'length'}
@@ -376,7 +371,6 @@ class JaffePotential(CPotentialBase):
     c : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'c': 'length'}
@@ -421,7 +415,6 @@ class StonePotential(CPotentialBase):
     r_h : :class:`~astropy.units.Quantity`, numeric [length]
         Halo radius.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'r_c': 'length',
@@ -476,7 +469,6 @@ class PowerLawCutoffPotential(CPotentialBase):
     r_c : :class:`~astropy.units.Quantity`, numeric [length]
         Cutoff radius.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'alpha': 'dimensionless',
@@ -532,7 +524,6 @@ class SatohPotential(CPotentialBase):
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Scare height.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'a': 'length',
@@ -581,7 +572,6 @@ class MiyamotoNagaiPotential(CPotentialBase):
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Scare height.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'a': 'length',
@@ -656,7 +646,6 @@ class NFWPotential(CPotentialBase):
     c : numeric
         Minor axis scale.
     {common_doc}
-
     """
     _physical_types = {'m': 'mass',
                        'r_s': 'length',
@@ -781,7 +770,6 @@ class LogarithmicPotential(CPotentialBase):
     phi : `~astropy.units.Quantity`, numeric
         First euler angle in the z-x-z convention.
     {common_doc}
-
     """
     _physical_types = {'v_c': 'speed',
                        'r_h': 'length',
@@ -844,7 +832,6 @@ class LeeSutoTriaxialNFWPotential(CPotentialBase):
     c : numeric
         Minor axis.
     {common_doc}
-
     """
     _physical_types = {'v_c': 'speed',
                        'r_s': 'length',
@@ -936,7 +923,6 @@ class NullPotential(CPotentialBase):
     Parameters
     ----------
     {common_doc}
-
     """
     def __init__(self, units=None, origin=None, R=None):
         parameters = OrderedDict()

--- a/gala/potential/potential/builtin/cybuiltin.pyx
+++ b/gala/potential/potential/builtin/cybuiltin.pyx
@@ -13,7 +13,6 @@ import warnings
 
 # Third-party
 from astropy.extern import six
-from astropy.utils import InheritDocstrings
 from astropy.constants import G
 import astropy.units as u
 import numpy as np
@@ -21,7 +20,8 @@ cimport numpy as np
 np.import_array()
 
 # Project
-from ..core import CompositePotential
+from ..core import CompositePotential, _potential_docstring
+from ..util import format_doc
 from ..cpotential import CPotentialBase
 from ..cpotential cimport CPotential, CPotentialWrapper
 from ..cpotential cimport densityfunc, energyfunc, gradientfunc, hessianfunc
@@ -123,22 +123,16 @@ cdef class HenonHeilesWrapper(CPotentialWrapper):
         self.cpotential.value[0] = <energyfunc>(henon_heiles_value)
         self.cpotential.gradient[0] = <gradientfunc>(henon_heiles_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class HenonHeilesPotential(CPotentialBase):
     r"""
     HenonHeilesPotential(units=None, origin=None, R=None)
 
     The Hénon-Heiles potential.
 
-    .. math::
-
-        \Phi(x,y) = \frac{1}{2}(x^2 + y^2 + 2x^2 y - \frac{2}{3}y^3)
-
     Parameters
     ----------
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
-
+    {common_doc}
     """
     def __init__(self, units=None, origin=None, R=None):
         parameters = OrderedDict()
@@ -147,6 +141,9 @@ class HenonHeilesPotential(CPotentialBase):
                                                    units=units,
                                                    origin=origin,
                                                    R=R)
+
+    def to_latex(self):
+        return r"\Phi(x,y) = \frac{1}{2}(x^2 + y^2 + 2x^2 y - \frac{2}{3}y^3)"
 
 
 # ============================================================================
@@ -163,23 +160,18 @@ cdef class KeplerWrapper(CPotentialWrapper):
         self.cpotential.gradient[0] = <gradientfunc>(kepler_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(kepler_hessian)
 
+@format_doc(common_doc=_potential_docstring)
 class KeplerPotential(CPotentialBase):
     r"""
     KeplerPotential(m, units=None, origin=None, R=None)
 
     The Kepler potential for a point mass.
 
-    .. math::
-
-        \Phi(r) = -\frac{Gm}{r}
-
     Parameters
     ----------
     m : :class:`~astropy.units.Quantity`, numeric [mass]
         Point mass value.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass'}
@@ -191,6 +183,9 @@ class KeplerPotential(CPotentialBase):
                                               units=units,
                                               origin=origin,
                                               R=R)
+
+    def to_latex(self):
+        return r"\Phi(r) = -\frac{Gm}{r}"
 
 
 cdef class IsochroneWrapper(CPotentialWrapper):
@@ -204,15 +199,12 @@ cdef class IsochroneWrapper(CPotentialWrapper):
         self.cpotential.gradient[0] = <gradientfunc>(isochrone_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(isochrone_hessian)
 
+@format_doc(common_doc=_potential_docstring)
 class IsochronePotential(CPotentialBase):
     r"""
     IsochronePotential(m, b, units=None, origin=None, R=None)
 
     The Isochrone potential.
-
-    .. math::
-
-        \Phi = -\frac{GM}{\sqrt{r^2+b^2} + b}
 
     Parameters
     ----------
@@ -220,9 +212,7 @@ class IsochronePotential(CPotentialBase):
         Mass.
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -236,6 +226,9 @@ class IsochronePotential(CPotentialBase):
                                                  units=units,
                                                  origin=origin,
                                                  R=R)
+
+    def to_latex(self):
+        return r"\Phi = -\frac{GM}{\sqrt{r^2+b^2} + b}"
 
     def action_angle(self, w):
         """
@@ -287,15 +280,12 @@ cdef class HernquistWrapper(CPotentialWrapper):
         self.cpotential.gradient[0] = <gradientfunc>(hernquist_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(hernquist_hessian)
 
+@format_doc(common_doc=_potential_docstring)
 class HernquistPotential(CPotentialBase):
     r"""
     HernquistPotential(m, c, units=None, origin=None, R=None)
 
     Hernquist potential for a spheroid.
-
-    .. math::
-
-        \Phi(r) = -\frac{G M}{r + c}
 
     See: http://adsabs.harvard.edu/abs/1990ApJ...356..359H
 
@@ -305,9 +295,7 @@ class HernquistPotential(CPotentialBase):
         Mass.
     c : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -319,6 +307,8 @@ class HernquistPotential(CPotentialBase):
         super(HernquistPotential, self).__init__(
             parameters=parameters, units=units, origin=origin, R=R)
 
+    def to_latex(self):
+        return r"\Phi(r) = -\frac{G M}{r + c}"
 
 cdef class PlummerWrapper(CPotentialWrapper):
 
@@ -331,15 +321,12 @@ cdef class PlummerWrapper(CPotentialWrapper):
         self.cpotential.gradient[0] = <gradientfunc>(plummer_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(plummer_hessian)
 
+@format_doc(common_doc=_potential_docstring)
 class PlummerPotential(CPotentialBase):
     r"""
     PlummerPotential(m, b, units=None, origin=None, R=None)
 
     Plummer potential for a spheroid.
-
-    .. math::
-
-        \Phi(r) = -\frac{G M}{\sqrt{r^2 + b^2}}
 
     Parameters
     ----------
@@ -347,9 +334,7 @@ class PlummerPotential(CPotentialBase):
        Mass.
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -363,6 +348,9 @@ class PlummerPotential(CPotentialBase):
                                                origin=origin,
                                                R=R)
 
+    def to_latex(self):
+        return r"\Phi(r) = -\frac{G M}{\sqrt{r^2 + b^2}}"
+
 
 cdef class JaffeWrapper(CPotentialWrapper):
 
@@ -374,15 +362,12 @@ cdef class JaffeWrapper(CPotentialWrapper):
         self.cpotential.density[0] = <densityfunc>(jaffe_density)
         self.cpotential.gradient[0] = <gradientfunc>(jaffe_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class JaffePotential(CPotentialBase):
     r"""
     JaffePotential(m, c, units=None, origin=None, R=None)
 
     Jaffe potential for a spheroid.
-
-    .. math::
-
-        \Phi(r) = \frac{G M}{c} \ln(\frac{r}{r + c})
 
     Parameters
     ----------
@@ -390,9 +375,7 @@ class JaffePotential(CPotentialBase):
         Mass.
     c : :class:`~astropy.units.Quantity`, numeric [length]
         Core concentration.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -407,6 +390,9 @@ class JaffePotential(CPotentialBase):
                                              origin=origin,
                                              R=R)
 
+    def to_latex(self):
+        return r"\Phi(r) = \frac{G M}{c} \ln(\frac{r}{r + c})"
+
 
 cdef class StoneWrapper(CPotentialWrapper):
 
@@ -418,15 +404,13 @@ cdef class StoneWrapper(CPotentialWrapper):
         self.cpotential.density[0] = <densityfunc>(stone_density)
         self.cpotential.gradient[0] = <gradientfunc>(stone_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class StonePotential(CPotentialBase):
     r"""
     StonePotential(m, r_c, r_h, units=None, origin=None, R=None)
 
-    Stone potential from `Stone & Ostriker (2015) <http://dx.doi.org/10.1088/2041-8205/806/2/L28>`_.
-
-    .. math::
-
-        \Phi(r) = -\frac{2 G M}{\pi(r_h - r_c)}\left[ \frac{\arctan(r/r_h)}{r/r_h} - \frac{\arctan(r/r_c)}{r/r_c} + \frac{1}{2}\ln\left(\frac{r^2+r_h^2}{r^2+r_c^2}\right)\right]
+    Stone potential from `Stone & Ostriker (2015)
+    <http://dx.doi.org/10.1088/2041-8205/806/2/L28>`_.
 
     Parameters
     ----------
@@ -436,9 +420,7 @@ class StonePotential(CPotentialBase):
         Core radius.
     r_h : :class:`~astropy.units.Quantity`, numeric [length]
         Halo radius.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -454,6 +436,9 @@ class StonePotential(CPotentialBase):
                                              origin=origin,
                                              R=R)
 
+    def to_latex(self):
+        return r"\Phi(r) = -\frac{2 G M}{\pi(r_h - r_c)}\left[ \frac{\arctan(r/r_h)}{r/r_h} - \frac{\arctan(r/r_c)}{r/r_c} + \frac{1}{2}\ln\left(\frac{r^2+r_h^2}{r^2+r_c^2}\right)\right]"
+
 
 cdef class PowerLawCutoffWrapper(CPotentialWrapper):
 
@@ -467,6 +452,7 @@ cdef class PowerLawCutoffWrapper(CPotentialWrapper):
             self.cpotential.density[0] = <densityfunc>(powerlawcutoff_density)
             self.cpotential.gradient[0] = <gradientfunc>(powerlawcutoff_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class PowerLawCutoffPotential(CPotentialBase):
     r"""
     PowerLawCutoffPotential(m, alpha, r_c, units=None, origin=None, R=None)
@@ -481,11 +467,6 @@ class PowerLawCutoffPotential(CPotentialBase):
         built and installed with GSL support enaled (the default behavior).
         See http://gala.adrian.pw/en/latest/install.html for more information.
 
-    .. math::
-
-        \rho(r) = \frac{A}{r^\alpha} \, \exp{-\frac{r^2}{c^2}}\\
-        A = \frac{m}{2\pi} \, \frac{c^{\alpha-3}}{\Gamma(\frac{3-\alpha}{2})}
-
     Parameters
     ----------
     m : :class:`~astropy.units.Quantity`, numeric [mass]
@@ -494,9 +475,7 @@ class PowerLawCutoffPotential(CPotentialBase):
         Power law index. Must satisfy: ``alpha < 3``
     r_c : :class:`~astropy.units.Quantity`, numeric [length]
         Cutoff radius.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -519,6 +498,10 @@ class PowerLawCutoffPotential(CPotentialBase):
         super(PowerLawCutoffPotential, self).__init__(
             parameters=parameters, units=units, origin=origin, R=R)
 
+    def to_latex(self):
+        return (r"\rho(r) = \frac{A}{r^\alpha} \, \exp{-\frac{r^2}{c^2}}\\" +
+        r"A = \frac{m}{2\pi} \, \frac{c^{\alpha-3}}{\Gamma(\frac{3-\alpha}{2})}")
+
 
 # ============================================================================
 # Flattened, axisymmetric models
@@ -533,15 +516,12 @@ cdef class SatohWrapper(CPotentialWrapper):
         self.cpotential.density[0] = <densityfunc>(satoh_density)
         self.cpotential.gradient[0] = <gradientfunc>(satoh_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class SatohPotential(CPotentialBase):
     r"""
     SatohPotential(m, a, b, units=None, origin=None, R=None)
 
     Satoh potential for a flattened mass distribution.
-
-    .. math::
-
-        \Phi(R,z) = -\frac{G M}{\sqrt{R^2 + z^2 + a(a + 2\sqrt{z^2 + b^2})}}
 
     Parameters
     ----------
@@ -551,9 +531,7 @@ class SatohPotential(CPotentialBase):
         Scale length.
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Scare height.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -570,6 +548,9 @@ class SatohPotential(CPotentialBase):
                                              origin=origin,
                                              R=R)
 
+    def to_latex(self):
+        return r"\Phi(R,z) = -\frac{G M}{\sqrt{R^2 + z^2 + a(a + 2\sqrt{z^2 + b^2})}}"
+
 
 cdef class MiyamotoNagaiWrapper(CPotentialWrapper):
 
@@ -582,15 +563,12 @@ cdef class MiyamotoNagaiWrapper(CPotentialWrapper):
         self.cpotential.gradient[0] = <gradientfunc>(miyamotonagai_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(miyamotonagai_hessian)
 
+@format_doc(common_doc=_potential_docstring)
 class MiyamotoNagaiPotential(CPotentialBase):
     r"""
     MiyamotoNagaiPotential(m, a, b, units=None, origin=None, R=None)
 
     Miyamoto-Nagai potential for a flattened mass distribution.
-
-    .. math::
-
-        \Phi(R,z) = -\frac{G M}{\sqrt{R^2 + (a + \sqrt{z^2 + b^2})^2}}
 
     See: http://adsabs.harvard.edu/abs/1975PASJ...27..533M
 
@@ -602,9 +580,7 @@ class MiyamotoNagaiPotential(CPotentialBase):
         Scale length.
     b : :class:`~astropy.units.Quantity`, numeric [length]
         Scare height.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -618,6 +594,9 @@ class MiyamotoNagaiPotential(CPotentialBase):
         parameters['b'] = b
         super(MiyamotoNagaiPotential, self).__init__(
             parameters=parameters, units=units, origin=origin, R=R)
+
+    def to_latex(self):
+        return r"\Phi(R,z) = -\frac{G M}{\sqrt{R^2 + (a + \sqrt{z^2 + b^2})^2}}"
 
 
 # ============================================================================
@@ -653,6 +632,7 @@ cdef class TriaxialNFWWrapper(CPotentialWrapper):
         self.cpotential.value[0] = <energyfunc>(triaxialnfw_value)
         self.cpotential.gradient[0] = <gradientfunc>(triaxialnfw_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class NFWPotential(CPotentialBase):
     r"""
     NFWPotential(m, r_s, a=1, b=1, c=1, units=None, origin=None, R=None)
@@ -662,10 +642,6 @@ class NFWPotential(CPotentialBase):
     density, and can therefore lead to unphysical mass distributions. For a
     triaxial NFW potential that supports flattening in the density, see
     :class:`gala.potential.LeeSutoTriaxialNFWPotential`.
-
-    .. math::
-
-        \Phi(r) = -\frac{v_c^2}{\sqrt{\ln 2 - \frac{1}{2}}} \frac{\ln(1 + r/r_s)}{r/r_s}
 
     Parameters
     ----------
@@ -679,9 +655,7 @@ class NFWPotential(CPotentialBase):
         Intermediate axis scale.
     c : numeric
         Minor axis scale.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'m': 'mass',
@@ -714,6 +688,9 @@ class NFWPotential(CPotentialBase):
                                            Wrapper=NFWWrapper,
                                            origin=origin,
                                            R=R)
+
+    def to_latex(self):
+        return r"\Phi(r) = -\frac{v_c^2}{\sqrt{\ln 2 - \frac{1}{2}}} \frac{\ln(1 + r/r_s)}{r/r_s}"
 
     @staticmethod
     def from_circular_velocity(v_c, r_s, a=1., b=1., c=1., r_ref=None,
@@ -772,6 +749,7 @@ class NFWPotential(CPotentialBase):
         vs2 = v_c**2 / uu / (np.log(1+uu)/uu**2 - 1/(uu*(1+uu)))
         return (r_s*vs2 / G)
 
+
 cdef class LogarithmicWrapper(CPotentialWrapper):
 
     def __init__(self, G, parameters, q0, R):
@@ -781,15 +759,12 @@ cdef class LogarithmicWrapper(CPotentialWrapper):
         self.cpotential.value[0] = <energyfunc>(logarithmic_value)
         self.cpotential.gradient[0] = <gradientfunc>(logarithmic_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class LogarithmicPotential(CPotentialBase):
     r"""
     LogarithmicPotential(v_c, r_h, q1, q2, q3, phi=0, theta=0, psi=0, units=None, origin=None, R=None)
 
     Triaxial logarithmic potential.
-
-    .. math::
-
-        \Phi(x,y,z) &= \frac{1}{2}v_{c}^2\ln((x/q_1)^2 + (y/q_2)^2 + (z/q_3)^2 + r_h^2)\\
 
     Parameters
     ----------
@@ -805,9 +780,7 @@ class LogarithmicPotential(CPotentialBase):
         Flattening in Z.
     phi : `~astropy.units.Quantity`, numeric
         First euler angle in the z-x-z convention.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'v_c': 'speed',
@@ -834,6 +807,9 @@ class LogarithmicPotential(CPotentialBase):
             if self.units['angle'] != u.radian:
                 raise ValueError("Angle unit must be radian.")
 
+    def to_latex(self):
+        return r"\Phi(x,y,z) &= \frac{1}{2}v_{c}^2\ln((x/q_1)^2 + (y/q_2)^2 + (z/q_3)^2 + r_h^2)"
+
 
 cdef class LeeSutoTriaxialNFWWrapper(CPotentialWrapper):
 
@@ -845,6 +821,7 @@ cdef class LeeSutoTriaxialNFWWrapper(CPotentialWrapper):
         self.cpotential.density[0] = <densityfunc>(leesuto_density)
         self.cpotential.gradient[0] = <gradientfunc>(leesuto_gradient)
 
+@format_doc(common_doc=_potential_docstring)
 class LeeSutoTriaxialNFWPotential(CPotentialBase):
     r"""
     LeeSutoTriaxialNFWPotential(v_c, r_s, a, b, c, units=None, origin=None, R=None)
@@ -866,9 +843,7 @@ class LeeSutoTriaxialNFWPotential(CPotentialBase):
         Intermediate axis.
     c : numeric
         Minor axis.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     _physical_types = {'v_c': 'speed',
@@ -899,6 +874,7 @@ cdef class LongMuraliBarWrapper(CPotentialWrapper):
         self.cpotential.gradient[0] = <gradientfunc>(longmuralibar_gradient)
         self.cpotential.density[0] = <densityfunc>(longmuralibar_density)
 
+@format_doc(common_doc=_potential_docstring)
 class LongMuraliBarPotential(CPotentialBase):
     r"""
     LongMuraliBarPotential(m, a, b, c, alpha=0, units=None, origin=None, R=None)
@@ -918,10 +894,7 @@ class LongMuraliBarPotential(CPotentialBase):
         Like the Miyamoto-Nagai ``b`` parameter.
     c : `~astropy.units.Quantity`, numeric [length]
         Like the Miyamoto-Nagai ``c`` parameter.
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
-
+    {common_doc}
     """
     _physical_types = {'m': 'mass',
                        'a': 'length',
@@ -953,6 +926,7 @@ cdef class NullWrapper(CPotentialWrapper):
         self.cpotential.gradient[0] = <gradientfunc>(null_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(null_hessian)
 
+@format_doc(common_doc=_potential_docstring)
 class NullPotential(CPotentialBase):
     r"""
     NullPotential(units=None, origin=None, R=None)
@@ -961,9 +935,7 @@ class NullPotential(CPotentialBase):
 
     Parameters
     ----------
-    units : `~gala.units.UnitSystem` (optional)
-        Set of non-reducable units that specify (at minimum) the
-        length, mass, time, and angle units.
+    {common_doc}
 
     """
     def __init__(self, units=None, origin=None, R=None):

--- a/gala/potential/potential/builtin/cybuiltin.pyx
+++ b/gala/potential/potential/builtin/cybuiltin.pyx
@@ -182,7 +182,6 @@ class KeplerPotential(CPotentialBase):
         length, mass, time, and angle units.
 
     """
-=======
     _physical_types = {'m': 'mass'}
 
     def __init__(self, m, units=None, origin=None, R=None):
@@ -693,36 +692,6 @@ class NFWPotential(CPotentialBase):
 
     def __init__(self, m=None, r_s=None, a=1., b=1., c=1., v_c=None, units=None,
                  origin=None, R=None):
-        # TODO: v_c included in above for backwards-compatibility (and m, r_s
-        # default to None)
-
-        if v_c is not None and m is None:
-            warnings.warn("NFWPotential now expects a scale mass in the default"
-                          " initializer. To initialize from a circular "
-                          "velocity, use the classmethod "
-                          "from_circular_velocity() instead instead.",
-                          DeprecationWarning)
-
-            parameters = OrderedDict()
-            ptypes = OrderedDict()
-
-            parameters['v_c'] = v_c
-            ptypes['v_c'] = 'speed'
-
-            parameters['r_s'] = r_s
-            ptypes['r_s'] = 'length'
-
-            # get appropriate units:
-            parameters = CPotentialBase._prepare_parameters(parameters, ptypes,
-                                                            units)
-
-            # r_ref = r_s for old parametrization
-            m = NFWPotential._vc_rs_rref_to_m(parameters['v_c'],
-                                              parameters['r_s'],
-                                              parameters['r_s'])
-            m = m.to(units['mass'])
-
-    def __init__(self, m, r_s, a=1., b=1., c=1., units=None, origin=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['r_s'] = r_s
@@ -959,7 +928,7 @@ class LongMuraliBarPotential(CPotentialBase):
                        'b': 'length',
                        'c': 'length',
                        'alpha': 'angle'}
-    def __init__(self, m, a, b, c, alpha=0., units=None, origin=None, R=R):
+    def __init__(self, m, a, b, c, alpha=0., units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['a'] = a

--- a/gala/potential/potential/builtin/cybuiltin.pyx
+++ b/gala/potential/potential/builtin/cybuiltin.pyx
@@ -125,7 +125,7 @@ cdef class HenonHeilesWrapper(CPotentialWrapper):
 
 class HenonHeilesPotential(CPotentialBase):
     r"""
-    HenonHeilesPotential(units=None, origin=None)
+    HenonHeilesPotential(units=None, origin=None, R=None)
 
     The Hénon-Heiles potential.
 
@@ -140,12 +140,13 @@ class HenonHeilesPotential(CPotentialBase):
         length, mass, time, and angle units.
 
     """
-    def __init__(self, units=None, origin=None):
+    def __init__(self, units=None, origin=None, R=None):
         parameters = OrderedDict()
         super(HenonHeilesPotential, self).__init__(parameters=parameters,
                                                    ndim=2,
                                                    units=units,
-                                                   origin=origin)
+                                                   origin=origin,
+                                                   R=R)
 
 
 # ============================================================================
@@ -164,7 +165,7 @@ cdef class KeplerWrapper(CPotentialWrapper):
 
 class KeplerPotential(CPotentialBase):
     r"""
-    KeplerPotential(m, units=None, origin=None)
+    KeplerPotential(m, units=None, origin=None, R=None)
 
     The Kepler potential for a point mass.
 
@@ -181,14 +182,16 @@ class KeplerPotential(CPotentialBase):
         length, mass, time, and angle units.
 
     """
+=======
     _physical_types = {'m': 'mass'}
 
-    def __init__(self, m, units=None, origin=None):
+    def __init__(self, m, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         super(KeplerPotential, self).__init__(parameters=parameters,
                                               units=units,
-                                              origin=origin)
+                                              origin=origin,
+                                              R=R)
 
 
 cdef class IsochroneWrapper(CPotentialWrapper):
@@ -204,7 +207,7 @@ cdef class IsochroneWrapper(CPotentialWrapper):
 
 class IsochronePotential(CPotentialBase):
     r"""
-    IsochronePotential(m, b, units=None, origin=None)
+    IsochronePotential(m, b, units=None, origin=None, R=None)
 
     The Isochrone potential.
 
@@ -226,13 +229,14 @@ class IsochronePotential(CPotentialBase):
     _physical_types = {'m': 'mass',
                        'b': 'length'}
 
-    def __init__(self, m, b, units=None, origin=None):
+    def __init__(self, m, b, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['b'] = b
         super(IsochronePotential, self).__init__(parameters=parameters,
                                                  units=units,
-                                                 origin=origin)
+                                                 origin=origin,
+                                                 R=R)
 
     def action_angle(self, w):
         """
@@ -286,7 +290,7 @@ cdef class HernquistWrapper(CPotentialWrapper):
 
 class HernquistPotential(CPotentialBase):
     r"""
-    HernquistPotential(m, c, units=None, origin=None)
+    HernquistPotential(m, c, units=None, origin=None, R=None)
 
     Hernquist potential for a spheroid.
 
@@ -309,12 +313,12 @@ class HernquistPotential(CPotentialBase):
     """
     _physical_types = {'m': 'mass',
                        'c': 'length'}
-    def __init__(self, m, c, units=None, origin=None):
+    def __init__(self, m, c, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['c'] = c
         super(HernquistPotential, self).__init__(
-            parameters=parameters, units=units, origin=origin)
+            parameters=parameters, units=units, origin=origin, R=R)
 
 
 cdef class PlummerWrapper(CPotentialWrapper):
@@ -330,7 +334,7 @@ cdef class PlummerWrapper(CPotentialWrapper):
 
 class PlummerPotential(CPotentialBase):
     r"""
-    PlummerPotential(m, b, units=None, origin=None)
+    PlummerPotential(m, b, units=None, origin=None, R=None)
 
     Plummer potential for a spheroid.
 
@@ -351,13 +355,14 @@ class PlummerPotential(CPotentialBase):
     """
     _physical_types = {'m': 'mass',
                        'b': 'length'}
-    def __init__(self, m, b, units=None, origin=None):
+    def __init__(self, m, b, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['b'] = b
         super(PlummerPotential, self).__init__(parameters=parameters,
                                                units=units,
-                                               origin=origin)
+                                               origin=origin,
+                                               R=R)
 
 
 cdef class JaffeWrapper(CPotentialWrapper):
@@ -372,7 +377,7 @@ cdef class JaffeWrapper(CPotentialWrapper):
 
 class JaffePotential(CPotentialBase):
     r"""
-    JaffePotential(m, c, units=None, origin=None)
+    JaffePotential(m, c, units=None, origin=None, R=None)
 
     Jaffe potential for a spheroid.
 
@@ -394,13 +399,14 @@ class JaffePotential(CPotentialBase):
     _physical_types = {'m': 'mass',
                        'c': 'length'}
 
-    def __init__(self, m, c, units=None, origin=None):
+    def __init__(self, m, c, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['c'] = c
         super(JaffePotential, self).__init__(parameters=parameters,
                                              units=units,
-                                             origin=origin)
+                                             origin=origin,
+                                             R=R)
 
 
 cdef class StoneWrapper(CPotentialWrapper):
@@ -415,7 +421,7 @@ cdef class StoneWrapper(CPotentialWrapper):
 
 class StonePotential(CPotentialBase):
     r"""
-    StonePotential(m, r_c, r_h, units=None, origin=None)
+    StonePotential(m, r_c, r_h, units=None, origin=None, R=None)
 
     Stone potential from `Stone & Ostriker (2015) <http://dx.doi.org/10.1088/2041-8205/806/2/L28>`_.
 
@@ -439,14 +445,15 @@ class StonePotential(CPotentialBase):
     _physical_types = {'m': 'mass',
                        'r_c': 'length',
                        'r_h': 'length'}
-    def __init__(self, m, r_c, r_h, units=None, origin=None):
+    def __init__(self, m, r_c, r_h, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['r_c'] = r_c
         parameters['r_h'] = r_h
         super(StonePotential, self).__init__(parameters=parameters,
                                              units=units,
-                                             origin=origin)
+                                             origin=origin,
+                                             R=R)
 
 
 cdef class PowerLawCutoffWrapper(CPotentialWrapper):
@@ -463,7 +470,7 @@ cdef class PowerLawCutoffWrapper(CPotentialWrapper):
 
 class PowerLawCutoffPotential(CPotentialBase):
     r"""
-    PowerLawCutoffPotential(m, alpha, r_c, units=None, origin=None)
+    PowerLawCutoffPotential(m, alpha, r_c, units=None, origin=None, R=None)
 
     A spherical power-law density profile with an exponential cutoff.
 
@@ -497,7 +504,7 @@ class PowerLawCutoffPotential(CPotentialBase):
                        'alpha': 'dimensionless',
                        'r_c': 'length'}
 
-    def __init__(self, m, alpha, r_c, units=None, origin=None):
+    def __init__(self, m, alpha, r_c, units=None, origin=None, R=None):
         from ...._cconfig import GSL_ENABLED
         if not GSL_ENABLED:
             raise ValueError("Gala was compiled without GSL and so this "
@@ -511,7 +518,7 @@ class PowerLawCutoffPotential(CPotentialBase):
         parameters['alpha'] = alpha
         parameters['r_c'] = r_c
         super(PowerLawCutoffPotential, self).__init__(
-            parameters=parameters, units=units, origin=origin)
+            parameters=parameters, units=units, origin=origin, R=R)
 
 
 # ============================================================================
@@ -529,7 +536,7 @@ cdef class SatohWrapper(CPotentialWrapper):
 
 class SatohPotential(CPotentialBase):
     r"""
-    SatohPotential(m, a, b, units=None, origin=None)
+    SatohPotential(m, a, b, units=None, origin=None, R=None)
 
     Satoh potential for a flattened mass distribution.
 
@@ -554,14 +561,15 @@ class SatohPotential(CPotentialBase):
                        'a': 'length',
                        'b': 'length'}
 
-    def __init__(self, m, a, b, units=None, origin=None):
+    def __init__(self, m, a, b, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['a'] = a
         parameters['b'] = b
         super(SatohPotential, self).__init__(parameters=parameters,
                                              units=units,
-                                             origin=origin)
+                                             origin=origin,
+                                             R=R)
 
 
 cdef class MiyamotoNagaiWrapper(CPotentialWrapper):
@@ -577,7 +585,7 @@ cdef class MiyamotoNagaiWrapper(CPotentialWrapper):
 
 class MiyamotoNagaiPotential(CPotentialBase):
     r"""
-    MiyamotoNagaiPotential(m, a, b, units=None, origin=None)
+    MiyamotoNagaiPotential(m, a, b, units=None, origin=None, R=None)
 
     Miyamoto-Nagai potential for a flattened mass distribution.
 
@@ -604,13 +612,13 @@ class MiyamotoNagaiPotential(CPotentialBase):
                        'a': 'length',
                        'b': 'length'}
 
-    def __init__(self, m, a, b, units=None, origin=None):
+    def __init__(self, m, a, b, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['a'] = a
         parameters['b'] = b
         super(MiyamotoNagaiPotential, self).__init__(
-            parameters=parameters, units=units, origin=origin)
+            parameters=parameters, units=units, origin=origin, R=R)
 
 
 # ============================================================================
@@ -648,7 +656,7 @@ cdef class TriaxialNFWWrapper(CPotentialWrapper):
 
 class NFWPotential(CPotentialBase):
     r"""
-    NFWPotential(m, r_s, a=1, b=1, c=1, units=None, origin=None)
+    NFWPotential(m, r_s, a=1, b=1, c=1, units=None, origin=None, R=None)
 
     General Navarro-Frenk-White potential. Supports spherical, flattened, and
     triaxiality but the flattening is introduced into the potential, not the
@@ -683,6 +691,37 @@ class NFWPotential(CPotentialBase):
                        'b': 'dimensionless',
                        'c': 'dimensionless'}
 
+    def __init__(self, m=None, r_s=None, a=1., b=1., c=1., v_c=None, units=None,
+                 origin=None, R=None):
+        # TODO: v_c included in above for backwards-compatibility (and m, r_s
+        # default to None)
+
+        if v_c is not None and m is None:
+            warnings.warn("NFWPotential now expects a scale mass in the default"
+                          " initializer. To initialize from a circular "
+                          "velocity, use the classmethod "
+                          "from_circular_velocity() instead instead.",
+                          DeprecationWarning)
+
+            parameters = OrderedDict()
+            ptypes = OrderedDict()
+
+            parameters['v_c'] = v_c
+            ptypes['v_c'] = 'speed'
+
+            parameters['r_s'] = r_s
+            ptypes['r_s'] = 'length'
+
+            # get appropriate units:
+            parameters = CPotentialBase._prepare_parameters(parameters, ptypes,
+                                                            units)
+
+            # r_ref = r_s for old parametrization
+            m = NFWPotential._vc_rs_rref_to_m(parameters['v_c'],
+                                              parameters['r_s'],
+                                              parameters['r_s'])
+            m = m.to(units['mass'])
+
     def __init__(self, m, r_s, a=1., b=1., c=1., units=None, origin=None):
         parameters = OrderedDict()
         parameters['m'] = m
@@ -704,13 +743,14 @@ class NFWPotential(CPotentialBase):
         super(NFWPotential, self).__init__(parameters=parameters,
                                            units=units,
                                            Wrapper=NFWWrapper,
-                                           origin=origin)
+                                           origin=origin,
+                                           R=R)
 
     @staticmethod
     def from_circular_velocity(v_c, r_s, a=1., b=1., c=1., r_ref=None,
-                               units=None, origin=None):
+                               units=None, origin=None, R=None):
         r"""
-        from_circular_velocity(v_c, r_s, a=1., b=1., c=1., r_ref=None, units=None, origin=None)
+        from_circular_velocity(v_c, r_s, a=1., b=1., c=1., r_ref=None, units=None, origin=None, R=None)
 
         Initialize an NFW potential from a circular velocity, scale radius, and
         reference radius for the circular velocity.
@@ -755,7 +795,7 @@ class NFWPotential(CPotentialBase):
         m = m.to(units['mass'])
 
         return NFWPotential(m=m, r_s=r_s, a=a, b=b, c=c,
-                            units=units, origin=origin)
+                            units=units, origin=origin, R=R)
 
     @staticmethod
     def _vc_rs_rref_to_m(v_c, r_s, r_ref):
@@ -774,7 +814,7 @@ cdef class LogarithmicWrapper(CPotentialWrapper):
 
 class LogarithmicPotential(CPotentialBase):
     r"""
-    LogarithmicPotential(v_c, r_h, q1, q2, q3, phi=0, theta=0, psi=0, units=None, origin=None)
+    LogarithmicPotential(v_c, r_h, q1, q2, q3, phi=0, theta=0, psi=0, units=None, origin=None, R=None)
 
     Triaxial logarithmic potential.
 
@@ -808,7 +848,8 @@ class LogarithmicPotential(CPotentialBase):
                        'q3': 'dimensionless',
                        'phi': 'angle'}
 
-    def __init__(self, v_c, r_h, q1, q2, q3, phi=0., units=None, origin=None):
+    def __init__(self, v_c, r_h, q1, q2, q3, phi=0., units=None,
+                 origin=None, R=None):
         parameters = OrderedDict()
         parameters['v_c'] = v_c
         parameters['r_h'] = r_h
@@ -818,7 +859,7 @@ class LogarithmicPotential(CPotentialBase):
         parameters['phi'] = phi
 
         super(LogarithmicPotential, self).__init__(
-            parameters=parameters, units=units, origin=origin)
+            parameters=parameters, units=units, origin=origin, R=R)
 
         if not isinstance(self.units, DimensionlessUnitSystem):
             if self.units['angle'] != u.radian:
@@ -837,7 +878,7 @@ cdef class LeeSutoTriaxialNFWWrapper(CPotentialWrapper):
 
 class LeeSutoTriaxialNFWPotential(CPotentialBase):
     r"""
-    LeeSutoTriaxialNFWPotential(v_c, r_s, a, b, c, units=None, origin=None)
+    LeeSutoTriaxialNFWPotential(v_c, r_s, a, b, c, units=None, origin=None, R=None)
 
     Approximation of a Triaxial NFW Potential with the flattening in the density,
     not the potential.
@@ -867,7 +908,7 @@ class LeeSutoTriaxialNFWPotential(CPotentialBase):
                        'b': 'dimensionless',
                        'c': 'dimensionless'}
 
-    def __init__(self, v_c, r_s, a, b, c, units=None, origin=None):
+    def __init__(self, v_c, r_s, a, b, c, units=None, origin=None, R=None):
         parameters = OrderedDict()
         parameters['v_c'] = v_c
         parameters['r_s'] = r_s
@@ -876,7 +917,7 @@ class LeeSutoTriaxialNFWPotential(CPotentialBase):
         parameters['c'] = c
 
         super(LeeSutoTriaxialNFWPotential, self).__init__(
-            parameters=parameters, units=units, origin=origin)
+            parameters=parameters, units=units, origin=origin, R=R)
 
 
 cdef class LongMuraliBarWrapper(CPotentialWrapper):
@@ -891,7 +932,7 @@ cdef class LongMuraliBarWrapper(CPotentialWrapper):
 
 class LongMuraliBarPotential(CPotentialBase):
     r"""
-    LongMuraliBarPotential(m, a, b, c, alpha=0, units=None, origin=None)
+    LongMuraliBarPotential(m, a, b, c, alpha=0, units=None, origin=None, R=None)
 
     A simple, triaxial model for a galaxy bar. This is a softened "needle"
     density distribution with an analytic potential form.
@@ -918,7 +959,7 @@ class LongMuraliBarPotential(CPotentialBase):
                        'b': 'length',
                        'c': 'length',
                        'alpha': 'angle'}
-    def __init__(self, m, a, b, c, alpha=0., units=None, origin=None):
+    def __init__(self, m, a, b, c, alpha=0., units=None, origin=None, R=R):
         parameters = OrderedDict()
         parameters['m'] = m
         parameters['a'] = a
@@ -926,7 +967,7 @@ class LongMuraliBarPotential(CPotentialBase):
         parameters['c'] = c
         parameters['alpha'] = alpha
         super(LongMuraliBarPotential, self).__init__(
-            parameters=parameters, units=units, origin=origin)
+            parameters=parameters, units=units, origin=origin, R=R)
 
 
 # ==============================================================================
@@ -945,7 +986,7 @@ cdef class NullWrapper(CPotentialWrapper):
 
 class NullPotential(CPotentialBase):
     r"""
-    NullPotential(units=None, origin=None)
+    NullPotential(units=None, origin=None, R=None)
 
     A null potential with 0 mass. Does nothing.
 
@@ -956,8 +997,9 @@ class NullPotential(CPotentialBase):
         length, mass, time, and angle units.
 
     """
-    def __init__(self, units=None, origin=None):
+    def __init__(self, units=None, origin=None, R=None):
         parameters = OrderedDict()
         super(NullPotential, self).__init__(parameters=parameters,
                                             units=units,
-                                            origin=origin)
+                                            origin=origin,
+                                            R=R)

--- a/gala/potential/potential/ccompositepotential.pyx
+++ b/gala/potential/potential/ccompositepotential.pyx
@@ -51,6 +51,7 @@ cdef class CCompositePotentialWrapper(CPotentialWrapper):
             tmp_cp = _cpotential_arr[i].cpotential
             cp.parameters[i] = &(_cpotential_arr[i]._params[0])
             cp.q0[i] = &(_cpotential_arr[i]._q0[0])
+            cp.R[i] = &(_cpotential_arr[i]._R[0])
             cp.value[i] = tmp_cp.value[0]
             cp.density[i] = tmp_cp.density[0]
             cp.gradient[i] = tmp_cp.gradient[0]

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -203,6 +203,9 @@ class PotentialBase(CommonBase):
             ``(q.shape[0],q.shape[0]) + q.shape[1:]``. That is, an ``n_dim`` by
             ``n_dim`` array (matrix) for each position.
         """
+        if self.R is not None:
+            raise NotImplementedError("Computing Hessian matrices for rotated "
+                                      "potentials is currently not supported.")
         q = self._remove_units_prepare_shape(q)
         orig_shape,q = self._get_c_valid_arr(q)
         t = self._validate_prepare_time(t, q)

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -125,7 +125,7 @@ class PotentialBase(CommonBase):
             The potential energy per unit mass or value of the potential.
         """
         q = self._remove_units_prepare_shape(q)
-        orig_shape,q = self._get_c_valid_arr(q)
+        orig_shape, q = self._get_c_valid_arr(q)
         t = self._validate_prepare_time(t, q)
         ret_unit = self.units['energy'] / self.units['mass']
 
@@ -149,7 +149,7 @@ class PotentialBase(CommonBase):
             the input position.
         """
         q = self._remove_units_prepare_shape(q)
-        orig_shape,q = self._get_c_valid_arr(q)
+        orig_shape, q = self._get_c_valid_arr(q)
         t = self._validate_prepare_time(t, q)
         ret_unit = self.units['length'] / self.units['time']**2
         return (self._gradient(q, t=t).T.reshape(orig_shape) * ret_unit).to(self.units['acceleration'])
@@ -173,7 +173,7 @@ class PotentialBase(CommonBase):
             shape ``q.shape[1:]``.
         """
         q = self._remove_units_prepare_shape(q)
-        orig_shape,q = self._get_c_valid_arr(q)
+        orig_shape, q = self._get_c_valid_arr(q)
         t = self._validate_prepare_time(t, q)
         ret_unit = self.units['mass'] / self.units['length']**3
         return (self._density(q, t=t).T * ret_unit).to(self.units['mass density'])
@@ -242,7 +242,7 @@ class PotentialBase(CommonBase):
             ``q.shape[1:]``.
         """
         q = self._remove_units_prepare_shape(q)
-        orig_shape,q = self._get_c_valid_arr(q)
+        orig_shape, q = self._get_c_valid_arr(q)
         t = self._validate_prepare_time(t, q)
 
         # small step-size in direction of q
@@ -251,7 +251,7 @@ class PotentialBase(CommonBase):
         # Radius
         r = np.sqrt(np.sum(q**2, axis=1))
 
-        epsilon = h*q/r[:,np.newaxis]
+        epsilon = h*q/r[:, np.newaxis]
 
         dPhi_dr_plus = self._energy(q + epsilon, t=t)
         dPhi_dr_minus = self._energy(q - epsilon, t=t)
@@ -316,7 +316,7 @@ class PotentialBase(CommonBase):
             par_fmt = "{}"
             post = ""
 
-            if hasattr(v,'unit'):
+            if hasattr(v, 'unit'):
                 post = " {}".format(v.unit)
                 v = v.value
 
@@ -331,7 +331,7 @@ class PotentialBase(CommonBase):
             elif isinstance(v, int) and np.log10(v) > 5:
                 par_fmt = "{:.2e}"
 
-            pars += ("{}=" + par_fmt + post).format(k,v) + ", "
+            pars += ("{}=" + par_fmt + post).format(k, v) + ", "
 
         if isinstance(self.units, DimensionlessUnitSystem):
             return "<{}: {} (dimensionless)>".format(self.__class__.__name__, pars.rstrip(", "))
@@ -350,7 +350,7 @@ class PotentialBase(CommonBase):
         new_pot = CompositePotential()
 
         if isinstance(self, CompositePotential):
-            for k,v in self.items():
+            for k, v in self.items():
                 new_pot[k] = v
 
         else:
@@ -358,7 +358,7 @@ class PotentialBase(CommonBase):
             new_pot[k] = self
 
         if isinstance(other, CompositePotential):
-            for k,v in self.items():
+            for k, v in self.items():
                 if k in new_pot:
                     raise KeyError('Potential component "{}" already exists --'
                                    'duplicate key provided in potential '
@@ -412,11 +412,11 @@ class PotentialBase(CommonBase):
         # figure out which elements are iterable, which are numeric
         _grids = []
         _slices = []
-        for ii,g in enumerate(grid):
+        for ii, g in enumerate(grid):
             if isiterable(g):
-                _grids.append((ii,g))
+                _grids.append((ii, g))
             else:
-                _slices.append((ii,g))
+                _slices.append((ii, g))
 
         # figure out the dimensionality
         ndim = len(_grids)
@@ -438,7 +438,7 @@ class PotentialBase(CommonBase):
             r = np.zeros((len(_grids) + len(_slices), len(x1)))
             r[_grids[0][0]] = x1
 
-            for ii,slc in _slices:
+            for ii, slc in _slices:
                 r[ii] = slc
 
             Z = self.energy(r*self.units['length']).value
@@ -449,15 +449,15 @@ class PotentialBase(CommonBase):
                 ax.set_ylabel("potential")
         else:
             # 2D contours
-            x1,x2 = np.meshgrid(_grids[0][1], _grids[1][1])
+            x1, x2 = np.meshgrid(_grids[0][1], _grids[1][1])
             shp = x1.shape
-            x1,x2 = x1.ravel(), x2.ravel()
+            x1, x2 = x1.ravel(), x2.ravel()
 
             r = np.zeros((len(_grids) + len(_slices), len(x1)))
             r[_grids[0][0]] = x1
             r[_grids[1][0]] = x2
 
-            for ii,slc in _slices:
+            for ii, slc in _slices:
                 r[ii] = slc
 
             Z = self.energy(r*self.units['length']).value
@@ -515,11 +515,11 @@ class PotentialBase(CommonBase):
         # figure out which elements are iterable, which are numeric
         _grids = []
         _slices = []
-        for ii,g in enumerate(grid):
+        for ii, g in enumerate(grid):
             if isiterable(g):
-                _grids.append((ii,g))
+                _grids.append((ii, g))
             else:
-                _slices.append((ii,g))
+                _slices.append((ii, g))
 
         # figure out the dimensionality
         ndim = len(_grids)
@@ -541,7 +541,7 @@ class PotentialBase(CommonBase):
             r = np.zeros((len(_grids) + len(_slices), len(x1)))
             r[_grids[0][0]] = x1
 
-            for ii,slc in _slices:
+            for ii, slc in _slices:
                 r[ii] = slc
 
             Z = self.density(r*self.units['length']).value
@@ -552,15 +552,15 @@ class PotentialBase(CommonBase):
                 ax.set_ylabel("potential")
         else:
             # 2D contours
-            x1,x2 = np.meshgrid(_grids[0][1], _grids[1][1])
+            x1, x2 = np.meshgrid(_grids[0][1], _grids[1][1])
             shp = x1.shape
-            x1,x2 = x1.ravel(), x2.ravel()
+            x1, x2 = x1.ravel(), x2.ravel()
 
             r = np.zeros((len(_grids) + len(_slices), len(x1)))
             r[_grids[0][0]] = x1
             r[_grids[1][0]] = x2
 
-            for ii,slc in _slices:
+            for ii, slc in _slices:
                 r[ii] = slc
 
             Z = self.density(r*self.units['length']).value
@@ -705,10 +705,10 @@ class CompositePotential(PotentialBase, OrderedDict):
         self.ndim = None
 
         if len(args) > 0 and isinstance(args[0], list):
-            for k,v in args[0]:
+            for k, v in args[0]:
                 kwargs[k] = v
         else:
-            for i,v in args:
+            for i, v in args:
                 kwargs[str(i)] = v
 
         self.lock = False
@@ -750,7 +750,7 @@ class CompositePotential(PotentialBase, OrderedDict):
     @property
     def parameters(self):
         params = dict()
-        for k,v in self.items():
+        for k, v in self.items():
             params[k] = v.parameters
         return ImmutableDict(**params)
 

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -786,11 +786,11 @@ class CompositePotential(PotentialBase, OrderedDict):
 
 
 _potential_docstring = """units : `~gala.units.UnitSystem` (optional)
-    Set of non-reducable units that specify (at minimum) the
-    length, mass, time, and angle units.
-origin : `~astropy.units.Quantity` (optional)
-    The origin of the potential, the default being 0.
-R : array_like (optional)
-    A rotation matrix that specifies a rotation of the potential. This is
-    applied *after* the origin shift. Default is the identity matrix.
+        Set of non-reducable units that specify (at minimum) the
+        length, mass, time, and angle units.
+    origin : `~astropy.units.Quantity` (optional)
+        The origin of the potential, the default being 0.
+    R : array_like (optional)
+        A rotation matrix that specifies a rotation of the potential. This is
+        applied *after* the origin shift. Default is the identity matrix.
 """

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.constants import G
 import astropy.units as u
 from astropy.utils import isiterable
-import six
+from scipy.spatial.transform import Rotation
 
 # Project
 from ..common import CommonBase
@@ -19,8 +19,8 @@ from ...units import DimensionlessUnitSystem
 
 __all__ = ["PotentialBase", "CompositePotential"]
 
-@six.add_metaclass(abc.ABCMeta)
-class PotentialBase(CommonBase):
+
+class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
     """
     A baseclass for defining pure-Python gravitational potentials.
 
@@ -56,6 +56,9 @@ class PotentialBase(CommonBase):
 
         if R is None:
             R = np.eye(ndim)
+        elif isinstance(R, Rotation):
+            R = R.as_dcm()
+
         R = np.array(R)
         if R.shape != (ndim, ndim):
             raise ValueError('Rotation matrix passed to potential {0} has '
@@ -790,7 +793,8 @@ _potential_docstring = """units : `~gala.units.UnitSystem` (optional)
         length, mass, time, and angle units.
     origin : `~astropy.units.Quantity` (optional)
         The origin of the potential, the default being 0.
-    R : array_like (optional)
-        A rotation matrix that specifies a rotation of the potential. This is
-        applied *after* the origin shift. Default is the identity matrix.
+    R : `~scipy.spatial.transform.Rotation`, array_like (optional)
+        A Scipy ``Rotation`` object or an array representing a rotation matrix
+        that specifies a rotation of the potential. This is applied *after* the
+        origin shift. Default is the identity matrix.
 """

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -50,12 +50,18 @@ class PotentialBase(CommonBase):
             origin = np.zeros(self.ndim)
         self.origin = self._remove_units(origin)
 
-        if R is not None and ndim == 3:
+        if R is not None and ndim not in [2, 3]:
             raise NotImplementedError('Gala potentials currently only support '
-                                      'rotations when ndim=3.')
+                                      'rotations when ndim=2 or ndim=3.')
 
         if R is None:
             R = np.eye(ndim)
+        R = np.array(R)
+        if R.shape != (ndim, ndim):
+            raise ValueError('Rotation matrix passed to potential {0} has '
+                             'an invalid shape: expected {1}, got {2}'
+                             .format(self.__class__.__name__,
+                                     (ndim, ndim), R.shape))
         self.R = R
 
     # ========================================================================

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -32,7 +32,8 @@ class PotentialBase(CommonBase):
     to compute the density and hessian: ``_density()``, ``_hessian()``.
     """
 
-    def __init__(self, parameters, origin=None,
+    def __init__(self, parameters, origin=None, R=None,
+                 parameter_physical_types=None,
                  ndim=3, units=None):
 
         self.units = self._validate_units(units)
@@ -48,6 +49,14 @@ class PotentialBase(CommonBase):
         if origin is None:
             origin = np.zeros(self.ndim)
         self.origin = self._remove_units(origin)
+
+        if R is not None and ndim == 3:
+            raise NotImplementedError('Gala potentials currently only support '
+                                      'rotations when ndim=3.')
+
+        if R is None:
+            R = np.eye(ndim)
+        self.R = R
 
     # ========================================================================
     # Abstract methods that must be implemented by subclasses

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -203,7 +203,8 @@ class PotentialBase(CommonBase):
             ``(q.shape[0],q.shape[0]) + q.shape[1:]``. That is, an ``n_dim`` by
             ``n_dim`` array (matrix) for each position.
         """
-        if self.R is not None:
+        if (self.R is not None and
+                not np.allclose(np.diag(self.R), 1., atol=1e-15, rtol=0)):
             raise NotImplementedError("Computing Hessian matrices for rotated "
                                       "potentials is currently not supported.")
         q = self._remove_units_prepare_shape(q)
@@ -725,6 +726,8 @@ class CompositePotential(PotentialBase, OrderedDict):
             self._check_component(v)
 
         OrderedDict.__init__(self, **kwargs)
+
+        self.R = None # TODO: this is a little messy
 
     def __setitem__(self, key, value):
         self._check_component(value)

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -64,6 +64,9 @@ class PotentialBase(CommonBase):
                                      (ndim, ndim), R.shape))
         self.R = R
 
+    def to_latex(self):
+        return ""
+
     # ========================================================================
     # Abstract methods that must be implemented by subclasses
     #
@@ -780,3 +783,14 @@ class CompositePotential(PotentialBase, OrderedDict):
 
     def __repr__(self):
         return "<CompositePotential {}>".format(",".join(self.keys()))
+
+
+_potential_docstring = """units : `~gala.units.UnitSystem` (optional)
+    Set of non-reducable units that specify (at minimum) the
+    length, mass, time, and angle units.
+origin : `~astropy.units.Quantity` (optional)
+    The origin of the potential, the default being 0.
+R : array_like (optional)
+    A rotation matrix that specifies a rotation of the potential. This is
+    applied *after* the origin shift. Default is the identity matrix.
+"""

--- a/gala/potential/potential/cpotential.pxd
+++ b/gala/potential/potential/cpotential.pxd
@@ -24,6 +24,7 @@ cdef extern from "potential/src/cpotential.h":
         int n_params[MAX_N_COMPONENTS]
         double *parameters[MAX_N_COMPONENTS]
         double *q0[MAX_N_COMPONENTS]
+        double *R[MAX_N_COMPONENTS]
 
     double c_potential(CPotential *p, double t, double *q) nogil
     double c_density(CPotential *p, double t, double *q) nogil
@@ -42,8 +43,10 @@ cdef class CPotentialWrapper:
     cdef int[::1] _n_params
     cdef list _potentials # HACK: for CCompositePotentialWrapper
     cdef double[::1] _q0
+    cdef double[::1] _R
 
-    cpdef init(self, list parameters, double[::1] q0, int n_dim=?)
+    cpdef init(self, list parameters, double[::1] q0, double[:, ::1] R,
+               int n_dim=?)
 
     cpdef energy(self, double[:,::1] q, double[::1] t)
     cpdef density(self, double[:,::1] q, double[::1] t)

--- a/gala/potential/potential/src/cpotential.c
+++ b/gala/potential/potential/src/cpotential.c
@@ -48,13 +48,12 @@ void apply_shift_rotate(double *q_in, double *q0, double *R, int n_dim,
 
 double c_potential(CPotential *p, double t, double *qp) {
     double v = 0;
-    int i;
+    int i, j;
     double qp_trans[p->n_dim];
 
-    for (i=0; i < p->n_dim; i++)
-        qp_trans[i] = 0.;
-
     for (i=0; i < p->n_components; i++) {
+        for (j=0; j < p->n_dim; j++)
+            qp_trans[j] = 0.;
         apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, 0,
                            &qp_trans[0]);
         v = v + (p->value)[i](t, (p->parameters)[i], &qp_trans[0], p->n_dim);
@@ -66,13 +65,12 @@ double c_potential(CPotential *p, double t, double *qp) {
 
 double c_density(CPotential *p, double t, double *qp) {
     double v = 0;
-    int i;
+    int i, j;
     double qp_trans[p->n_dim];
 
-    for (i=0; i < p->n_dim; i++)
-        qp_trans[i] = 0.;
-
     for (i=0; i < p->n_components; i++) {
+        for (j=0; j < p->n_dim; j++)
+            qp_trans[j] = 0.;
         apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, 0,
                            &qp_trans[0]);
         v = v + (p->density)[i](t, (p->parameters)[i], &qp_trans[0], p->n_dim);

--- a/gala/potential/potential/src/cpotential.c
+++ b/gala/potential/potential/src/cpotential.c
@@ -1,78 +1,99 @@
 #include <math.h>
 #include "cpotential.h"
 
+
+void apply_shift_rotate(double *qp_in, double *q0, double *R, int n_dim,
+                        double *qp_out) {
+    double tmp[n_dim];
+    int j;
+
+    // Shift to the specified origin
+    for (j=0; j < n_dim; j++) {
+        tmp[j] = qp_in[j] - q0[j];
+    }
+
+    // Apply rotation matrix
+    // NOTE: elsewhere, we enforce that rotation matrix only works for
+    // ndim=2 or ndim=3, so here we can assume that!
+    if (n_dim == 3) {
+        qp_out[0] = R[0] * tmp[0] + R[1] * tmp[1] + R[2] * tmp[2];
+        qp_out[1] = R[3] * tmp[0] + R[4] * tmp[1] + R[5] * tmp[2];
+        qp_out[2] = R[6] * tmp[0] + R[7] * tmp[1] + R[8] * tmp[2];
+    } else if (n_dim == 2) {
+        qp_out[0] = R[0] * tmp[0] + R[1] * tmp[1];
+        qp_out[1] = R[2] * tmp[0] + R[3] * tmp[1];
+    } else {
+        for (j=0; j < n_dim; j++)
+            qp_out[j] = tmp[j];
+    }
+}
+
+
 double c_potential(CPotential *p, double t, double *qp) {
     double v = 0;
-    int i, j;
-    double _qp[p->n_dim];
+    int i;
+    double qp_trans[p->n_dim];
 
     for (i=0; i < p->n_components; i++) {
-        // this looks like it sucks, but doesn't add much time...
-        for (j=0; j < p->n_dim; j++) {
-            _qp[j] = qp[j] - (p->q0)[i][j];
-        }
-        v = v + (p->value)[i](t, (p->parameters)[i], &_qp[0], p->n_dim);
+        apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, &qp_trans[0]);
+        v = v + (p->value)[i](t, (p->parameters)[i], &qp_trans[0], p->n_dim);
     }
 
     return v;
 }
+
 
 double c_density(CPotential *p, double t, double *qp) {
     double v = 0;
-    int i, j;
-    double _qp[p->n_dim];
+    int i;
+    double qp_trans[p->n_dim];
 
     for (i=0; i < p->n_components; i++) {
-        // this looks like it sucks, but doesn't add much time...
-        for (j=0; j < p->n_dim; j++) {
-            _qp[j] = qp[j] - (p->q0)[i][j];
-        }
-        v = v + (p->density)[i](t, (p->parameters)[i], &_qp[0], p->n_dim);
+        apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, &qp_trans[0]);
+        v = v + (p->density)[i](t, (p->parameters)[i], &qp_trans[0], p->n_dim);
     }
 
     return v;
 }
 
+
 void c_gradient(CPotential *p, double t, double *qp, double *grad) {
-    int i, j;
-    double _qp[p->n_dim];
+    int i;
+    double qp_trans[p->n_dim];
 
     for (i=0; i < p->n_dim; i++) {
         grad[i] = 0.;
     }
 
     for (i=0; i < p->n_components; i++) {
-        // this looks like it sucks, but doesn't add much time...
-        for (j=0; j < p->n_dim; j++) {
-            _qp[j] = qp[j] - (p->q0)[i][j];
-        }
-        (p->gradient)[i](t, (p->parameters)[i], &_qp[0], p->n_dim, grad);
+        apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, &qp_trans[0]);
+        (p->gradient)[i](t, (p->parameters)[i], &qp_trans[0], p->n_dim, grad);
     }
 
 }
 
+
 void c_hessian(CPotential *p, double t, double *qp, double *hess) {
-    int i, j;
-    double _qp[p->n_dim];
+    int i;
+    double qp_trans[p->n_dim];
 
     for (i=0; i < pow(p->n_dim,2); i++) {
         hess[i] = 0.;
     }
 
     for (i=0; i < p->n_components; i++) {
-        // this looks like it sucks, but doesn't add much time...
-        for (j=0; j < p->n_dim; j++) {
-            _qp[j] = qp[j] - (p->q0)[i][j];
-        }
-        (p->hessian)[i](t, (p->parameters)[i], &_qp[0], p->n_dim, hess);
+        apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, &qp_trans[0]);
+        (p->hessian)[i](t, (p->parameters)[i], &qp_trans[0], p->n_dim, hess);
     }
 
 }
+
 
 double c_d_dr(CPotential *p, double t, double *qp, double *epsilon) {
     double h, r, dPhi_dr;
     int j;
     double r2 = 0;
+
     for (j=0; j<p->n_dim; j++) {
         r2 = r2 + qp[j]*qp[j];
     }
@@ -95,6 +116,7 @@ double c_d_dr(CPotential *p, double t, double *qp, double *epsilon) {
 
     return dPhi_dr / (2.*h);
 }
+
 
 double c_d2_dr2(CPotential *p, double t, double *qp, double *epsilon) {
     double h, r, d2Phi_dr2;
@@ -123,7 +145,9 @@ double c_d2_dr2(CPotential *p, double t, double *qp, double *epsilon) {
     return d2Phi_dr2 / (h*h);
 }
 
-double c_mass_enclosed(CPotential *p, double t, double *qp, double G, double *epsilon) {
+
+double c_mass_enclosed(CPotential *p, double t, double *qp, double G,
+                       double *epsilon) {
     double r2, dPhi_dr;
     int j;
 

--- a/gala/potential/potential/src/cpotential.c
+++ b/gala/potential/potential/src/cpotential.c
@@ -120,7 +120,8 @@ void c_hessian(CPotential *p, double t, double *qp, double *hess) {
         apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, 0,
                            &qp_trans[0]);
         (p->hessian)[i](t, (p->parameters)[i], &qp_trans[0], p->n_dim, hess);
-        // TODO: here - need to apply rotate to the Hessian! damn matrices
+        // TODO: here - need to apply inverse rotation to the Hessian!
+        // - Hessian calculation for potentials with rotations are disabled
     }
 
 }

--- a/gala/potential/potential/src/cpotential.h
+++ b/gala/potential/potential/src/cpotential.h
@@ -22,11 +22,14 @@
         // array containing the number of parameters in each component
         int n_params[MAX_N_COMPONENTS];
 
-        // pointer to array of pointers to the parameter arrays for each component
+        // pointer to array of pointers to the parameter arrays
         double *parameters[MAX_N_COMPONENTS];
 
-        // pointer to array of pointers containing the origin coordinates for each
+        // pointer to array of pointers containing the origin coordinates
         double *q0[MAX_N_COMPONENTS];
+
+        // pointer to array of pointers containing rotation matrix elements
+        double *R[MAX_N_COMPONENTS];
     };
 #endif
 

--- a/gala/potential/potential/tests/helpers.py
+++ b/gala/potential/potential/tests/helpers.py
@@ -224,13 +224,13 @@ class PotentialTestBase(object):
 
     def test_orbit_integration(self):
         """
-        Make we can integrate an orbit in this potential
+        Make sure we can integrate an orbit in this potential
         """
         w0 = self.w0
         w0 = np.vstack((w0,w0,w0)).T
 
         t1 = time.time()
-        orbit = self.H.integrate_orbit(w0, dt=1., n_steps=10000)
+        orbit = self.H.integrate_orbit(w0, dt=0.1, n_steps=10000)
         print("Integration time (10000 steps): {}".format(time.time() - t1))
 
         if self.show_plots:
@@ -242,7 +242,7 @@ class PotentialTestBase(object):
         us = self.potential.units
         w0 = PhaseSpacePosition(pos=w0[:self.ndim]*us['length'],
                                 vel=w0[self.ndim:]*us['length']/us['time'])
-        orbit = self.H.integrate_orbit(w0, dt=1., n_steps=10000)
+        orbit = self.H.integrate_orbit(w0, dt=0.1, n_steps=10000)
 
         if self.show_plots:
             f = orbit.plot()

--- a/gala/potential/potential/tests/test_all_builtin.py
+++ b/gala/potential/potential/tests/test_all_builtin.py
@@ -7,6 +7,7 @@ import numpy as np
 import astropy.units as u
 from astropy.tests.helper import quantity_allclose
 import pytest
+from scipy.spatial.transform import Rotation
 
 # This project
 from ..core import CompositePotential
@@ -252,6 +253,18 @@ class TestLongMuraliBarRotate(PotentialTestBase):
                                        R=np.array([[ 0.63302222,  0.75440651,  0.17364818],
                                                    [-0.76604444,  0.64278761,  0.        ],
                                                    [-0.1116189 , -0.13302222,  0.98480775]]))
+    vc = potential.circular_velocity([19.,0,0]*u.kpc).decompose(galactic).value[0]
+    w0 = [19.0,0.2,-0.9,0.,vc,0.]
+
+    def test_hessian(self):
+        # TODO: when hessian for rotated potentials implemented, remove this
+        with pytest.raises(NotImplementedError):
+            self.potential.hessian([1., 2., 3.])
+
+class TestLongMuraliBarRotationScipy(PotentialTestBase):
+    potential = LongMuraliBarPotential(units=galactic, m=1E11,
+                                       a=4.*u.kpc, b=1*u.kpc, c=1.*u.kpc,
+                                       R=Rotation.from_euler('zxz', [90., 0, 0.], degrees=True))
     vc = potential.circular_velocity([19.,0,0]*u.kpc).decompose(galactic).value[0]
     w0 = [19.0,0.2,-0.9,0.,vc,0.]
 

--- a/gala/potential/potential/tests/test_all_builtin.py
+++ b/gala/potential/potential/tests/test_all_builtin.py
@@ -1,4 +1,3 @@
-
 """
     Test the builtin CPotential classes
 """
@@ -13,6 +12,7 @@ import pytest
 from ..core import CompositePotential
 from ..builtin import *
 from ..ccompositepotential import *
+from ...frame import ConstantRotatingFrame
 from ....units import solarsystem, galactic, DimensionlessUnitSystem
 from .helpers import PotentialTestBase, CompositePotentialTestBase
 from ...._cconfig import GSL_ENABLED
@@ -125,6 +125,7 @@ class TestPowerLawCutoff(PotentialTestBase):
     def setup(self):
         self.potential = PowerLawCutoffPotential(units=galactic,
                                                  m=1E10, r_c=1., alpha=1.8)
+        super().setup()
 
 class TestSphericalNFW(PotentialTestBase):
     potential = NFWPotential(units=galactic, m=1E11, r_s=12.)
@@ -280,3 +281,18 @@ class TestCComposite(CompositePotentialTestBase):
     potential['disk'] = p2
     potential['halo'] = p1
     w0 = [19.0,2.7,-6.9,0.0352238,-0.03579493,0.075]
+
+class TestKepler3Body(CompositePotentialTestBase):
+    """ This implicitly tests the origin shift """
+    mu = 1/11.
+    x1 = -mu
+    m1 = 1-mu
+    x2 = 1-mu
+    m2 = mu
+    potential = CCompositePotential()
+    potential['m1'] = KeplerPotential(m=m1, origin=[x1, 0, 0.])
+    potential['m2'] = KeplerPotential(m=m2, origin=[x2, 0, 0.])
+
+    Omega = np.array([0, 0, 1.])
+    frame = ConstantRotatingFrame(Omega=Omega)
+    w0 = [0.5,0,0, 0., 1.05800316, 0.]

--- a/gala/potential/potential/tests/test_all_builtin.py
+++ b/gala/potential/potential/tests/test_all_builtin.py
@@ -245,6 +245,20 @@ class TestLongMuraliBar(PotentialTestBase):
     vc = potential.circular_velocity([19.,0,0]*u.kpc).decompose(galactic).value[0]
     w0 = [19.0,0.2,-0.9,0.,vc,0.]
 
+class TestLongMuraliBarRotate(PotentialTestBase):
+    potential = LongMuraliBarPotential(units=galactic, m=1E11,
+                                       a=4.*u.kpc, b=1*u.kpc, c=1.*u.kpc,
+                                       R=np.array([[ 0.63302222,  0.75440651,  0.17364818],
+                                                   [-0.76604444,  0.64278761,  0.        ],
+                                                   [-0.1116189 , -0.13302222,  0.98480775]]))
+    vc = potential.circular_velocity([19.,0,0]*u.kpc).decompose(galactic).value[0]
+    w0 = [19.0,0.2,-0.9,0.,vc,0.]
+
+    def test_hessian(self):
+        # TODO: when hessian for rotated potentials implemented, remove this
+        with pytest.raises(NotImplementedError):
+            self.potential.hessian([1., 2., 3.])
+
 class TestComposite(CompositePotentialTestBase):
     p1 = LogarithmicPotential(units=galactic,
                               v_c=0.17, r_h=10.,

--- a/gala/potential/potential/tests/test_special.py
+++ b/gala/potential/potential/tests/test_special.py
@@ -31,3 +31,4 @@ class TestBovyMWPotential2014(CompositePotentialTestBase):
 
     def setup(self):
         self.potential = BovyMWPotential2014()
+        super().setup()

--- a/gala/potential/potential/util.py
+++ b/gala/potential/potential/util.py
@@ -160,3 +160,30 @@ def from_equation(expr, vars, pars, name=None, hessian=False):
 
     CustomPotential.save = None
     return CustomPotential
+
+
+def format_doc(*args, **kwargs):
+    """
+    Replaces the docstring of the decorated object and then formats it.
+
+    Modeled after astropy.utils.decorators.format_doc
+    """
+    def set_docstring(obj):
+
+        # None means: use the objects __doc__
+        doc = obj.__doc__
+        # Delete documentation in this case so we don't end up with
+        # awkwardly self-inserted docs.
+        obj.__doc__ = None
+
+        if not doc:
+            # In case the docstring is empty it's probably not what was wanted.
+            raise ValueError('docstring must be a string or containing a '
+                             'docstring that is not empty.')
+
+        # If the original has a not-empty docstring append it to the format
+        # kwargs.
+        kwargs['__doc__'] = obj.__doc__ or ''
+        obj.__doc__ = doc.format(*args, **kwargs)
+        return obj
+    return set_docstring

--- a/gala/potential/potential/util.py
+++ b/gala/potential/potential/util.py
@@ -176,11 +176,6 @@ def format_doc(*args, **kwargs):
         # awkwardly self-inserted docs.
         obj.__doc__ = None
 
-        if not doc:
-            # In case the docstring is empty it's probably not what was wanted.
-            raise ValueError('docstring must be a string or containing a '
-                             'docstring that is not empty.')
-
         # If the original has a not-empty docstring append it to the format
         # kwargs.
         kwargs['__doc__'] = obj.__doc__ or ''

--- a/gala/potential/scf/bfe_class.pyx
+++ b/gala/potential/scf/bfe_class.pyx
@@ -52,8 +52,10 @@ __all__ = ['SCFPotential']
 
 cdef class SCFWrapper(CPotentialWrapper):
 
-    def __init__(self, G, parameters, q0):
-        self.init([G] + list(parameters), np.ascontiguousarray(q0))
+    def __init__(self, G, parameters, q0, R):
+        self.init([G] + list(parameters),
+                  np.ascontiguousarray(q0),
+                  np.ascontiguousarray(R))
         if USE_GSL == 1:
             self.cpotential.value[0] = <energyfunc>(scf_value)
             self.cpotential.density[0] = <densityfunc>(scf_density)

--- a/gala/potential/scf/bfe_class.pyx
+++ b/gala/potential/scf/bfe_class.pyx
@@ -63,7 +63,7 @@ cdef class SCFWrapper(CPotentialWrapper):
 
 class SCFPotential(CPotentialBase):
     r"""
-    SCFPotential(m, r_s, Snlm, Tnlm, units=None)
+    SCFPotential(m, r_s, Snlm, Tnlm, units=None, origin=None, R=None)
 
     A gravitational potential represented as a basis function expansion.  This
     uses the self-consistent field (SCF) method of Hernquist & Ostriker (1992)
@@ -98,7 +98,8 @@ class SCFPotential(CPotentialBase):
                        'Snlm': 'dimensionless',
                        'Tnlm': 'dimensionless'}
 
-    def __init__(self, m, r_s, Snlm, Tnlm=None, units=None):
+    def __init__(self, m, r_s, Snlm, Tnlm=None, units=None,
+                 origin=None, R=None):
         from gala._cconfig import GSL_ENABLED
         if not GSL_ENABLED:
             raise ValueError("Gala was compiled without GSL and so the "
@@ -134,4 +135,6 @@ class SCFPotential(CPotentialBase):
         super(SCFPotential, self).__init__(parameters=parameters,
                                            units=units,
                                            Wrapper=SCFWrapper,
+                                           origin=origin,
+                                           R=R,
                                            c_only=['nmax', 'lmax']) # don't expose these in the .parameters dictionary


### PR DESCRIPTION
- [x] Document that rotation matrix applied *after* origin shift
- [x] Add utility functions or examples of creating R from euler angles or axis-angle representation
- [x] Python-only potentials don't do anything with origin or R
- [x] Tests!
- [x] update https://github.com/adrn/gala-cpotential-demo
- [x] add docs page to "potential" section about "specifying potential origin and rotation"

This fixes #71 