### PR TITLE
typo in docs [skip ci]

### DIFF
--- a/docs/examples/mock-stream-heliocentric.rst
+++ b/docs/examples/mock-stream-heliocentric.rst
@@ -14,7 +14,7 @@ We first need to import some relevant packages::
    >>> import gala.potential as gp
    >>> from gala.units import galactic
 
-In the examples below, we will work use the ``galactic``
+In the examples below, we will use the ``galactic``
 `~gala.units.UnitSystem`: as I define it, this is: :math:`{\rm kpc}`,
 :math:`{\rm Myr}`, :math:`{\rm M}_\odot`.
 


### PR DESCRIPTION
found a typo in the mock stellar stream docs 