### PR TITLE
Add option to not store all phase-space positions at all timesteps 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New Features
 - The ``Orbit.estimate_period()`` method now returns period estimates in all
   phase-space components instead of just the radial period.
 
+- Added a ``store_all`` flag to the integrators to control whether to save
+  phase-space information for all timesteps or only the final timestep.
+
 Bug fixes
 ---------
 

--- a/gala/integrate/core.py
+++ b/gala/integrate/core.py
@@ -4,29 +4,38 @@
 import numpy as np
 
 # This project
-from ..units import UnitSystem, DimensionlessUnitSystem
+from gala.units import UnitSystem, DimensionlessUnitSystem
 
 __all__ = ["Integrator"]
 
 
 class Integrator(object):
-
-    def __init__(self, func, func_args=(), func_units=None, progress=False):
-        if not hasattr(func, '__call__'):
-            raise ValueError("func must be a callable object, e.g., "
-                             "a function.")
+    def __init__(
+        self,
+        func,
+        func_args=(),
+        func_units=None,
+        progress=False,
+        store_all=True,
+    ):
+        if not hasattr(func, "__call__"):
+            raise ValueError(
+                "func must be a callable object, e.g., a function."
+            )
 
         self.F = func
         self._func_args = func_args
 
-        if func_units is not None and not isinstance(func_units,
-                                                     DimensionlessUnitSystem):
+        if func_units is not None and not isinstance(
+            func_units, DimensionlessUnitSystem
+        ):
             func_units = UnitSystem(func_units)
         else:
             func_units = DimensionlessUnitSystem()
         self._func_units = func_units
 
         self.progress = bool(progress)
+        self.store_all = store_all
 
     def _get_range_func(self):
         if self.progress:
@@ -34,63 +43,72 @@ class Integrator(object):
                 from tqdm import trange
                 return trange
             except ImportError:
-                raise ImportError("tqdm must be installed to use progress=True "
-                                  "when running {}"
-                                  .format(self.__class__.__name__))
+                raise ImportError(
+                    "tqdm must be installed to use progress=True when running "
+                    f"{self.__class__.__name__}"
+                )
 
         return range
 
     def _prepare_ws(self, w0, mmap, n_steps):
         """
-        Decide how to make the return array. If mmap is False, this returns a
-        full array of zeros, but with the correct shape as the output. If mmap
-        is True, return a pointer to a memory-mapped array. The latter is
-        particularly useful for integrating a large number of orbits or
-        integrating a large number of time steps.
+        Decide how to make the return array. If ``mmap`` is False, this returns a full
+        array of zeros, but with the correct shape as the output. If ``mmap`` is True,
+        return a pointer to a memory-mapped array. The latter is particularly useful for
+        integrating a large number of orbits or integrating a large number of time
+        steps.
         """
         from ..dynamics import PhaseSpacePosition
+
         if not isinstance(w0, PhaseSpacePosition):
             w0 = PhaseSpacePosition.from_w(w0)
 
         arr_w0 = w0.w(self._func_units)
 
         self.ndim, self.norbits = arr_w0.shape
-        self.ndim = self.ndim//2
+        self.ndim = self.ndim // 2
 
-        return_shape = (2*self.ndim, n_steps+1, self.norbits)
+        if self.store_all:
+            return_shape = (2 * self.ndim, n_steps + 1, self.norbits)
+        else:
+            return_shape = (2 * self.ndim, self.norbits)
+
         if mmap is None:
             # create the return arrays
             ws = np.zeros(return_shape, dtype=float)
 
         else:
             if mmap.shape != return_shape:
-                raise ValueError("Shape of memory-mapped array doesn't match "
-                                 "expected shape of return array ({} vs {})"
-                                 .format(mmap.shape, return_shape))
+                raise ValueError(
+                    "Shape of memory-mapped array doesn't match expected shape of "
+                    f"return array ({mmap.shape} vs {return_shape})"
+                )
 
             if not mmap.flags.writeable:
