### PR TITLE
Changed the _max_helper() function to use parabola not interpolation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ New Features
 - Added a ``Orbit.animate()`` method to make ``matplotlib`` animations of
   orbits.
 
+- Modified ``Orbit._max_helper()`` to use a parabola instead of interpolation
 
 Bug fixes
 ---------

--- a/gala/dynamics/tests/test_orbit.py
+++ b/gala/dynamics/tests/test_orbit.py
@@ -390,10 +390,10 @@ def test_apocenter_pericenter_period():
     T = w.estimate_period()  # noqa
 
     dapo = np.std(apos) / np.mean(apos)
-    assert (dapo > 0) and np.allclose(dapo, 0., atol=1E-5)
+    assert (dapo > 0) and np.allclose(dapo, 0., atol=1E-4)
 
     dper = np.std(pers) / np.mean(pers)
-    assert (dper > 0) and np.allclose(dper, 0., atol=1E-5)
+    assert (dper > 0) and np.allclose(dper, 0., atol=1E-4)
 
     # Now try for expected behavior when multiple orbits are integrated:
     w0 = PhaseSpacePosition(pos=([[1, 0, 0.], [1.1, 0, 0]]*u.au).T,


### PR DESCRIPTION
Fixes #239

### Describe your changes

As @adrn stated in issue #239, this method is faster than the existing interpolation approach, however, the standard deviations of the results it produces, as seen in `test_apocenter_pericenter_period()` is greater than that of the interpolation method.

Note: No new tests were added as there already exist tests for `apocenter()` and `pericenter()`, which use this `_max_helper()` function, instead these existing tests were modified to accommodate for the slightly greater standard deviations of this method.

### Checklist

* [x] Did you add tests?
* [x] Did you add documentation for your changes?
* [x] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?
