### PR TITLE
Add option to replace units on a potential instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - CONDA_DEPENDENCIES='cython jinja2 scipy matplotlib pyyaml h5py sympy qt ipython jupyter notebook ipykernel numexpr' # SEE PANDOC HACK BELOW
-        - PIP_DEPENDENCIES='nbsphinx==0.3.1 tqdm'
+        - PIP_DEPENDENCIES='nbsphinx tqdm'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
 
     matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 New Features
 ------------
+- Potential objects now support replacing the unit system with the
+  ``.replace_units()`` method, or by updating the ``.units`` attribute on an
+  existing instance.
 
 Bug fixes
 ---------

--- a/gala/potential/potential/builtin/special.py
+++ b/gala/potential/potential/builtin/special.py
@@ -52,19 +52,19 @@ class LM10Potential(CCompositePotential):
                             phi=97*u.degree,
                             v_c=np.sqrt(2)*121.858*u.km/u.s)
 
-        for k,v in default_disk.items():
+        for k, v in default_disk.items():
             if k not in disk:
                 disk[k] = v
 
-        for k,v in default_bulge.items():
+        for k, v in default_bulge.items():
             if k not in bulge:
                 bulge[k] = v
 
-        for k,v in default_halo.items():
+        for k, v in default_halo.items():
             if k not in halo:
                 halo[k] = v
 
-        super(LM10Potential,self).__init__()
+        super().__init__()
 
         self["disk"] = MiyamotoNagaiPotential(units=units, **disk)
         self["bulge"] = HernquistPotential(units=units, **bulge)
@@ -121,23 +121,23 @@ class MilkyWayPotential(CCompositePotential):
         if nucleus is None:
             nucleus = dict()
 
-        for k,v in default_disk.items():
+        for k, v in default_disk.items():
             if k not in disk:
                 disk[k] = v
 
-        for k,v in default_bulge.items():
+        for k, v in default_bulge.items():
             if k not in bulge:
                 bulge[k] = v
 
-        for k,v in default_halo.items():
+        for k, v in default_halo.items():
             if k not in halo:
                 halo[k] = v
 
-        for k,v in default_nucl.items():
+        for k, v in default_nucl.items():
             if k not in nucleus:
                 nucleus[k] = v
 
-        super(MilkyWayPotential, self).__init__()
+        super().__init__()
 
         self["disk"] = MiyamotoNagaiPotential(units=units, **disk)
         self["bulge"] = HernquistPotential(units=units, **bulge)
@@ -194,19 +194,19 @@ class BovyMWPotential2014(CCompositePotential):
         if bulge is None:
             bulge = dict()
 
-        for k,v in default_disk.items():
+        for k, v in default_disk.items():
             if k not in disk:
                 disk[k] = v
 
-        for k,v in default_bulge.items():
+        for k, v in default_bulge.items():
             if k not in bulge:
                 bulge[k] = v
 
-        for k,v in default_halo.items():
+        for k, v in default_halo.items():
             if k not in halo:
                 halo[k] = v
 
-        super(BovyMWPotential2014, self).__init__()
+        super().__init__()
 
         self["disk"] = MiyamotoNagaiPotential(units=units, **disk)
         self["bulge"] = PowerLawCutoffPotential(units=units, **bulge)

--- a/gala/potential/potential/ccompositepotential.pyx
+++ b/gala/potential/potential/ccompositepotential.pyx
@@ -67,7 +67,8 @@ cdef class CCompositePotentialWrapper(CPotentialWrapper):
     def __reduce__(self):
         return (self.__class__, (list(self._potentials),))
 
-class CCompositePotential(CPotentialBase, CompositePotential):
+
+class CCompositePotential(CompositePotential, CPotentialBase):
 
     def __init__(self, **potentials):
         CompositePotential.__init__(self, **potentials)
@@ -84,9 +85,10 @@ class CCompositePotential(CPotentialBase, CompositePotential):
         self._reset_c_instance()
 
     def __setstate__(self, state):
-        # when rebuilding from a pickle, temporarily release lock to add components
+        # when rebuilding from a pickle, temporarily release lock
         self.lock = False
-        for name,potential in state:
+        self._units = None
+        for name, potential in state:
             self[name] = potential
         self._reset_c_instance()
         self.lock = True

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -1,5 +1,6 @@
 # Standard library
 import abc
+import copy as pycopy
 from collections import OrderedDict
 import warnings
 import uuid
