### PR TITLE
Fix UnitSystem to work with Astropy v4.3

### DIFF
--- a/gala/dynamics/tests/test_actionangle_staeckel.py
+++ b/gala/dynamics/tests/test_actionangle_staeckel.py
@@ -50,6 +50,7 @@ def test_staeckel_fudge_delta():
     paired_potentials.append((potential, galpy_potential))
 
     # TEST:
+    # TODO: remove the randomness here
     N = 1024
     rnd = np.random.default_rng(42)
     w = PhaseSpacePosition(pos=rnd.uniform(-10, 10, size=(3, N)) * u.kpc,
@@ -62,5 +63,4 @@ def test_staeckel_fudge_delta():
         galpy_deltas = estimateDeltaStaeckel(galpy_p, R, z,
                                              no_median=True)
         gala_deltas = get_staeckel_fudge_delta(p, w).value
-        print(p, np.allclose(gala_deltas, galpy_deltas))
-        assert np.allclose(gala_deltas, galpy_deltas, atol=1e-6)
+        assert np.allclose(gala_deltas, galpy_deltas, atol=1e-5, rtol=1e-3)

--- a/gala/tests/test_units.py
+++ b/gala/tests/test_units.py
@@ -2,6 +2,9 @@
     Test the unit system.
 """
 
+# Standard library
+import pickle
+
 # Third party
 import astropy.units as u
 from astropy.constants import G, c
@@ -72,3 +75,13 @@ def test_compare():
 
     assert usys1 != usys3
     assert usys3 != usys1
+
+
+def test_pickle(tmpdir):
+    usys = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun)
+
+    with open(tmpdir / 'test.pkl', 'wb') as f:
+        pickle.dump(usys, f)
+
+    with open(tmpdir / 'test.pkl', 'rb') as f:
+        usys2 = pickle.load(f)

--- a/gala/units.py
+++ b/gala/units.py
@@ -27,8 +27,8 @@ else:
 class UnitSystem:
     _required_physical_types = [
         get_physical_type('length'),
-        get_physical_type('mass'),
         get_physical_type('time'),
+        get_physical_type('mass'),
         get_physical_type('angle')
     ]
 
@@ -104,6 +104,10 @@ class UnitSystem:
 
     def __getitem__(self, key):
         key = get_physical_type(key)
+
+        # TODO: remove this when astropy 4.3 is min version
+        if key == 'velocity':
+            key = 'speed'
 
         if key in self._registry:
             return self._registry[key]

--- a/gala/units.py
+++ b/gala/units.py
@@ -103,11 +103,11 @@ class UnitSystem:
             self._core_units.append(self._registry[phys_type])
 
     def __getitem__(self, key):
-        key = get_physical_type(key)
-
         # TODO: remove this when astropy 4.3 is min version
         if key == 'velocity':
             key = 'speed'
+
+        key = get_physical_type(key)
 
         if key in self._registry:
             return self._registry[key]

--- a/gala/units.py
+++ b/gala/units.py
@@ -10,6 +10,7 @@ _greek_letters = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta",
                   "omega"]
 
 
+# TODO: this can be removed when gala requires astropy >= 4.3
 import astropy
 ASTROPY_GTR_43 = (
     version.parse(version.parse(astropy.__version__).base_version) >=

--- a/gala/units.py
+++ b/gala/units.py
@@ -9,53 +9,61 @@ _greek_letters = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta",
                   "omega"]
 
 
-class UnitSystem(object):
-    """
-    Represents a system of units. At minimum, this consists of a set of
-    length, time, mass, and angle units, but may also contain preferred
-    representations for composite units. For example, the base unit system
-    could be ``{kpc, Myr, Msun, radian}``, but you can also specify a preferred
-    speed, such as ``km/s``.
-
-    This class functions like a dictionary with keys set by physical types.
-    If a unit for a particular physical type is not specified on creation,
-    a composite unit will be created with the base units. See Examples below
-    for some demonstrations.
-
-    Parameters
-    ----------
-    *units
-        The units that define the unit system. At minimum, this must
-        contain length, time, mass, and angle units.
-
-    Examples
-    --------
-    If only base units are specified, any physical type specified as a key
-    to this object will be composed out of the base units::
-
-        >>> usys = UnitSystem(u.m, u.s, u.kg, u.radian)
-        >>> usys['energy']
-        Unit("kg m2 / s2")
-
-    However, custom representations for composite units can also be specified
-    when initializing::
-
-        >>> usys = UnitSystem(u.m, u.s, u.kg, u.radian, u.erg)
-        >>> usys['energy']
-        Unit("erg")
-
-    This is useful for Galactic dynamics where lengths and times are usually
-    given in terms of ``kpc`` and ``Myr``, but speeds are given in ``km/s``::
-
-        >>> usys = UnitSystem(u.kpc, u.Myr, u.Msun, u.radian, u.km/u.s)
-        >>> usys['speed']
-        Unit("km / s")
-
-    """
+class UnitSystem:
+    _required_physical_types = [
+        u.get_physical_type('length'),
+        u.get_physical_type('mass'),
+        u.get_physical_type('time'),
+        u.get_physical_type('angle')
+    ]
 
     def __init__(self, units, *args):
+        """
+        Represents a system of units.
 
-        self._required_physical_types = ['length', 'time', 'mass', 'angle']
+        At minimum, this consists of a set of length, time, mass, and angle
+        units, but may also contain preferred representations for composite
+        units. For example, the base unit system could be ``{kpc, Myr, Msun,
+        radian}``, but you can also specify a preferred velocity unit, such as
+        ``km/s``.
+
+        This class behaves like a dictionary with keys set by physical types. If
+        a unit for a particular physical type is not specified on creation, a
+        composite unit will be created with the base units. See the examples
+        below for some demonstrations.
+
+        Parameters
+        ----------
+        *units
+            The units that define the unit system. At minimum, this must
+            contain length, time, mass, and angle units.
+
+        Examples
+        --------
+        If only base units are specified, any physical type specified as a key
+        to this object will be composed out of the base units::
+
+            >>> usys = UnitSystem(u.m, u.s, u.kg, u.radian)
+            >>> usys['energy']
+            Unit("kg m2 / s2")
+
+        However, custom representations for composite units can also be
+        specified when initializing::
+
+            >>> usys = UnitSystem(u.m, u.s, u.kg, u.radian, u.erg)
+            >>> usys['energy']
+            Unit("erg")
+
+        This is useful for Galactic dynamics where lengths and times are usually
+        given in terms of ``kpc`` and ``Myr``, but velocities are given in
+        ``km/s``::
+
+            >>> usys = UnitSystem(u.kpc, u.Myr, u.Msun, u.radian, u.km/u.s)
+            >>> usys['velocity']
+            Unit("km / s")
+
+        """
+
         self._core_units = []
 
         if isinstance(units, UnitSystem):
@@ -80,6 +88,7 @@ class UnitSystem(object):
             self._core_units.append(self._registry[phys_type])
 
     def __getitem__(self, key):
+        key = u.get_physical_type(key)
 
         if key in self._registry:
             return self._registry[key]
@@ -193,11 +202,13 @@ class UnitSystem(object):
 
 
 class DimensionlessUnitSystem(UnitSystem):
+    _required_physical_types = []
 
     def __init__(self):
         self._core_units = [u.one]
-        self._registry = dict()
-        self._registry['dimensionless'] = u.one
+        self._registry = {
+            'dimensionless': u.one
+        }
 
     def __getitem__(self, key):
         return u.one

--- a/gala/units.py
+++ b/gala/units.py
@@ -2,6 +2,7 @@
 import astropy.units as u
 from astropy.units.physical import _physical_unit_mapping
 import astropy.constants as const
+from packaging import version
 
 _greek_letters = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta",
                   "theta", "iota", "kappa", "lambda", "mu", "nu", "xi", "pi",
@@ -9,12 +10,23 @@ _greek_letters = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta",
                   "omega"]
 
 
+import astropy
+ASTROPY_GTR_43 = (
+    version.parse(version.parse(astropy.__version__).base_version) >=
+    version.parse('4.3')
+)
+if ASTROPY_GTR_43:
+    get_physical_type = u.get_physical_type
+else:
+    get_physical_type = lambda x: str(x)  # noqa
+
+
 class UnitSystem:
     _required_physical_types = [
-        u.get_physical_type('length'),
-        u.get_physical_type('mass'),
-        u.get_physical_type('time'),
-        u.get_physical_type('angle')
+        get_physical_type('length'),
+        get_physical_type('mass'),
+        get_physical_type('time'),
+        get_physical_type('angle')
     ]
 
     def __init__(self, units, *args):
@@ -88,7 +100,7 @@ class UnitSystem:
             self._core_units.append(self._registry[phys_type])
 
     def __getitem__(self, key):
-        key = u.get_physical_type(key)
+        key = get_physical_type(key)
 
         if key in self._registry:
             return self._registry[key]

--- a/gala/units.py
+++ b/gala/units.py
@@ -1,3 +1,5 @@
+__all__ = ['UnitSystem', 'galactic', 'dimensionless', 'solarsystem']
+
 # Third-party
 import astropy.units as u
 from astropy.units.physical import _physical_unit_mapping

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     pyyaml
     cython>=0.29
     scipy>=1.2
+    packaging
 python_requires = >=3.7
 setup_requires =
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ zip_safe = False
 packages = find:
 install_requires =
     numpy>=1.17
-    astropy>=4.0
+    astropy>=4.2
     pyyaml
     cython>=0.29
     scipy>=1.2

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,8 @@ deps =
     astropylts: astropy==4.0.*
 
     devdeps: :NIGHTLY:numpy
-    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    # devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/adrn/astropy.git@units/pickle-phystype
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
This adds support for the new `PhysicalType` objects in Astropy v4.3.

Fixes #222 