### PR TITLE
Fix the bug in installation when gsl_version<1.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,10 +170,10 @@ if gsl_version is None:
         print('GSL not found: installing without GSL support. ' + _see_msg)
 
 elif gsl_version < ['1', '14']:
-    gsl_version = None
     print('Warning: GSL version ({0}) is below the minimum required version '
           '(1.16). Installing without GSL support. '
           .format('.'.join(gsl_version)) + _see_msg)
+    gsl_version = None
 
 else:
     print("GSL version {0} found: installing with GSL support"


### PR DESCRIPTION
If gsl_version=1.13 the existing code first assigns None to gsl_version then tries to to do print '.'.join(gsl_version), 
while it should be the other way around.