@@ -37,10 +38,9 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
     """
 
     def __init__(self, parameters, origin=None, R=None,
-                 parameter_physical_types=None,
                  ndim=3, units=None):
 
-        self.units = self._validate_units(units)
+        self._units = self._validate_units(units)
         self.parameters = self._prepare_parameters(parameters, self.units)
 
         try:
@@ -58,17 +58,16 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
             raise NotImplementedError('Gala potentials currently only support '
                                       'rotations when ndim=2 or ndim=3.')
 
-        if R is None:
-            R = np.eye(ndim)
-        elif isinstance(R, Rotation):
-            R = R.as_dcm()
+        if R is not None:
+            if isinstance(R, Rotation):
+                R = R.as_dcm()
+            R = np.array(R)
 
-        R = np.array(R)
-        if R.shape != (ndim, ndim):
-            raise ValueError('Rotation matrix passed to potential {0} has '
-                             'an invalid shape: expected {1}, got {2}'
-                             .format(self.__class__.__name__,
-                                     (ndim, ndim), R.shape))
+            if R.shape != (ndim, ndim):
+                raise ValueError('Rotation matrix passed to potential {0} has '
+                                 'an invalid shape: expected {1}, got {2}'
+                                 .format(self.__class__.__name__,
+                                         (ndim, ndim), R.shape))
         self.R = R
 
     def to_latex(self):
@@ -681,6 +680,39 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
         from .io import save
         save(self, f)
 
+    @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, units):
+        self.replace_units(units, copy=False)
+
+    def replace_units(self, units, copy=True):
+        """Change the unit system of this potential.
+
+        Parameters
+        ----------
+        units : `~gala.units.UnitSystem`
+            Set of non-reducable units that specify (at minimum) the
+            length, mass, time, and angle units.
+        copy : bool (optional)
+            If True, returns a copy, if False, changes this object.
+        """
+        if copy:
+            pot = pycopy.copy(self)
+        else:
+            pot = self
+
+        PotentialBase.__init__(pot,
+                               parameters=self.parameters,
+                               origin=self.origin,
+                               R=self.R,
+                               ndim=self.ndim,
+                               units=units)
+
+        return pot
+
     # ========================================================================
     # Deprecated methods
     #
@@ -753,21 +785,20 @@ class CompositePotential(PotentialBase, OrderedDict):
             self.ndim = p.ndim
 
         else:
-            if sorted([str(x) for x in self.units]) != sorted([str(x) for x in p.units]):
-                raise ValueError("Unit system of new potential component must match "
-                                 "unit systems of other potential components.")
+            if (sorted([str(x) for x in self.units]) !=
+                    sorted([str(x) for x in p.units])):
+                raise ValueError("Unit system of new potential component must "
+                                 "match unit systems of other potential "
+                                 "components.")
 
             if p.ndim != self.ndim:
-                raise ValueError("All potential components must have the same number of "
-                                 "phase-space dimensions ({} in this case)".format(self.ndim))
+                raise ValueError("All potential components must have the same "
+                                 "number of phase-space dimensions ({} in this "
+                                 "case)".format(self.ndim))
 
         if self.lock:
-            raise ValueError("Potential object is locked - new components can only be"
-                             " added to unlocked potentials.")
-
-    @property
-    def units(self):  # read-only
-        return self._units
+            raise ValueError("Potential object is locked - new components can "
+                             "only be added to unlocked potentials.")
 
     @property
     def parameters(self):
@@ -775,6 +806,32 @@ class CompositePotential(PotentialBase, OrderedDict):
         for k, v in self.items():
             params[k] = v.parameters
         return ImmutableDict(**params)
+
+    def replace_units(self, units, copy=True):
+        """Change the unit system of this potential.
+
+        Parameters
+        ----------
+        units : `~gala.units.UnitSystem`
+            Set of non-reducable units that specify (at minimum) the
+            length, mass, time, and angle units.
+        copy : bool (optional)
+            If True, returns a copy, if False, changes this object.
+        """
+        _lock = self.lock
+        if copy:
+            pots = self.__class__()
+        else:
+            pots = self
+
+        pots._units = None
+        pots.lock = False
+
+        for k, v in self.items():
+            pots[k] = v.replace_units(units, copy=copy)
+
+        pots.lock = _lock
+        return pots
 
     def _energy(self, q, t=0.):
         return np.sum([p._energy(q, t) for p in self.values()], axis=0)

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -700,7 +700,7 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
             If True, returns a copy, if False, changes this object.
         """
         if copy:
-            pot = pycopy.copy(self)
+            pot = pycopy.deepcopy(self)
         else:
             pot = self
 

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -286,7 +286,8 @@ class CPotentialBase(PotentialBase):
         # remove C-only parameters from parameter dictionary
         if self._c_only is not None:
             for name in self._c_only:
-                del self.parameters[name]
+                if name in self.parameters:
+                    del self.parameters[name]
 
     def _energy(self, q, t):
         return self.c_instance.energy(q, t=t)

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -7,6 +7,7 @@
 
 # Standard library
 from collections import OrderedDict
+import copy as pycopy
 import sys
 import warnings
 import uuid
@@ -254,26 +255,37 @@ class CPotentialBase(PotentialBase):
         super(CPotentialBase, self).__init__(
             parameters, origin=origin, R=R, units=units, ndim=ndim)
 
+        self._c_only = c_only
+
+        if Wrapper is None:
+            # magic to set the c_instance attribute based on the name of the class
+            wrapper_name = '{}Wrapper'.format(
+                self.__class__.__name__.replace('Potential', ''))
+            module = sys.modules[self.__module__]
+            Wrapper = getattr(module, wrapper_name)  # try to find wrapper in the same module
+        self._Wrapper = Wrapper
+
+        self._init_c_instance()
+
+    def _init_c_instance(self):
         # to support array parameters, but they get unraveled
-        arrs = [np.atleast_1d(v.value).ravel() for v in self.parameters.values()]
+        arrs = [np.atleast_1d(v.value).ravel()
+                for v in self.parameters.values()]
         if len(arrs) > 0:
             self.c_parameters = np.concatenate(arrs)
         else:
             self.c_parameters = np.array([])
 
-        if Wrapper is None:
-            # magic to set the c_instance attribute based on the name of the class
-            wrapper_name = '{}Wrapper'.format(self.__class__.__name__.replace('Potential', ''))
-
-            module = sys.modules[self.__module__]
-            Wrapper = getattr(module, wrapper_name)  # try to find wrapper in the same module
-
-        self.c_instance = Wrapper(self.G, self.c_parameters, q0=self.origin,
-                                  R=self.R)
+        if self.R is None:
+            self._R = np.eye(self.ndim)
+        else:
+            self._R = self.R
+        self.c_instance = self._Wrapper(self.G, self.c_parameters,
+                                        q0=self.origin, R=self._R)
 
         # remove C-only parameters from parameter dictionary
-        if c_only is not None:
-            for name in c_only:
+        if self._c_only is not None:
+            for name in self._c_only:
                 del self.parameters[name]
 
     def _energy(self, q, t):
@@ -367,3 +379,30 @@ class CPotentialBase(PotentialBase):
             new_pot[k] = pot
 
         return new_pot
+
+    def replace_units(self, units, copy=True):
+        """Change the unit system of this potential.
+
+        Parameters
+        ----------
+        units : `~gala.units.UnitSystem`
+            Set of non-reducable units that specify (at minimum) the
+        length, mass, time, and angle units.
+        copy : bool (optional)
+            If True, returns a copy, if False, changes this object.
+        """
+        if copy:
+            pot = pycopy.copy(self)
+        else:
+            pot = self
+
+        CPotentialBase.__init__(pot,
+                                parameters=self.parameters,
+                                origin=self.origin,
+                                R=self.R,
+                                ndim=self.ndim,
+                                units=units,
+                                Wrapper=self._Wrapper,
+                                c_only=self._c_only)
+
+        return pot

--- a/gala/potential/potential/tests/helpers.py
+++ b/gala/potential/potential/tests/helpers.py
@@ -1,8 +1,10 @@
 # Standard library
+import copy
 import pickle
 import time
 
 # Third-party
+import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.misc import derivative
@@ -67,10 +69,26 @@ class PotentialTestBase(object):
     def test_unitsystem(self):
         assert isinstance(self.potential.units, UnitSystem)
 
+        # check that we can replace the units as expected
+        usys = UnitSystem([u.pc, u.Gyr, u.degree, u.Msun])
+        pot = copy.deepcopy(self.potential)
+
+        pot2 = pot.replace_units(usys, copy=True)
+        assert pot2.units == usys
+        assert pot.units == self.potential.units
+
+        pot.replace_units(usys, copy=False)
+        assert pot.units == usys
+
+        # try by setting units attribute
+        pot = copy.deepcopy(self.potential)
+        pot.units = usys
+        assert pot.units == usys
+
     def test_energy(self):
         assert self.ndim == self.potential.ndim
 
