### PR TITLE
Build wheels automatically with gh actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,11 +1,11 @@
 name: Wheels
 on:
-  # release:
-  #   types:
-  #     - published
-  push:
+  release:
+    types:
+      - published
+  pull_request:
     branches:
-      - wheeltest
+      - main
 
 env:
   CIBW_BUILD: "cp3?-*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,52 +13,51 @@ env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
 jobs:
-  # build_nix_wheels:
-  #   name: Build ${{ matrix.python-version }} wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-18.04, macos-latest]
+  build_nix_wheels:
+    name: Build ${{ matrix.python-version }} wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - uses: actions/setup-python@v2
-  #       name: Install Python
-  #       with:
-  #         # Note: cibuildwheel builds for many Python versions beyond this one
-  #         python-version: "3.7"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          # Note: cibuildwheel builds for many Python versions beyond this one
+          python-version: "3.7"
 
-  #     # Mac:
-  #     - name: Setup Mac
-  #       if: runner.os == 'macOS'
-  #       run: |
-  #         brew install gsl
+      # Mac:
+      - name: Setup Mac
+        if: runner.os == 'macOS'
+        run: |
+          brew install gsl
 
-  #     # Ubuntu:
-  #     - name: Setup Linux
-  #       if: runner.os == 'Linux'
-  #       run: |
-  #         sudo apt-get install gsl-bin libgsl0-dev
+      # Ubuntu:
+      - name: Setup Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install gsl-bin libgsl0-dev
 
-  #     - name: Build wheels
-  #       run: |
-  #         python -m pip install cibuildwheel==1.5.2
-  #         python -m cibuildwheel --output-dir wheelhouse
+      - name: Build wheels
+        run: |
+          python -m pip install cibuildwheel==1.5.2
+          python -m cibuildwheel --output-dir wheelhouse
 
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         path: ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
 
   build_win_wheels:
     name: Build ${{ matrix.python-version }} wheels on Windows
     runs-on: windows-latest
     strategy:
       matrix:
-        # python-version: [3.6, 3.7, 3.8]
-        python-version: [3.7]
+        python-version: [3.6, 3.7, 3.8]
       fail-fast: false
 
     steps:
@@ -77,29 +76,14 @@ jobs:
           conda install -c conda-forge -q gsl libpython
           gsl-config --version
 
-      # - name: Set environment variables on Windows
-      #   shell: bash -l {0}
-      #   run: |
-      #     # echo ::set-env name=INCLUDE::$CONDA_PREFIX\\Library\\include
-      #     # echo ::set-env name=LIB::$CONDA_PREFIX\\Library\\lib
-      #     # echo ::set-env name=LIBPATH::$CONDA_PREFIX\\Library\\lib
-      #     gsl-config --version
-
       - name: Build wheels
         shell: bash -l {0}
         run: |
           which gsl-config
           export GALA_GSL_VERSION=$(gsl-config --version)
-          # export GALA_GSL_PREFIX=$(gsl-config --prefix)
           export GALA_GSL_PREFIX="/c/Miniconda/envs/gala-wheels/Library/"
-          # pip install pep517
-          # python -m pep517.build -o wheelhouse .
-
-          pip install setuptools setuptools_scm wheel extension-helpers
-          conda install astropy # because there is no wheel for py38 on windows!
-          pip install -r requirements.txt
-          python setup.py build_ext
-          python setup.py bdist_wheel
+          pip install pep517
+          python -m pep517.build -o wheelhouse .
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,51 +1,105 @@
 name: Wheels
 on:
-  release:
-    types:
-      - published
+  # release:
+  #   types:
+  #     - published
   push:
     branches:
       - wheeltest
 
 env:
   CIBW_BUILD: "cp3?-*"
-  CIBW_SKIP: "*-win32 *-manylinux_i686"
+  CIBW_SKIP: "*-win32 *-manylinux_i686 cp35-*"
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
 jobs:
-  build_wheels:
-    name: Build ${{ matrix.python-version }} wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  # build_nix_wheels:
+  #   name: Build ${{ matrix.python-version }} wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-18.04, macos-latest]
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-python@v2
+  #       name: Install Python
+  #       with:
+  #         # Note: cibuildwheel builds for many Python versions beyond this one
+  #         python-version: "3.7"
+
+  #     # Mac:
+  #     - name: Setup Mac
+  #       if: runner.os == 'macOS'
+  #       run: |
+  #         brew install gsl
+
+  #     # Ubuntu:
+  #     - name: Setup Linux
+  #       if: runner.os == 'Linux'
+  #       run: |
+  #         sudo apt-get install gsl-bin libgsl0-dev
+
+  #     - name: Build wheels
+  #       run: |
+  #         python -m pip install cibuildwheel==1.5.2
+  #         python -m cibuildwheel --output-dir wheelhouse
+
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  build_win_wheels:
+    name: Build ${{ matrix.python-version }} wheels on Windows
+    runs-on: windows-latest
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8"]
+        # python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: true
-
+          fetch-depth: 0
       - uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          activate-environment: gala-wheels
 
       - name: Install dependencies
+        shell: bash -l {0}
         run: |
-          conda create -n gala-wheels python=${{ matrix.python-version }} -q -c conda-forge
-          conda activate gala-wheels
           conda install -c conda-forge -q gsl libpython
-          python -m pip install cibuildwheel==1.5.1
+          gsl-config --version
 