-                raise TypeError("Memory-mapped array must be a writable mode, "
-                                " not '{}'".format(mmap.mode))
+                raise TypeError(
+                    f"Memory-mapped array must be a writable mode, not '{mmap.mode}'"
+                )
 
             ws = mmap
 
         return w0, arr_w0, ws
 
     def _handle_output(self, w0, t, w):
-        """
-        """
+        """ """
         if w.shape[-1] == 1:
             w = w[..., 0]
 
-        pos_unit = self._func_units['length']
-        t_unit = self._func_units['time']
+        pos_unit = self._func_units["length"]
+        t_unit = self._func_units["time"]
         vel_unit = pos_unit / t_unit
 
         from ..dynamics import Orbit
-        orbit = Orbit(pos=w[:self.ndim]*pos_unit,
-                      vel=w[self.ndim:]*vel_unit,
-                      t=t*t_unit)  # HACK: BADDDD
 
+        orbit = Orbit(
+            pos=w[:self.ndim] * pos_unit,
+            vel=w[self.ndim:] * vel_unit,
+            t=t * t_unit,
+        )
         return orbit
 
     def run(self):
@@ -108,7 +126,7 @@ class Integrator(object):
                 A fixed timestep dt and a number of steps to run for.
             dt, t1, t2 : (numeric, numeric, numeric)
                 A fixed timestep dt, an initial time, and a final time.
-            t : array_like
+            t : array-like
                 An array of times to solve on.
 
         Parameters

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -182,7 +182,7 @@ cdef dop853_helper_save_all(CPotential *cp, CFrameType *cf, FcnEqDiff F,
     return np.asarray(all_w)
 
 cpdef dop853_integrate_hamiltonian(hamiltonian, double[:, ::1] w0, double[::1] t,
-                                   double atol=1E-10, double rtol=1E-10, int nmax=0, progress=False, int store_all=True):
+                                   double atol=1E-10, double rtol=1E-10, int nmax=0, progress=False, int store_all=1):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -52,7 +52,8 @@ cdef void c_leapfrog_step(CPotential *p, int half_ndim, double t, double dt,
         v_jm1[k] = v_jm1_2[k] - grad[k] * dt/2.
         v_jm1_2[k] = v_jm1_2[k] - grad[k] * dt
 
-cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1] t):
+cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1] t,
+                                     int store_all):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -63,9 +64,10 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
         raise TypeError("Input Hamiltonian object does not support C-level access.")
 
     if not isinstance(hamiltonian.frame, StaticFrame):
-        raise TypeError("Leapfrog integration is currently only supported "
-                        "for StaticFrame, not {}."
-                        .format(hamiltonian.frame.__class__.__name__))
+        raise TypeError(
+            "Leapfrog integration is currently only supported for StaticFrame, "
+            f"not {hamiltonian.frame.__class__.__name__}"
+        )
 
     cdef:
         # temporary scalars
@@ -82,30 +84,43 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
         double[:, ::1] v_jm1_2 = np.zeros((n, half_ndim))
 
         # return arrays
-        double[:, :, ::1] all_w = np.zeros((ntimes, n, ndim))
+        double[:, :, ::1] all_w
+        double[:, ::1] tmp_w = np.zeros((n, ndim))
 
         # whoa, so many dots
         CPotential cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
-    # save initial conditions
-    all_w[0, :, :] = w0.copy()
+    if store_all:
+        all_w = np.zeros((ntimes, n, ndim))
+
+        # save initial conditions
+        all_w[0, :, :] = w0.copy()
+
+    tmp_w = w0.copy()
 
     with nogil:
         # first initialize the velocities so they are evolved by a
         #   half step relative to the positions
         for i in range(n):
             c_init_velocity(&cp, half_ndim, t[0], dt,
-                            &all_w[0, i, 0], &all_w[0, i, half_ndim], &v_jm1_2[i, 0], &grad[0])
+                            &tmp_w[i, 0], &tmp_w[i, half_ndim],
+                            &v_jm1_2[i, 0], &grad[0])
 
         for j in range(1, ntimes, 1):
             for i in range(n):
                 for k in range(half_ndim):
