### PR TITLE
Add compatibility with galpy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ New Features
 - Added a new ``.to_sympy()`` classmethod for the ``Potential`` classes to
   return a sympy expression and variables.
 
+- Added a method, ``.to_galpy_orbit()``, to convert Gala ``Orbit`` instances to
+  Galpy ``Orbit`` objects.
+
 Bug fixes
 ---------
 

--- a/gala/dynamics/core.py
+++ b/gala/dynamics/core.py
@@ -865,8 +865,14 @@ class PhaseSpacePosition(object):
         Parameters
         ----------
         ro : `astropy.units.Quantity` or `astropy.units.UnitBase`
-            Natural length unit, in
+            "Natural" length unit.
         vo : `astropy.units.Quantity` or `astropy.units.UnitBase`
+            "Natural" velocity unit.
+
+        Returns
+        -------
+        galpy_orbit : `galpy.orbit.Orbit`
+
         """
         import galpy
         from galpy.orbit import Orbit

--- a/gala/dynamics/tests/test_core.py
+++ b/gala/dynamics/tests/test_core.py
@@ -16,6 +16,14 @@ from ...potential import Hamiltonian, HernquistPotential
 from ...potential.frame import StaticFrame, ConstantRotatingFrame
 from ...units import galactic, solarsystem
 
+try:
+    import galpy
+    import galpy.orbit
+    import galpy.potential
+    HAS_GALPY = True
+except ImportError:
+    HAS_GALPY = False
+
 
 def test_initialize():
 
@@ -401,3 +409,19 @@ def test_io(tmpdir, obj):
     assert u.allclose(obj.xyz, obj2.xyz)
     assert u.allclose(obj.v_xyz, obj2.v_xyz)
     assert obj.frame == obj2.frame
+
+
+@pytest.mark.parametrize('obj', [
+    PhaseSpacePosition([1,2,3.]*u.kpc, [1,2,3.]*u.km/u.s),
+    PhaseSpacePosition([1,2,3.]*u.kpc, [1,2,3.]*u.km/u.s,
+                       StaticFrame(galactic)),
+    PhaseSpacePosition([1,2,3.]*u.kpc, [1,2,3.]*u.km/u.s,
+                       ConstantRotatingFrame([1.,0,0]*u.rad/u.Myr, galactic)),
+])
+@pytest.mark.skipif(not HAS_GALPY,
+                    reason="requires galpy to run this test")
+def test_to_galpy(obj):
+    o1 = obj.to_galpy_orbit()
+    o2 = obj.to_galpy_orbit(ro=8*u.kpc)
+    o3 = obj.to_galpy_orbit(vo=220*u.km/u.s)
+    o4 = obj.to_galpy_orbit(ro=8*u.kpc, vo=220*u.km/u.s)

--- a/gala/potential/potential/tests/test_against_galpy.py
+++ b/gala/potential/potential/tests/test_against_galpy.py
@@ -18,9 +18,9 @@ try:
     import galpy
     import galpy.orbit
     import galpy.potential
-    GALPY_INSTALLED = True
+    HAS_GALPY = True
 except ImportError:
-    GALPY_INSTALLED = False
+    HAS_GALPY = False
 
 # Set to arbitrary values for testing
 ro = 8.1 * u.kpc
@@ -48,7 +48,7 @@ def helper(gala_pot, galpy_pot):
                        -galpy_pot.zforce(R=Rs.to_value(ro), z=zs.to_value(ro)))
 
 
-@pytest.mark.skipif(not GALPY_INSTALLED,
+@pytest.mark.skipif(not HAS_GALPY,
                     reason="requires galpy to run this test")
 def test_kepler():
     from galpy.potential import KeplerPotential as BovyKeplerPotential
@@ -62,7 +62,7 @@ def test_kepler():
     helper(gala_pot, bovy_pot)
 
 
-@pytest.mark.skipif(not GALPY_INSTALLED,
+@pytest.mark.skipif(not HAS_GALPY,
                     reason="requires galpy to run this test")
 def test_miyamoto():
     from galpy.potential import MiyamotoNagaiPotential as BovyMiyamotoNagaiPotential
@@ -79,7 +79,7 @@ def test_miyamoto():
     helper(gala_pot, bovy_pot)
 
 
-@pytest.mark.skipif(not GALPY_INSTALLED,
+@pytest.mark.skipif(not HAS_GALPY,
                     reason="requires galpy to run this test")
 def test_nfw():
     from galpy.potential import NFWPotential as BovyNFWPotential
@@ -93,7 +93,7 @@ def test_nfw():
     helper(gala_pot, bovy_pot)
 
 
-@pytest.mark.skipif(not GALPY_INSTALLED or not GSL_ENABLED,
+@pytest.mark.skipif(not HAS_GALPY or not GSL_ENABLED,
                     reason="requires galpy and GSL to run this test")
 def test_powerlawcutoff():
     from galpy.potential import PowerSphericalPotentialwCutoff
@@ -112,7 +112,7 @@ def test_powerlawcutoff():
     helper(gala_pot, bovy_pot)
 
 
-@pytest.mark.skipif(not GALPY_INSTALLED or not GSL_ENABLED,
+@pytest.mark.skipif(not HAS_GALPY or not GSL_ENABLED,
                     reason="requires galpy and GSL to run this test")
 def test_mwpotential2014():
     from galpy.potential import (MWPotential2014,


### PR DESCRIPTION
This adds support for converting `Orbit` / `PhaseSpacePosition` to a galpy `Orbit` instance. 

- [x] Changelog entry
- [x] Tests