-      - name: Install Visual C++ for Python 3.7
-        if: runner.os == 'Windows'
-        run: |
-          choco install vcpython37 -f -y
+      # - name: Set environment variables on Windows
+      #   shell: bash -l {0}
+      #   run: |
+      #     # echo ::set-env name=INCLUDE::$CONDA_PREFIX\\Library\\include
+      #     # echo ::set-env name=LIB::$CONDA_PREFIX\\Library\\lib
+      #     # echo ::set-env name=LIBPATH::$CONDA_PREFIX\\Library\\lib
+      #     gsl-config --version
 
       - name: Build wheels
+        shell: bash -l {0}
         run: |
-          python -m cibuildwheel --output-dir wheelhouse
+          which gsl-config
+          export GALA_GSL_VERSION=$(gsl-config --version)
+          # export GALA_GSL_PREFIX=$(gsl-config --prefix)
+          export GALA_GSL_PREFIX="/c/Miniconda/envs/gala-wheels/Library/"
+          # pip install pep517
+          # python -m pep517.build -o wheelhouse .
+
+          pip install setuptools setuptools_scm wheel extension-helpers
+          conda install astropy # because there is no wheel for py38 on windows!
+          pip install -r requirements.txt
+          python setup.py build_ext
+          python setup.py bdist_wheel
 
       - uses: actions/upload-artifact@v2
         with:
@@ -57,39 +111,34 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: true
-
-      - uses: goanpeca/setup-miniconda@v1
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
         with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          conda create -n gala-wheels python=${{ matrix.python-version }} -q -c conda-forge
-          conda activate gala-wheels
-          conda install -c conda-forge -q gsl libpython
-          python -m pip install cibuildwheel==1.5.1
+          python-version: "3.7"
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: |
+          sudo apt-get install gsl-bin libgsl0-dev
+          pip install pep517
+          python -m pep517.build -s .
 
       - uses: actions/upload-artifact@v2
         with:
           path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
+  # upload_pypi:
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'release' && github.event.action == 'published'
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: artifact
+  #         path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+  #     - uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.pypi_password }}
+  #         # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -111,18 +111,18 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  # upload_pypi:
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   if: github.event_name == 'release' && github.event.action == 'published'
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: artifact
-  #         path: dist
+  upload_pypi:
+    needs: [build_nix_wheels, build_win_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
 
-  #     - uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.pypi_password }}
-  #         # To test: repository_url: https://test.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,4 +1,4 @@
-name: windows-tests
+name: Windows-tests
 
 on:
   push:

--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,8 @@ the `LICENSE <https://github.com/adrn/gala/blob/main/LICENSE>`_ file.
    :target: https://codecov.io/gh/adrn/gala
 .. |Build status| image:: http://img.shields.io/travis/adrn/gala/main.svg?style=flat
    :target: http://travis-ci.org/adrn/gala
-.. |Windows status| image:: https://github.com/adrn/gala/workflows/windows-tests/badge.svg?branch=main
-   :target: https://github.com/adrn/gala/workflows/windows-tests
+.. |Windows status| image:: https://github.com/adrn/gala/workflows/Windows-tests/badge.svg?branch=main
+   :target: https://github.com/adrn/gala/workflows/Windows-tests
 .. |License| image:: http://img.shields.io/badge/license-MIT-blue.svg?style=flat
    :target: https://github.com/adrn/gala/blob/main/LICENSE
 .. |PyPI| image:: https://badge.fury.io/py/astro-gala.svg

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,9 @@ install_requires =
     cython
     scipy
 python_requires = >=3.6
-setup_requires = setuptools_scm
+setup_requires =
+    setuptools_scm
+    extension-helpers
 
 [options.package_data]
 * = *.c

--- a/setup.py
+++ b/setup.py
@@ -96,19 +96,19 @@ else:
 
 # First, see if the user wants to install without GSL:
 nogsl = bool(int(os.environ.get('GALA_NOGSL', 0)))
+gsl_version = os.environ.get('GALA_GSL_VERSION', None)
+gsl_prefix = os.environ.get('GALA_GSL_PREFIX', None)
 
 # Auto-detect whether GSL is installed
-if not nogsl or nogsl is None: # GSL support enabled
+if (not nogsl or nogsl is None) and gsl_version is None: # GSL support enabled
     cmd = ['gsl-config', '--version']
     try:
-        gsl_version = check_output(cmd, env=env)
+        gsl_version = check_output(cmd, env=env).decode('utf-8')
     except (OSError, CalledProcessError):
         gsl_version = None
-    else:
-        gsl_version = gsl_version.decode('utf-8').strip().split('.')
 
-else:
-    gsl_version = None
+if gsl_version is not None:
+    gsl_version = gsl_version.strip().split('.')
 
 # If the hacky macros file already exists, read from that what to do.
 # This means people experimenting might need to run "git clean" to remove all
@@ -142,12 +142,15 @@ else:
     print("GSL version {0} found: installing with GSL support"
           .format('.'.join(gsl_version)))
 
-    # Now get the gsl install location
-    cmd = ['gsl-config', '--prefix']
-    try:
-        gsl_prefix = check_output(cmd, encoding='utf-8').strip()
-    except:
-        gsl_prefix = str(check_output(cmd)).strip()
+    if gsl_prefix is None:
+        # Now get the gsl install location
+        cmd = ['gsl-config', '--prefix']
+        try:
+            gsl_prefix = check_output(cmd, encoding='utf-8')
+        except:
+            gsl_prefix = str(check_output(cmd, shell=shell))
+
+    gsl_prefix = os.path.normpath(gsl_prefix.strip())
 
 print("-" * 79)
 


### PR DESCRIPTION
This builds mac, linux, and windows (!!) pip wheels for python 3.6, 3.7, 3.8. If a release is published, this should also upload them to pypi automatically.