-                    all_w[j, i, k] = all_w[j-1, i, k]
-
-                for k in range(half_ndim):
                     grad[k] = 0.
 
                 c_leapfrog_step(&cp, half_ndim, t[j], dt,
-                                &all_w[j, i, 0], &all_w[j, i, half_ndim], &v_jm1_2[i, 0], &grad[0])
+                                &tmp_w[i, 0], &tmp_w[i, half_ndim],
+                                &v_jm1_2[i, 0],
+                                &grad[0])
 
-    return np.asarray(t), np.asarray(all_w)
+                if store_all:
+                    for k in range(half_ndim):
+                        all_w[j, i, k] = tmp_w[i, k]
+
+    if store_all:
+        return np.asarray(t), np.asarray(all_w)
+    else:
+        return np.asarray(t[-1:]), np.asarray(tmp_w)

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -53,7 +53,7 @@ cdef void c_leapfrog_step(CPotential *p, int half_ndim, double t, double dt,
         v_jm1_2[k] = v_jm1_2[k] - grad[k] * dt
 
 cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1] t,
-                                     int store_all):
+                                     int store_all=1):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -117,7 +117,7 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
                                 &grad[0])
 
                 if store_all:
-                    for k in range(half_ndim):
+                    for k in range(ndim):
                         all_w[j, i, k] = tmp_w[i, k]
 
     if store_all:

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -45,7 +45,7 @@ cdef void c_ruth4_step(CPotential *p, int half_ndim, double t, double dt,
 cpdef ruth4_integrate_hamiltonian(hamiltonian,
                                   double[:, ::1] w0,
                                   double[::1] t,
-                                  int store_all):
+                                  int store_all=1):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -113,7 +113,7 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
                              &tmp_w[i, 0], &grad[0])
 
                 if store_all:
-                    for k in range(half_ndim):
+                    for k in range(ndim):
                         all_w[j, i, k] = tmp_w[i, k]
 
     if store_all:

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -3,6 +3,7 @@
 """
 
 # Standard library
+from itertools import product
 import time
 
 # Third-party
@@ -67,6 +68,35 @@ def test_compare_to_py(Integrator, integrate_func, dt):
     assert py_w.shape == cy_w.shape
     assert np.allclose(cy_w[:, -1], py_w[:, -1])
     assert np.allclose(cy_t, py_t)
+
+
+@pytest.mark.parametrize(
+    ["integrate_func", "dt"],
+    product(func_list, [-2., 2])
+)
+def test_store_all(integrate_func, dt):
+    p = HernquistPotential(m=1e11, c=0.5, units=galactic)
+    H = Hamiltonian(potential=p)
+
+    w0 = np.array(
+        [
+            [0.0, 10.0, 0.0, 0.2, 0.0, 0.0],
+            [10.0, 0.0, 0.0, 0.0, 0.2, 0.0],
+            [0.0, 10.0, 0.0, 0.0, 0.0, 0.2],
+        ]
+    )
+
+    # 1024 steps
+    t = np.linspace(0, dt * 1024, 1024 + 1)
+
+    t_all, w_all = integrate_func(H, w0, t)
+    t_f, w_f = integrate_func(H, w0, t, store_all=False)
+
+    assert t_all[-1] == t_f[0]
+
+    print(w_all[-1])
+    print(w_f)
+    assert np.allclose(w_all[-1], w_f)
 
 
 # TODO: move this to only run if a flag like --remote-data is passed, like

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -675,6 +675,10 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
             If there is a Cython version of the integrator implemented,
             and the potential object has a C instance, using Cython
             will be *much* faster.
+        store_all : bool (optional)
+            Controls whether to store the phase-space position at all intermediate
+            timesteps. Set to False to store only the final values (i.e. the
+            phase-space position(s) at the final timestep). Default is True.
         **time_spec
             Specification of how long to integrate. See documentation
             for `~gala.integrate.parse_time_specification`.


### PR DESCRIPTION
### Describe your changes

This adds an option to the integrators to control whether to store all timestep data, or only the final timestep.

### Checklist

* [x] Did you add tests?
* [x] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [x] Is the milestone set?
