### PR TITLE
Fixes a bug in the Python-only LeapfrogIntegrator for backwards-integrated orbits in non-conservative systems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,10 @@ Bug fixes
 - Fixed a bug with ``DirectNBody`` with composite potentials where only the
   first potential component would move as a body / particle.
 
+- Fixed a bug with the Python implementation of Leapfrog integration
+  ``LeapfrogIntegrator`` that led to incorrect orbits for non-conservative
+  systems that were integrated backwards (i.e. with ``dt<<0``).
+
 API changes
 -----------
 

--- a/gala/integrate/pyintegrators/leapfrog.py
+++ b/gala/integrate/pyintegrators/leapfrog.py
@@ -137,17 +137,11 @@ class LeapfrogIntegrator(Integrator):
         # generate the array of times
         times = parse_time_specification(self._func_units, **time_spec)
         n_steps = len(times) - 1
-        _dt = times[1] - times[0]
+        dt = times[1] - times[0]
 
         w0_obj, w0, ws = self._prepare_ws(w0, mmap, n_steps)
         x0 = w0[:self.ndim]
         v0 = w0[self.ndim:]
-
-        if _dt < 0.:
-            v0 *= -1.
-            dt = np.abs(_dt)
-        else:
-            dt = _dt
 
         # prime the integrator so velocity is offset from coordinate by a
         #   half timestep
@@ -161,8 +155,5 @@ class LeapfrogIntegrator(Integrator):
             ws[:self.ndim, ii, :] = x_i
             ws[self.ndim:, ii, :] = v_i
             x_im1, v_im1_2 = x_i, v_ip1_2
-
-        if _dt < 0:
-            ws[self.ndim:, ...] *= -1.
 
         return self._handle_output(w0_obj, times, ws)

--- a/gala/integrate/pyintegrators/leapfrog.py
+++ b/gala/integrate/pyintegrators/leapfrog.py
@@ -141,7 +141,6 @@ class LeapfrogIntegrator(Integrator):
 
         w0_obj, w0, ws = self._prepare_ws(w0, mmap, n_steps)
         x0 = w0[:self.ndim]
-        v0 = w0[self.ndim:]
 
         # prime the integrator so velocity is offset from coordinate by a
         #   half timestep

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -25,11 +25,17 @@ func_list = [
     dop853_integrate_hamiltonian,
     ruth4_integrate_hamiltonian,
 ]
-_list = zip(integrator_list, func_list)
+
+_list = []
+for dt in [2, -2]:
+    _list.extend([(x, y, dt) for x, y in zip(integrator_list, func_list)])
 
 
-@pytest.mark.parametrize(("Integrator", "integrate_func"), _list)
-def test_compare_to_py(Integrator, integrate_func):
+@pytest.mark.parametrize(
+    ["Integrator", "integrate_func", "dt"],
+    _list
+)
+def test_compare_to_py(Integrator, integrate_func, dt):
     p = HernquistPotential(m=1e11, c=0.5, units=galactic)
     H = Hamiltonian(potential=p)
 
@@ -47,7 +53,6 @@ def test_compare_to_py(Integrator, integrate_func):
     py_w0 = np.ascontiguousarray(cy_w0.T)
 
     n_steps = 1024
-    dt = 2.0
     t = np.linspace(0, dt * n_steps, n_steps + 1)
 
     cy_t, cy_w = integrate_func(H, cy_w0, t)
@@ -67,7 +72,10 @@ def test_compare_to_py(Integrator, integrate_func):
 # TODO: move this to only run if a flag like --remote-data is passed, like
 # --speed-scaling or something?
 @pytest.mark.skipif(True, reason="Slow test - mainly for plotting locally")
-@pytest.mark.parametrize(("Integrator", "integrate_func"), _list)
+@pytest.mark.parametrize(
+    ["Integrator", "integrate_func"],
+    zip(integrator_list, func_list)
+)
 def test_scaling(tmpdir, Integrator, integrate_func):
     p = HernquistPotential(m=1e11, c=0.5, units=galactic)
 


### PR DESCRIPTION
As reported by @ekta1224

### Checklist

* [ ] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [ ] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [ ] Is the milestone set?
