### PR TITLE
intersphinx xref physical types

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -3,4 +3,5 @@ dependencies:
   - gsl
   - pip
   - pip:
+    - astropy  @ git+https://github.com/astropy/astropy.git
     - -e .[docs]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,15 @@ import datetime
 from importlib import import_module
 import warnings
 
+try:
+    # THIRD PARTY
+    from sphinx_astropy.conf.v1 import *  # noqa: F401, F403
+except ImportError:
+    print(
+        "ERROR: documentation requires installing the sphinx-astropy package",
+    )
+    sys.exit(1)
+
 # Get configuration information from setup.cfg
 from configparser import ConfigParser
 conf = ConfigParser()
@@ -43,15 +52,15 @@ numpydoc_xref_param_type = True
 
 # Words not to cross-reference. Most likely, these are common words used in
 # parameter type descriptions that may be confused for classes of the same
-# name.
-numpydoc_xref_ignore = {
-    'type', 'optional', 'default', 'or', 'of', 'method', 'instance', "like",
-    "class", 'subclass', "keyword-only", "default", "thereof", "mixin",
-    # needed in subclassing numpy  # TODO! revisit
+# name. The base set comes from sphinx-astropy. We add more here.
+# TODO! check if there are any repeats here.
+numpydoc_xref_ignore.update({
+    "mixin",
+    # needed in subclassing numpy
     "Arguments", "Path",
     # TODO! not need to ignore.
     "flag", "bits",
-}
+})
 
 # Mappings to fully qualified paths (or correct ReST references) for the
 # aliases/shortcuts used when specifying the types of parameters.
@@ -86,6 +95,8 @@ numpydoc_xref_aliases = {
     "writable": ":term:`writable file-like object`",
     "readable": ":term:`readable file-like object`",
 }
