### PR TITLE
Make it so `autolim=True` doesn't set axis limits too small

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,10 @@ Bug fixes
 - Enabled pickling ``Frame`` instances and therefore now ``Hamiltonian``
   instances.
 
+- Fixed a bug with ``autolim=True`` during Orbit plotting where the axes limits
+  were only dependent on the most recent Orbit rather than all that were present
+  on the axis
+
 API changes
 -----------
 

--- a/gala/dynamics/plot.py
+++ b/gala/dynamics/plot.py
@@ -124,6 +124,14 @@ def plot_projections(x, relative_to=None, autolim=True, axes=None,
                 axes[k].set_ylabel(labels[j])
 
             if autolim:
+                # ensure new limits only ever expand current axis limits
+                xlims = axes[k].get_xlim()
+                ylims = axes[k].get_ylim()
+                lims[i] = (min(lims[i][0], xlims[0]),
+                           max(lims[i][1], xlims[1]))
+                lims[j] = (min(lims[j][0], ylims[0]),
+                           max(lims[j][1], ylims[1]))
+
                 axes[k].set_xlim(lims[i])
                 axes[k].set_ylim(lims[j])
 


### PR DESCRIPTION
### Describe your changes
Added a check of the current axis limits when plotting Orbits with `autolim=True` to prevent Gala from making the axis limits too small to see everything already plotted.

### Checklist for contributor:

* [x] Did you add tests?
* [x] Did you add documentation for your changes?
* [x] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)

### Checklist for maintainers:
* [x] Are the CI tests passing?
* [x] Is the milestone set?
