### PR TITLE
Add option to control mockstream snapshot output

### DIFF
--- a/gala/dynamics/mockstream/core.py
+++ b/gala/dynamics/mockstream/core.py
@@ -9,7 +9,8 @@ import numpy as np
 from .. import PhaseSpacePosition, Orbit
 from ...potential import Hamiltonian, CPotentialBase
 from ...integrate import DOPRI853Integrator, LeapfrogIntegrator
-from ._mockstream import _mock_stream_dop853, _mock_stream_leapfrog, _mock_stream_animate
+from ._mockstream import (_mock_stream_dop853, _mock_stream_leapfrog,
+                          _mock_stream_animate)
 
 __all__ = ['mock_stream', 'streakline_stream', 'fardal_stream',
            'dissolved_fardal_stream']
@@ -17,7 +18,7 @@ __all__ = ['mock_stream', 'streakline_stream', 'fardal_stream',
 def mock_stream(hamiltonian, prog_orbit, prog_mass, k_mean, k_disp,
                 release_every=1, Integrator=DOPRI853Integrator,
                 Integrator_kwargs=dict(),
-                snapshot_filename=None, seed=None):
+                snapshot_filename=None, output_every=1, seed=None):
     """
     Generate a mock stellar stream in the specified potential with a
     progenitor system that ends up at the specified position.
@@ -51,6 +52,9 @@ def mock_stream(hamiltonian, prog_orbit, prog_mass, k_mean, k_disp,
         Filename to save all incremental snapshots of particle positions and
         velocities. Warning: this can make very large files if you are not
         careful!
+    output_every : int (optional)
+        If outputing snapshots (i.e., if snapshot_filename is specified), this
+        controls how often to output a snapshot.
     seed : int (optional)
         A random number seed for initializing the particle positions.
 
@@ -132,6 +136,7 @@ def mock_stream(hamiltonian, prog_orbit, prog_mass, k_mean, k_disp,
 
             _mock_stream_animate(snapshot_filename, hamiltonian, t=prog_t, prog_w=prog_w,
                                  release_every=release_every,
+                                 output_every=output_every,
                                  _k_mean=k_mean, _k_disp=k_disp,
                                  G=hamiltonian.potential.G,
                                  _prog_mass=prog_mass, seed=seed,
@@ -221,7 +226,7 @@ def streakline_stream(hamiltonian, prog_orbit, prog_mass, release_every=1,
 
 def fardal_stream(hamiltonian, prog_orbit, prog_mass, release_every=1,
                   Integrator=DOPRI853Integrator, Integrator_kwargs=dict(),
-                  snapshot_filename=None, seed=None):
+                  snapshot_filename=None, seed=None, output_every=1):
     """
     Generate a mock stellar stream in the specified potential with a
     progenitor system that ends up at the specified position.