-        for arr,  shp in zip(self.w0s, self._valu_return_shapes):
+        for arr, shp in zip(self.w0s, self._valu_return_shapes):
             v = self.potential.energy(arr[:self.ndim])
             assert v.shape == shp
 

--- a/gala/potential/potential/tests/test_core.py
+++ b/gala/potential/potential/tests/test_core.py
@@ -17,7 +17,7 @@ from matplotlib import cm
 from ..core import PotentialBase, CompositePotential
 from ....units import UnitSystem
 
-units = [u.kpc,u.Myr,u.Msun,u.radian]
+units = [u.kpc, u.Myr, u.Msun, u.radian]
 G = G.decompose(units)
 
 def test_new_simple():
@@ -42,9 +42,9 @@ def test_new_simple():
     p.energy(np.arange(0.5, 11.5, 0.5).reshape(1,-1))
     p.acceleration(np.arange(0.5, 11.5, 0.5).reshape(1,-1))
 
-# ----------------------------------------------------------------------------
 
 usys = UnitSystem(u.au, u.yr, u.Msun, u.radian)
+
 class MyPotential(PotentialBase):
     def __init__(self, m, x0, units=None):
         parameters = OrderedDict()
@@ -74,6 +74,7 @@ def test_repr():
     assert _repr.endswith("(AU,yr,solMass,rad)>")
     # assert p.__repr__() == "<MyPotential: m=1.00e+10, x0=0.00e+00 (AU,yr,solMass,rad)>"
 
+
 def test_plot():
     p = MyPotential(m=1, x0=[1.,3.,0.], units=usys)
     f = p.plot_contours(grid=(np.linspace(-10., 10., 100), 0., 0.),
@@ -92,6 +93,7 @@ def test_plot():
                               np.linspace(-10., 10., 100)),
                         cmap=cm.Blues, labels=["X", "Z"])
     # f.savefig(os.path.join(plot_path, "contour_xz.png"))
+
 
 def test_composite():
     p1 = MyPotential(m=1., x0=[1.,0.,0.], units=usys)
@@ -112,3 +114,23 @@ def test_composite():
     assert u.au in p.units
     assert u.yr in p.units
     assert u.Msun in p.units
+
+
+def test_replace_units():
+    usys1 = UnitSystem([u.kpc, u.Gyr, u.Msun, u.radian])
+    usys2 = UnitSystem([u.pc, u.Myr, u.Msun, u.degree])
+
+    p = MyPotential(m=1.E10*u.Msun, x0=0., units=usys1)
+    assert p.parameters['m'].unit == usys1['mass']
+
+    p2 = p.replace_units(usys2, copy=True)
+    assert p2.parameters['m'].unit == usys2['mass']
+    assert p.units == usys1
+    assert p2.units == usys2
+
+    p.replace_units(usys2, copy=False)
+    assert p.parameters['m'].unit == usys2['mass']
+    assert p.units == usys2
+
+    p.units = usys1
+    assert p.parameters['m'].unit == usys1['mass']

--- a/gala/potential/potential/tests/test_cpotential.py
+++ b/gala/potential/potential/tests/test_cpotential.py
@@ -1,0 +1,30 @@
+# Third party
+import astropy.units as u
+
+# This package
+from ..builtin import HernquistPotential
+from ....units import UnitSystem
+
+
+def test_replace_units():
+    usys1 = UnitSystem([u.kpc, u.Gyr, u.Msun, u.radian])
+    usys2 = UnitSystem([u.pc, u.Myr, u.Msun, u.degree])
+
+    p = HernquistPotential(m=1E10*u.Msun, c=1.*u.kpc, units=usys1)
+    assert p.parameters['m'].unit == usys1['mass']
+    assert p.parameters['c'].unit == usys1['length']
+
+    p2 = p.replace_units(usys2, copy=True)
+    assert p2.parameters['m'].unit == usys2['mass']
+    assert p2.parameters['c'].unit == usys2['length']
+    assert p.units == usys1
+    assert p2.units == usys2
+
+    p.replace_units(usys2, copy=False)
+    assert p.parameters['m'].unit == usys2['mass']
+    assert p.parameters['c'].unit == usys2['length']
+    assert p.units == usys2
+
+    p.units = usys1
+    assert p.parameters['m'].unit == usys1['mass']
+    assert p.parameters['c'].unit == usys1['length']


### PR DESCRIPTION
With this PR, potential objects now support replacing the unit system, either on a copy or on the object itself.

## TODO
* [x] add changelog entry
* [ ] add example to documentation
