### PR TITLE
Remove python 3.6 from wheels build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CIBW_BUILD: "cp3?-*"
-  CIBW_SKIP: "*-win32 *-manylinux_i686 cp35-*"
+  CIBW_SKIP: "*-win32 *-manylinux_i686 cp35-* cp36-*"
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build wheels
         run: |
-          python -m pip install cibuildwheel==1.5.2
+          python -m pip install cibuildwheel==1.6.3
           python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8] # , 3.9  # TODO
+        python-version: [3.7, 3.8] # , 3.9  # TODO
       fail-fast: false
 
     steps:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -106,11 +106,11 @@ Python Dependencies
 This packages has the following dependencies (note that the version requirements
 below indicate the versions for which Gala is tested with and should work with):
 
-- `Python`_ >= 3.6
+- `Python`_ >= 3.7
 
-- `Numpy`_ >= 1.16
+- `Numpy`_ >= 1.18
 
-- `Cython <http://www.cython.org/>`_: >= 0.28
+- `Cython <http://www.cython.org/>`_: >= 0.29
 
 - `Astropy`_ >= 3
 


### PR DESCRIPTION
Remove python 3.6 from wheels build