### PR TITLE
great circle representation transformations without lon

### DIFF
--- a/gala/coordinates/greatcircle.py
+++ b/gala/coordinates/greatcircle.py
@@ -181,7 +181,8 @@ class GreatCircleICRSFrame(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Describe your changes

In the great-circle represent_as hack, it assumes the representation will be spherical. This is now checked.

### Checklist

* [ ] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [ ] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [ ] Is the milestone set?
