### PR TITLE
Fix mockstream when nparticles=0 at end of sim

### DIFF
--- a/gala/dynamics/mockstream/df.pyx
+++ b/gala/dynamics/mockstream/df.pyx
@@ -278,6 +278,9 @@ cdef class StreaklineStreamDF(BaseStreamDF):
 
         j = 0
         for i in range(ntimes):
+            if prog_m[i] == 0:
+                continue
+
             self.get_rj_vj_R(&cpotential, G,
                              &prog_x[i, 0], &prog_v[i, 0], prog_m[i], prog_t[i],
                              &rj, &vj, R) # outputs
@@ -371,9 +374,12 @@ cdef class FardalStreamDF(BaseStreamDF):
 
         j = 0
         for i in range(ntimes):
+            if prog_m[i] == 0:
+                continue
+
             self.get_rj_vj_R(&cpotential, G,
                              &prog_x[i, 0], &prog_v[i, 0], prog_m[i], prog_t[i],
-                             &rj, &vj, R) # outputs
+                             &rj, &vj, R)  # outputs
 
             # Trailing tail
             if self._trail == 1:
@@ -467,6 +473,9 @@ cdef class LagrangeCloudStreamDF(BaseStreamDF):
 
         j = 0
         for i in range(ntimes):
+            if prog_m[i] == 0:
+                continue
+
             self.get_rj_vj_R(&cpotential, G,
                              &prog_x[i, 0], &prog_v[i, 0], prog_m[i], prog_t[i],
                              &rj, &vj, R) # outputs

--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -52,7 +52,7 @@ cdef extern from "dopri/dop853.h":
 
 cpdef mockstream_dop853(nbody, double[::1] time,
                         double[:, ::1] stream_w0, double[::1] stream_t1,
-                        int[::1] nstream,
+                        double tfinal, int[::1] nstream,
                         double atol=1E-10, double rtol=1E-10, int nmax=0):
     """
     Parameters
@@ -75,8 +75,8 @@ cpdef mockstream_dop853(nbody, double[::1] time,
     """
 
     cdef:
-        int i, j, k, n # indexing
-        unsigned ndim = 6 # TODO: hard-coded, but really must be 6D
+        int i, j, k, n  # indexing
+        unsigned ndim = 6  # TODO: hard-coded, but really must be 6D
 
         # For N-body support:
         void *args
@@ -84,8 +84,7 @@ cpdef mockstream_dop853(nbody, double[::1] time,
 
         # Time-stepping parameters:
         int ntimes = time.shape[0]
-        double dt0 = time[1] - time[0] # initial timestep
-        double t2 = time[ntimes-1] # final time
+        double dt0 = time[1] - time[0]  # initial timestep
 
         # whoa, so many dots
         CPotential cp = (<CPotentialWrapper>(nbody.H.potential.c_instance)).cpotential
@@ -96,7 +95,7 @@ cpdef mockstream_dop853(nbody, double[::1] time,
                                                      np.zeros(3), np.eye(3))
         CPotential null_p = null_wrapper.cpotential
 
-        int nbodies = nbody._c_w0.shape[0] # includes the progenitor
+        int nbodies = nbody._c_w0.shape[0]  # includes the progenitor
         double [:, ::1] nbody_w0 = nbody._c_w0
 
         int max_nstream = np.max(nstream)
@@ -135,7 +134,7 @@ cpdef mockstream_dop853(nbody, double[::1] time,
                 w_tmp[nbodies+j, k] = stream_w0[n+j, k]
 
         dop853_step(&cp, &cf, <FcnEqDiff> Fwrapper_direct_nbody,
-                    &w_tmp[0, 0], stream_t1[i], t2, dt0,
+                    &w_tmp[0, 0], stream_t1[i], tfinal, dt0,
                     ndim, nbodies+nstream[i], nbodies, args,
                     atol, rtol, nmax)
 

--- a/gala/dynamics/mockstream/mockstream_generator.py
+++ b/gala/dynamics/mockstream/mockstream_generator.py
@@ -217,11 +217,11 @@ class MockStreamGenerator:
         for t1, n in zip(unq_t1s, nstream):
             all_nstream[orbit_t == t1] = n
 
-        if output_every is None:  # store snapshots
+        if output_every is None:
             raw_nbody, raw_stream = mockstream_dop853(
-                nbody0, orbit_t[all_nstream != 0], w0, unq_t1s,
+                nbody0, orbit_t[all_nstream != 0], w0, unq_t1s, orbit_t[-1],
                 all_nstream[all_nstream != 0].astype('i4'))
-        else:
+        else:  # store snapshots
             if output_filename is None:
                 raise ValueError("If output_every is specified, you must also "
                                  "pass in a filename to store the snapshots in")


### PR DESCRIPTION
This fixes a bug that @abonaca reported elsewhere in which a mockstream would not end up at the correct position when `n_particles` had 0's near the end of the array.