+# add physical type aliases from sphinx-astropy
+numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)
 
 autosummary_generate = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ numpydoc_xref_ignore.update({
 # Numpy provides some defaults
 # https://github.com/numpy/numpydoc/blob/b352cd7635f2ea7748722f410a31f937d92545cc/numpydoc/xref.py#L62-L94
 # so we only need to define Astropy-specific x-refs
+# TODO use astropy intersphinx glossary references.
 numpydoc_xref_aliases = {
     # ulta-general
     "-like": ":term:`-like`",
@@ -95,7 +96,7 @@ numpydoc_xref_aliases = {
     "writable": ":term:`writable file-like object`",
     "readable": ":term:`readable file-like object`",
 }
-# add physical type aliases from sphinx-astropy
+# add physical type x-ref aliases from sphinx-astropy
 numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)
 
 autosummary_generate = True
@@ -116,15 +117,9 @@ rst_epilog = """
 """
 
 # intersphinx
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-    'matplotlib': ('https://matplotlib.org/', None),
-    'astropy': ('https://docs.astropy.org/en/stable/', None),
-    'h5py': ('https://docs.h5py.org/en/stable/', None),
+intersphinx_mapping.update({
     'sympy': ('https://docs.sympy.org/latest/', None)
-}
+})
 
 # Show / hide TODO blocks
 todo_include_todos = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,17 +68,14 @@ numpydoc_xref_ignore.update({
 # https://github.com/numpy/numpydoc/blob/b352cd7635f2ea7748722f410a31f937d92545cc/numpydoc/xref.py#L62-L94
 # so we only need to define Astropy-specific x-refs
 # TODO use astropy intersphinx glossary references.
-numpydoc_xref_aliases = {
+numpydoc_xref_aliases.update({
     # ulta-general
     "-like": ":term:`-like`",
     # python & adjacent
     "file-like": ":term:`python:file-like object`",
-    "file": ":term:`python:file object`",
-    "iterator": ":term:`python:iterator`",
     "path-like": ":term:`python:path-like object`",
     "module": ":term:`python:module`",
     "buffer-like": ":term:buffer-like",
-    "function": ":term:`python:function`",
     # for matplotlib
     "color": ":term:`color`",
     # for numpy
@@ -95,7 +92,7 @@ numpydoc_xref_aliases = {
     "Representation": ":class:`~astropy.coordinates.BaseRepresentation`",
     "writable": ":term:`writable file-like object`",
     "readable": ":term:`readable file-like object`",
-}
+})
 # add physical type x-ref aliases from sphinx-astropy
 numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,8 +69,6 @@ numpydoc_xref_ignore.update({
 # so we only need to define Astropy-specific x-refs
 # TODO use astropy intersphinx glossary references.
 numpydoc_xref_aliases.update({
-    # ulta-general
-    "-like": ":term:`-like`",
     # python & adjacent
     "file-like": ":term:`python:file-like object`",
     "path-like": ":term:`python:path-like object`",
@@ -81,20 +79,13 @@ numpydoc_xref_aliases.update({
     # for numpy
     "ints": ":class:`python:int`",
     # for astropy
-    "unit-like": ":term:`unit-like`",
-    "quantity-like": ":term:`quantity-like`",
-    "angle-like": ":term:`angle-like`",
-    "table-like": ":term:`table-like`",
-    "time-like": ":term:`time-like`",
-    "frame-like": ":term:`frame-like`",
-    "coordinate-like": ":term:`coordinate-like`",
     "number": ":term:`number`",
     "Representation": ":class:`~astropy.coordinates.BaseRepresentation`",
     "writable": ":term:`writable file-like object`",
     "readable": ":term:`readable file-like object`",
 })
-# add physical type x-ref aliases from sphinx-astropy
-numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)
+# add all Astropy x-ref aliases from sphinx-astropy
+numpydoc_xref_aliases.update(numpydoc_xref_astropy_aliases)
 
 autosummary_generate = True
 

--- a/gala/coordinates/gd1.py
+++ b/gala/coordinates/gd1.py
@@ -29,16 +29,16 @@ class GD1Koposov10(coord.BaseCoordinateFrame):
         The longitude-like angle corresponding to GD-1's orbit.
     phi2 : angle_like, optional, must be keyword
         The latitude-like angle corresponding to GD-1's orbit.
-    distance : :class:`~astropy.units.Quantity`, optional, must be keyword
+    distance : :class:`~astropy.units.Quantity` ['length'], optional, must be keyword
         The Distance for this object along the line-of-sight.
 
-    pm_phi1_cosphi2 : :class:`~astropy.units.Quantity`, optional, must be keyword
+    pm_phi1_cosphi2 : :class:`~astropy.units.Quantity` ['angular speed'], optional, must be keyword
         The proper motion in the longitude-like direction corresponding to
         the GD-1 stream's orbit.
-    pm_phi2 : :class:`~astropy.units.Quantity`, optional, must be keyword
+    pm_phi2 : :class:`~astropy.units.Quantity` ['angular speed'], optional, must be keyword
         The proper motion in the latitude-like direction perpendicular to the
         GD-1 stream's orbit.
-    radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
+    radial_velocity : :class:`~astropy.units.Quantity` ['speed'], optional, must be keyword
         The Distance for this object along the line-of-sight.
 
     """

--- a/gala/coordinates/greatcircle.py
+++ b/gala/coordinates/greatcircle.py
@@ -108,7 +108,7 @@ def greatcircle_transforms(self_transform=False):
 
 
 _components = """
-phi1 : `~astropy.units.Quantity`
+phi1 : `~astropy.units.Quantity` ['angle']
     Longitude component.
 phi2 : `~astropy.units.Quantity`
     Latitude component.

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ docs =
     sphinxcontrib-bibtex
     sphinx-astrorefs
     sphinx_automodapi
-    sphinx_astropy
+    sphinx_astropy   @ git+https://github.com/nstarman/sphinx-astropy.git@intersphinx-xref-physical-types
     rtds_action
     cmastro
     requests


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Describe your changes

Ahh. This solution will require astropy v4.3+ for the physical types. ~I'll get back to this later, when I update my PR to sphinx-astropy.~
~Done. Now need to get RTD to compile with astropy v4.3.   hmm.... any suggestions?~
~without building RTD in astropy v4.3+, the links are not live. https://gala-astro--223.org.readthedocs.build/en/223/~

Current state : Gala doesn't work with astropy dev #222

### Checklist

* [ ] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [ ] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [ ] Is the milestone set?

Requires: #224 