### PR TITLE
[Bug] representations not assumed to have attribute lon

### DIFF
--- a/gala/coordinates/gd1.py
+++ b/gala/coordinates/gd1.py
@@ -65,7 +65,8 @@ class GD1Koposov10(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 

--- a/gala/coordinates/jhelum.py
+++ b/gala/coordinates/jhelum.py
@@ -63,7 +63,8 @@ class JhelumBonaca19(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 

--- a/gala/coordinates/magellanic_stream.py
+++ b/gala/coordinates/magellanic_stream.py
@@ -65,7 +65,8 @@ class MagellanicStreamNidever08(BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = BaseCoordinateFrame.represent_as.__doc__
 

--- a/gala/coordinates/oph.py
+++ b/gala/coordinates/oph.py
@@ -65,7 +65,8 @@ class OphiuchusPriceWhelan16(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 

--- a/gala/coordinates/orphan.py
+++ b/gala/coordinates/orphan.py
@@ -69,7 +69,8 @@ class OrphanNewberg10(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 
@@ -150,7 +151,8 @@ class OrphanKoposov19(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 

--- a/gala/coordinates/pal13.py
+++ b/gala/coordinates/pal13.py
@@ -64,7 +64,8 @@ class Pal13Shipp20(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 

--- a/gala/coordinates/pal5.py
+++ b/gala/coordinates/pal5.py
@@ -64,7 +64,8 @@ class Pal5PriceWhelan18(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 

--- a/gala/coordinates/sgr.py
+++ b/gala/coordinates/sgr.py
@@ -64,7 +64,8 @@ class SagittariusLaw10(coord.BaseCoordinateFrame):
     # to have the longitude components wrap at the desired angle
     def represent_as(self, base, s='base', in_frame_units=False):
         r = super().represent_as(base, s=s, in_frame_units=in_frame_units)
-        r.lon.wrap_angle = self._default_wrap_angle
+        if hasattr(r, "lon"):
+            r.lon.wrap_angle = self._default_wrap_angle
         return r
     represent_as.__doc__ = coord.BaseCoordinateFrame.represent_as.__doc__
 


### PR DESCRIPTION
All the hardcoded coordinates were assumed to have spherical representations and therefore the attribute “lon”. This is now checked.