@@ -247,6 +252,9 @@ def fardal_stream(hamiltonian, prog_orbit, prog_mass, release_every=1,
         Filename to save all incremental snapshots of particle positions and
         velocities. Warning: this can make very large files if you are not
         careful!
+    output_every : int (optional)
+        If outputing snapshots (i.e., if snapshot_filename is specified), this
+        controls how often to output a snapshot.
     seed : int (optional)
         A random number seed for initializing the particle positions.
 
@@ -276,14 +284,18 @@ def fardal_stream(hamiltonian, prog_orbit, prog_mass, release_every=1,
     k_mean[5] = 0. # vz
     k_disp[5] = 0.5
 
-    return mock_stream(hamiltonian=hamiltonian, prog_orbit=prog_orbit, prog_mass=prog_mass,
-                       k_mean=k_mean, k_disp=k_disp, release_every=release_every,
-                       Integrator=Integrator, Integrator_kwargs=Integrator_kwargs,
-                       snapshot_filename=snapshot_filename, seed=seed)
+    return mock_stream(hamiltonian=hamiltonian, prog_orbit=prog_orbit,
+                       prog_mass=prog_mass,
+                       k_mean=k_mean, k_disp=k_disp,
+                       release_every=release_every,
+                       Integrator=Integrator,
+                       Integrator_kwargs=Integrator_kwargs,
+                       snapshot_filename=snapshot_filename,
+                       output_every=output_every, seed=seed)
 
 def dissolved_fardal_stream(hamiltonian, prog_orbit, prog_mass, t_disrupt, release_every=1,
                             Integrator=DOPRI853Integrator, Integrator_kwargs=dict(),
-                            snapshot_filename=None, seed=None):
+                            snapshot_filename=None, output_every=1, seed=None):
     """
     Generate a mock stellar stream in the specified potential with a
     progenitor system that ends up at the specified position.
@@ -313,6 +325,9 @@ def dissolved_fardal_stream(hamiltonian, prog_orbit, prog_mass, t_disrupt, relea
         Filename to save all incremental snapshots of particle positions and
         velocities. Warning: this can make very large files if you are not
         careful!
+    output_every : int (optional)
+        If outputing snapshots (i.e., if snapshot_filename is specified), this
+        controls how often to output a snapshot.
     seed : int (optional)
         A random number seed for initializing the particle positions.
 
@@ -352,7 +367,11 @@ def dissolved_fardal_stream(hamiltonian, prog_orbit, prog_mass, t_disrupt, relea
     k_mean[:,5] = 0. # vz
     k_disp[:,5] = 0.5
 
-    return mock_stream(hamiltonian=hamiltonian, prog_orbit=prog_orbit, prog_mass=prog_mass,
-                       k_mean=k_mean, k_disp=k_disp, release_every=release_every,
-                       Integrator=Integrator, Integrator_kwargs=Integrator_kwargs,
-                       snapshot_filename=snapshot_filename, seed=seed)
+    return mock_stream(hamiltonian=hamiltonian, prog_orbit=prog_orbit,
+                       prog_mass=prog_mass,
+                       k_mean=k_mean, k_disp=k_disp,
+                       release_every=release_every,
+                       Integrator=Integrator,
+                       Integrator_kwargs=Integrator_kwargs,
+                       snapshot_filename=snapshot_filename,
+                       output_every=output_every, seed=seed)

--- a/gala/dynamics/mockstream/core.py
+++ b/gala/dynamics/mockstream/core.py
@@ -345,27 +345,27 @@ def dissolved_fardal_stream(hamiltonian, prog_orbit, prog_mass, t_disrupt, relea
 
     disrupt_ix = np.abs(t - t_disrupt).argmin()
 
-    k_mean = np.zeros((t.size,6))
-    k_disp = np.zeros((t.size,6))
+    k_mean = np.zeros((t.size, 6))
+    k_disp = np.zeros((t.size, 6))
 
-    k_mean[:,0] = 2. # R
-    k_mean[disrupt_ix:,0] = 0.
-    k_disp[:,0] = 0.5
+    k_mean[:, 0] = 2. # R
+    k_mean[disrupt_ix:, 0] = 0.
+    k_disp[:, 0] = 0.5
 
-    k_mean[:,1] = 0. # phi
-    k_disp[:,1] = 0.
+    k_mean[:, 1] = 0. # phi
+    k_disp[:, 1] = 0.
 
-    k_mean[:,2] = 0. # z
-    k_disp[:,2] = 0.5
+    k_mean[:, 2] = 0. # z
+    k_disp[:, 2] = 0.5
 
-    k_mean[:,3] = 0. # vR
-    k_disp[:,3] = 0.
+    k_mean[:, 3] = 0. # vR
+    k_disp[:, 3] = 0.
 
-    k_mean[:,4] = 0.3 # vt
-    k_disp[:,4] = 0.5
+    k_mean[:, 4] = 0.3 # vt
+    k_disp[:, 4] = 0.5
 
-    k_mean[:,5] = 0. # vz
-    k_disp[:,5] = 0.5
+    k_mean[:, 5] = 0. # vz
+    k_disp[:, 5] = 0.5
 
     return mock_stream(hamiltonian=hamiltonian, prog_orbit=prog_orbit,
                        prog_mass=prog_mass,

--- a/gala/dynamics/mockstream/tests/test_mockstream.py
+++ b/gala/dynamics/mockstream/tests/test_mockstream.py
@@ -125,22 +125,23 @@ def test_animate(tmpdir):
 @pytest.mark.skipif('CI' in os.environ,
                     reason="For some reason, doesn't work on Travis/CI")
 def test_animate_output_every(tmpdir):
+    snapshot_filename = os.path.join(str(tmpdir), "test.hdf5")
 
     np.random.seed(42)
     pot = HernquistPotential(m=1E11, c=1., units=galactic)
     w0 = PhaseSpacePosition(pos=[5., 0, 0]*u.kpc, vel=[0, 0.1, 0]*u.kpc/u.Myr)
-    orbit = Hamiltonian(pot).integrate_orbit(w0, dt=1., n_steps=1000,
+    orbit = Hamiltonian(pot).integrate_orbit(w0, dt=1., n_steps=100,
                                              Integrator=DOPRI853Integrator)
 
     fardal_stream(pot, orbit, prog_mass=1E5*u.Msun, release_every=10,
-                  snapshot_filename=os.path.join(str(tmpdir), "test.hdf5"),
+                  snapshot_filename=snapshot_filename,
                   output_every=20, seed=42)
 
     stream = fardal_stream(pot, orbit, prog_mass=1E5*u.Msun, release_every=10,
                            seed=42)
 
     import h5py
-    with h5py.File(os.path.join(str(tmpdir), "test.hdf5")) as f:
+    with h5py.File(snapshot_filename, 'r') as f:
         t = f['t'][:]
         pos = f['pos'][:]
         vel = f['vel'][:]
@@ -151,4 +152,4 @@ def test_animate_output_every(tmpdir):
         assert np.allclose(pos[:, -1, idx], stream.xyz.value[:, idx], rtol=1E-4)
         assert np.allclose(vel[:, -1, idx], stream.v_xyz.value[:, idx], rtol=1E-4)
 
-    assert pos.shape[1] == (1000 // 20 + 1)
+    assert pos.shape[1] == (100 // 20 + 2) # initial and final


### PR DESCRIPTION
This fixes #134 (for @abonaca 😄).

The mockstream classes (with DOP853 integration) now support passing in an argument to control to frequency of snapshot saving, `output_every`.