### PR TITLE
Speedup Nbody and add new integrator functionality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features
 - Added a new Milky Way potential model: ``MilkyWayPotential2022``, which is based on
   updated measurements of the disk structure and circular velocity curve of the disk.
 
+- Added the ability to use leapfrog integration within the ``DirectNBody`` integrator.
+
 
 Bug fixes
 ---------

--- a/gala/dynamics/nbody/tests/test_nbody.py
+++ b/gala/dynamics/nbody/tests/test_nbody.py
@@ -4,66 +4,78 @@ import numpy as np
 import pytest
 
 # Custom
-from ....potential import (NullPotential, NFWPotential,
-                           HernquistPotential,
-                           ConstantRotatingFrame, StaticFrame)
-from ....dynamics import PhaseSpacePosition, combine
-from ....units import UnitSystem, galactic
+from gala.potential import (
+    NullPotential,
+    NFWPotential,
+    HernquistPotential,
+    ConstantRotatingFrame,
+    StaticFrame,
+)
+from gala.dynamics import PhaseSpacePosition, combine
+from gala.units import UnitSystem, galactic
+from gala.integrate import (
+    DOPRI853Integrator,
+    LeapfrogIntegrator,
+    Ruth4Integrator,
+)
 
 # Project
 from ..core import DirectNBody
 
 
 class TestDirectNBody:
-
     def setup_method(self):
-        self.usys = UnitSystem(u.pc, u.Unit(1e-5*u.Myr),
-                               u.Unit(1e6*u.Msun), u.radian)
-        pot_particle2 = HernquistPotential(m=1e6*u.Msun, c=0.1*u.pc,
-                                           units=self.usys)
-        vcirc = pot_particle2.circular_velocity([1, 0, 0.]*u.pc).to(u.km/u.s)
+        self.usys = UnitSystem(
+            u.pc, u.Unit(1e-5 * u.Myr), u.Unit(1e6 * u.Msun), u.radian
+        )
+        pot_particle2 = HernquistPotential(
+            m=1e6 * u.Msun, c=0.1 * u.pc, units=self.usys
+        )
+        vcirc = pot_particle2.circular_velocity([1, 0, 0.0] * u.pc).to(u.km / u.s)
 
-        self.particle_potentials = [NullPotential(units=self.usys),
-                                    pot_particle2]
+        self.particle_potentials = [NullPotential(units=self.usys), pot_particle2]
 
-        w0_2 = PhaseSpacePosition(pos=[10, 0, 0] * u.kpc,
-                                  vel=[0, 83, 0] * u.km/u.s)
-        w0_1 = PhaseSpacePosition(pos=w0_2.xyz + [1, 0, 0] * u.pc,
-                                  vel=w0_2.v_xyz + [0, 1., 0] * vcirc)
+        w0_2 = PhaseSpacePosition(pos=[10, 0, 0] * u.kpc, vel=[0, 83, 0] * u.km / u.s)
+        w0_1 = PhaseSpacePosition(
+            pos=w0_2.xyz + [1, 0, 0] * u.pc, vel=w0_2.v_xyz + [0, 1.0, 0] * vcirc
+        )
         self.w0 = combine((w0_1, w0_2))
 
         self.ext_pot = NFWPotential(m=1e11, r_s=10, units=galactic)
 
     def test_directnbody_init(self):
         # another unit system for testing
-        usys2 = UnitSystem(u.pc, u.Unit(1e-3*u.Myr),
-                           u.Unit(1e6*u.Msun), u.radian)
+        usys2 = UnitSystem(u.pc, u.Unit(1e-3 * u.Myr), u.Unit(1e6 * u.Msun), u.radian)
 
         particle_potentials_None = [None] + self.particle_potentials[1:]
 
         # Different VALID ways to initialize
-        nbody = DirectNBody(self.w0,
-                            particle_potentials=self.particle_potentials)
-        nbody = DirectNBody(self.w0,
-                            particle_potentials=particle_potentials_None)
-        nbody = DirectNBody(self.w0,
-                            particle_potentials=self.particle_potentials,
-                            external_potential=self.ext_pot)
-        nbody = DirectNBody(self.w0,
-                            particle_potentials=self.particle_potentials,
-                            external_potential=self.ext_pot, units=usys2)
-        nbody = DirectNBody(self.w0, particle_potentials=[None, None],
-                            units=usys2)
-        nbody = DirectNBody(self.w0, particle_potentials=[None, None],  # noqa
-                            external_potential=self.ext_pot)
+        nbody = DirectNBody(self.w0, particle_potentials=self.particle_potentials)
+        nbody = DirectNBody(self.w0, particle_potentials=particle_potentials_None)
+        nbody = DirectNBody(
+            self.w0,
+            particle_potentials=self.particle_potentials,
+            external_potential=self.ext_pot,
+        )
+        nbody = DirectNBody(
+            self.w0,
+            particle_potentials=self.particle_potentials,
+            external_potential=self.ext_pot,
+            units=usys2,
+        )
+        nbody = DirectNBody(self.w0, particle_potentials=[None, None], units=usys2)
+        nbody = DirectNBody(
+            self.w0,
+            particle_potentials=[None, None],  # noqa
+            external_potential=self.ext_pot,
+        )
 
         # Different INVALID ways to initialize
         with pytest.raises(TypeError):
             DirectNBody("sdf", particle_potentials=self.particle_potentials)
 
         with pytest.raises(ValueError):
-            DirectNBody(self.w0,
-                        particle_potentials=self.particle_potentials[:1])
+            DirectNBody(self.w0, particle_potentials=self.particle_potentials[:1])
 
         # MAX_NBODY1 = 65536+1
         # w0_max = combine([self.w0[0]]*MAX_NBODY1)
@@ -73,62 +85,73 @@ class TestDirectNBody:
         with pytest.raises(ValueError):
             DirectNBody(self.w0, particle_potentials=[None, None])
 
-    def test_directnbody_integrate(self):
+    @pytest.mark.parametrize(
+        "Integrator", [DOPRI853Integrator, Ruth4Integrator, LeapfrogIntegrator]
+    )
+    def test_directnbody_integrate(self, Integrator):
         # TODO: this is really a unit test, but we should have some functional tests
         # that check that the orbit integration is making sense!
 
         # First, compare with/without mass with no external potential:
-        nbody1 = DirectNBody(self.w0,
-                             particle_potentials=[None, None],
-                             units=self.usys)
-        nbody2 = DirectNBody(self.w0,
-                             particle_potentials=self.particle_potentials,
-                             units=self.usys)
+        nbody1 = DirectNBody(self.w0, particle_potentials=[None, None], units=self.usys)
+        nbody2 = DirectNBody(
+            self.w0, particle_potentials=self.particle_potentials, units=self.usys
+        )
 
-        orbits1 = nbody1.integrate_orbit(dt=1*self.usys['time'],
-                                         t1=0, t2=1*u.Myr)
-        orbits2 = nbody2.integrate_orbit(dt=1*self.usys['time'],
-                                         t1=0, t2=1*u.Myr)
+        orbits1 = nbody1.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
+        orbits2 = nbody2.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
 
         dx0 = orbits1[:, 0].xyz - orbits2[:, 0].xyz
         dx1 = orbits1[:, 1].xyz - orbits2[:, 1].xyz
-        assert u.allclose(np.abs(dx1), 0*u.pc, atol=1e-13*u.pc)
-        assert np.abs(dx0).max() > 50*u.pc
+        assert u.allclose(np.abs(dx1), 0 * u.pc, atol=1e-13 * u.pc)
+        assert np.abs(dx0).max() > 50 * u.pc
 
         # Now compare with/without mass with external potential:
-        nbody1 = DirectNBody(self.w0,
-                             particle_potentials=[None, None],
-                             units=self.usys,
-                             external_potential=self.ext_pot)
-        nbody2 = DirectNBody(self.w0,
-                             particle_potentials=self.particle_potentials,
-                             units=self.usys,
-                             external_potential=self.ext_pot)
+        nbody1 = DirectNBody(
+            self.w0,
+            particle_potentials=[None, None],
+            units=self.usys,
+            external_potential=self.ext_pot,
+        )
+        nbody2 = DirectNBody(
+            self.w0,
+            particle_potentials=self.particle_potentials,
+            units=self.usys,
+            external_potential=self.ext_pot,
+        )
 
-        orbits1 = nbody1.integrate_orbit(dt=1*self.usys['time'],
-                                         t1=0, t2=1*u.Myr)
-        orbits2 = nbody2.integrate_orbit(dt=1*self.usys['time'],
-                                         t1=0, t2=1*u.Myr)
+        orbits1 = nbody1.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
+        orbits2 = nbody2.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
 
         dx0 = orbits1[:, 0].xyz - orbits2[:, 0].xyz
         dx1 = orbits1[:, 1].xyz - orbits2[:, 1].xyz
-        assert u.allclose(np.abs(dx1), 0*u.pc, atol=1e-13*u.pc)
-        assert np.abs(dx0).max() > 50*u.pc
+        assert u.allclose(np.abs(dx1), 0 * u.pc, atol=1e-13 * u.pc)
+        assert np.abs(dx0).max() > 50 * u.pc
 
     def test_directnbody_acceleration(self):
-        pot1 = HernquistPotential(m=1e6*u.Msun, c=0.1*u.pc, units=self.usys)
-        pot2 = HernquistPotential(m=1.6e6*u.Msun, c=0.33*u.pc, units=self.usys)
+        pot1 = HernquistPotential(m=1e6 * u.Msun, c=0.1 * u.pc, units=self.usys)
+        pot2 = HernquistPotential(m=1.6e6 * u.Msun, c=0.33 * u.pc, units=self.usys)
 
-        nbody = DirectNBody(self.w0,
-                            particle_potentials=[pot1, pot2],
-                            external_potential=self.ext_pot)
+        nbody = DirectNBody(
+            self.w0, particle_potentials=[pot1, pot2], external_potential=self.ext_pot
+        )
 
         # Compute the acceleration we expect:
-        _pot1 = HernquistPotential(m=1e6*u.Msun, c=0.1*u.pc, units=self.usys,
-                                   origin=self.w0[0].xyz)
-        _pot2 = HernquistPotential(m=1.6e6*u.Msun, c=0.33*u.pc, units=self.usys,
-                                   origin=self.w0[1].xyz)
-        exp_acc = np.zeros((3, 2)) * self.usys['acceleration']
+        _pot1 = HernquistPotential(
+            m=1e6 * u.Msun, c=0.1 * u.pc, units=self.usys, origin=self.w0[0].xyz
+        )
+        _pot2 = HernquistPotential(
+            m=1.6e6 * u.Msun, c=0.33 * u.pc, units=self.usys, origin=self.w0[1].xyz
+        )
+        exp_acc = np.zeros((3, 2)) * self.usys["acceleration"]
         exp_acc[:, 0] = _pot2.acceleration(self.w0[0])[:, 0]
         exp_acc[:, 1] = _pot1.acceleration(self.w0[1])[:, 0]
         exp_acc += self.ext_pot.acceleration(self.w0)
@@ -136,47 +159,64 @@ class TestDirectNBody:
         acc = nbody.acceleration()
         assert u.allclose(acc, exp_acc)
 
-    def test_directnbody_integrate_dontsaveall(self):
+    @pytest.mark.parametrize(
+        "Integrator", [DOPRI853Integrator, Ruth4Integrator, LeapfrogIntegrator]
+    )
+    def test_directnbody_integrate_dontsaveall(self, Integrator):
         # If we set save_all = False, only return the final positions:
-        nbody1 = DirectNBody(self.w0,
-                             particle_potentials=self.particle_potentials,
-                             units=self.usys,
-                             external_potential=self.ext_pot,
-                             save_all=False)
-        nbody2 = DirectNBody(self.w0,
-                             particle_potentials=self.particle_potentials,
-                             units=self.usys,
-                             external_potential=self.ext_pot,
-                             save_all=True)
+        nbody1 = DirectNBody(
+            self.w0,
+            particle_potentials=self.particle_potentials,
+            units=self.usys,
+            external_potential=self.ext_pot,
+            save_all=False,
+        )
+        nbody2 = DirectNBody(
+            self.w0,
+            particle_potentials=self.particle_potentials,
+            units=self.usys,
+            external_potential=self.ext_pot,
+            save_all=True,
+        )
 
-        w1 = nbody1.integrate_orbit(dt=1*self.usys['time'],
-                                    t1=0, t2=1*u.Myr)
-        orbits = nbody2.integrate_orbit(dt=1*self.usys['time'],
-                                        t1=0, t2=1*u.Myr)
+        w1 = nbody1.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
+        orbits = nbody2.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
         w2 = orbits[-1]
         assert u.allclose(w1.xyz, w2.xyz)
         assert u.allclose(w1.v_xyz, w2.v_xyz)
 
-    def test_directnbody_integrate_rotframe(self):
+    @pytest.mark.parametrize("Integrator", [DOPRI853Integrator])
+    def test_directnbody_integrate_rotframe(self, Integrator):
         # Now compare with/without mass with external potential:
-        frame = ConstantRotatingFrame(Omega=[0, 0, 1]*self.w0[0].v_y/self.w0[0].x,
-                                      units=self.usys)
-        nbody = DirectNBody(self.w0,
-                            particle_potentials=self.particle_potentials,
-                            units=self.usys,
-                            external_potential=self.ext_pot,
-                            frame=frame)
-        nbody2 = DirectNBody(self.w0,
-                             particle_potentials=self.particle_potentials,
-                             units=self.usys,
-                             external_potential=self.ext_pot)
+        frame = ConstantRotatingFrame(
+            Omega=[0, 0, 1] * self.w0[0].v_y / self.w0[0].x, units=self.usys
+        )
+        nbody = DirectNBody(
+            self.w0,
+            particle_potentials=self.particle_potentials,
+            units=self.usys,
+            external_potential=self.ext_pot,
+            frame=frame,
+        )
+        nbody2 = DirectNBody(
+            self.w0,
+            particle_potentials=self.particle_potentials,
+            units=self.usys,
+            external_potential=self.ext_pot,
+        )
 
-        orbits = nbody.integrate_orbit(dt=1*self.usys['time'],
-                                       t1=0, t2=1*u.Myr)
+        orbits = nbody.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
         orbits_static = orbits.to_frame(StaticFrame(self.usys))
 
-        orbits2 = nbody2.integrate_orbit(dt=1*self.usys['time'],
-                                         t1=0, t2=1*u.Myr)
+        orbits2 = nbody2.integrate_orbit(
+            dt=1 * self.usys["time"], t1=0, t2=1 * u.Myr, Integrator=Integrator
+        )
 
         assert u.allclose(orbits_static.xyz, orbits_static.xyz)
         assert u.allclose(orbits2.v_xyz, orbits2.v_xyz)

--- a/gala/integrate/cyintegrators/leapfrog.pxd
+++ b/gala/integrate/cyintegrators/leapfrog.pxd
@@ -4,6 +4,9 @@ cdef extern from "potential/src/cpotential.h":
     ctypedef struct CPotential:
         pass
 
+cdef extern from "nbody_helper.h":
+    const int MAX_NBODY
+
 cdef void c_init_velocity(CPotential *p, int ndim, double t, double dt,
                           double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil
 

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -15,6 +15,7 @@ np.import_array()
 # Project
 from ...potential.potential.cpotential cimport CPotentialWrapper
 from ...potential.frame import StaticFrame
+from ...potential import NullPotential
 
 cdef extern from "frame/src/cframe.h":
     ctypedef struct CFrameType:
@@ -26,6 +27,12 @@ cdef extern from "potential/src/cpotential.h":
 
 cdef extern from "potential/src/cpotential.h":
     void c_gradient(CPotential *p, double t, double *q, double *grad) nogil
+    void c_nbody_gradient_symplectic(
+        CPotential **pots, double t, double *q,
+        double *nbody_q, int nbody, int nbody_i,
+        int ndim, double *grad
+    ) nogil
+
 
 cdef void c_init_velocity(CPotential *p, int half_ndim, double t, double dt,
                           double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil:
@@ -115,6 +122,129 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
                                 &tmp_w[i, 0], &tmp_w[i, half_ndim],
                                 &v_jm1_2[i, 0],
                                 &grad[0])
+
+                if store_all:
+                    for k in range(ndim):
+                        all_w[j, i, k] = tmp_w[i, k]
+
+    if store_all:
+        return np.asarray(t), np.asarray(all_w)
+    else:
+        return np.asarray(t[-1:]), np.asarray(tmp_w)
+
+# -------------------------------------------------------------------------------------
+# N-body stuff - TODO: to be moved, because this is a HACK!
+
+cdef void c_init_velocity_nbody(
+    CPotential *p, int half_ndim, double t, double dt,
+    CPotential **pots, double *x_nbody_jm1, int nbody, int nbody_i,
+    double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad
+) nogil:
+    cdef int k
+
+    c_gradient(p, t, x_jm1, grad)
+    c_nbody_gradient_symplectic(pots, t, x_jm1, x_nbody_jm1, nbody, nbody_i, half_ndim, grad)
+
+    for k in range(half_ndim):
+        v_jm1_2[k] = v_jm1[k] - grad[k] * dt/2.  # acceleration is minus gradient
+
+
+cdef void c_leapfrog_step_nbody(
+    CPotential *p, int half_ndim, double t, double dt,
+    CPotential **pots, double *x_nbody_jm1, int nbody, int nbody_i,
+    double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad
+) nogil:
+    cdef int k
+
+    # full step the positions
+    for k in range(half_ndim):
+        x_jm1[k] = x_jm1[k] + v_jm1_2[k] * dt
+
+    c_gradient(p, t, x_jm1, grad)  # compute gradient at new position
+    c_nbody_gradient_symplectic(pots, t, x_jm1, x_nbody_jm1, nbody, nbody_i, half_ndim, grad)
+
+    # step velocity forward by half step, aligned w/ position, then
+    #   finish the full step to leapfrog over position
+    for k in range(half_ndim):
+        v_jm1[k] = v_jm1_2[k] - grad[k] * dt/2.
+        v_jm1_2[k] = v_jm1_2[k] - grad[k] * dt
+
+
+cpdef leapfrog_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
+                               list particle_potentials, int store_all=1):
+    """
+    CAUTION: Interpretation of axes is different here! We need the
+    arrays to be C ordered and easy to iterate over, so here the
+    axes are (norbits, ndim).
+    """
+
+    if not hamiltonian.c_enabled:
+        raise TypeError("Input Hamiltonian object does not support C-level access.")
+
+    if not isinstance(hamiltonian.frame, StaticFrame):
+        raise TypeError(
+            "Leapfrog integration is currently only supported for StaticFrame, "
+            f"not {hamiltonian.frame.__class__.__name__}"
+        )
+
+    cdef:
+        # temporary scalars
+        int i, j, k
+        int n = w0.shape[0]
+        int ndim = w0.shape[1]
+        int half_ndim = ndim // 2
+
+        int ntimes = len(t)
+        double dt = t[1]-t[0]
+
+        # temporary array containers
+        double[::1] grad = np.zeros(half_ndim)
+        double[:, ::1] v_jm1_2 = np.zeros((n, half_ndim))
+
+        # return arrays
+        double[:, :, ::1] all_w
+        double[:, ::1] tmp_w = np.zeros((n, ndim))
+
+        # whoa, so many dots
+        CPotential cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
+        CPotential *c_particle_potentials[MAX_NBODY]
+        unsigned nbody = 0
+
+    if store_all:
+        all_w = np.zeros((ntimes, n, ndim))
+
+        # save initial conditions
+        all_w[0, :, :] = w0.copy()
+
+    for pot in particle_potentials:
+        if not isinstance(pot, NullPotential):
+            nbody += 1
+
+    # Extract the CPotential objects from the particle potentials.
+    for i in range(n):
+        c_particle_potentials[i] = &(<CPotentialWrapper>(particle_potentials[i].c_instance)).cpotential
+
+    tmp_w = w0.copy()
+
+    with nogil:
+        # first initialize the velocities so they are evolved by a
+        #   half step relative to the positions
+        for i in range(n):
+            c_init_velocity_nbody(&cp, half_ndim, t[0], dt,
+                                  &c_particle_potentials[0], &tmp_w[0, 0], nbody, i,
+                                  &tmp_w[i, 0], &tmp_w[i, half_ndim],
+                                  &v_jm1_2[i, 0], &grad[0])
+
+        for j in range(1, ntimes, 1):
+            for i in range(n):
+                for k in range(half_ndim):
+                    grad[k] = 0.
+
+                c_leapfrog_step_nbody(&cp, half_ndim, t[j], dt,
+                                      &c_particle_potentials[0], &tmp_w[0, 0], nbody, i,
+                                      &tmp_w[i, 0], &tmp_w[i, half_ndim],
+                                      &v_jm1_2[i, 0],
+                                      &grad[0])
 
                 if store_all:
                     for k in range(ndim):

--- a/gala/integrate/cyintegrators/ruth4.pxd
+++ b/gala/integrate/cyintegrators/ruth4.pxd
@@ -4,6 +4,9 @@ cdef extern from "potential/src/cpotential.h":
     ctypedef struct CPotential:
         pass
 
+cdef extern from "nbody_helper.h":
+    const int MAX_NBODY
+
 cdef void c_ruth4_step(CPotential *p, int ndim, double t, double dt,
                        double *cs, double *ds,
                        double *w, double *grad) nogil

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -15,6 +15,7 @@ np.import_array()
 # Project
 from ...potential.potential.cpotential cimport CPotentialWrapper
 from ...potential.frame import StaticFrame
+from ...potential import NullPotential
 
 cdef extern from "frame/src/cframe.h":
     ctypedef struct CFrameType:
@@ -26,6 +27,11 @@ cdef extern from "potential/src/cpotential.h":
 
 cdef extern from "potential/src/cpotential.h":
     void c_gradient(CPotential *p, double t, double *q, double *grad) nogil
+    void c_nbody_gradient_symplectic(
+        CPotential **pots, double t, double *q,
+        double *nbody_q, int nbody, int nbody_i,
+        int ndim, double *grad
+    ) nogil
 
 
 cdef void c_ruth4_step(CPotential *p, int half_ndim, double t, double dt,
@@ -111,6 +117,122 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
                 c_ruth4_step(&cp, half_ndim, t[j], dt,
                              &cs[0], &ds[0],
                              &tmp_w[i, 0], &grad[0])
+
+                if store_all:
+                    for k in range(ndim):
+                        all_w[j, i, k] = tmp_w[i, k]
+
+    if store_all:
+        return np.asarray(t), np.asarray(all_w)
+    else:
+        return np.asarray(t[-1:]), np.asarray(tmp_w)
+
+
+# -------------------------------------------------------------------------------------
+# N-body stuff - TODO: to be moved, because this is a HACK!
+
+cdef void c_ruth4_step_nbody(
+    CPotential *p, int half_ndim, double t, double dt,
+    CPotential **pots, double *w_nbody, int nbody, int nbody_i,
+    double *cs, double *ds,
+    double *w, double *grad
+) nogil:
+    cdef:
+        int j, k
+
+    for j in range(4):
+        for k in range(half_ndim):
+             grad[k] = 0.
+
+        c_gradient(p, t, w, grad)
+        c_nbody_gradient_symplectic(pots, t, w, w_nbody, nbody, nbody_i, half_ndim, grad)
+
+        for k in range(half_ndim):
+            w[half_ndim + k] = w[half_ndim + k] - ds[j] * grad[k] * dt
+            w[k] = w[k] + cs[j] * w[half_ndim + k] * dt
+
+cpdef ruth4_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
+                            list particle_potentials, int store_all=1):
+    """
+    CAUTION: Interpretation of axes is different here! We need the
+    arrays to be C ordered and easy to iterate over, so here the
+    axes are (norbits, ndim).
+    """
+
+    if not hamiltonian.c_enabled:
+        raise TypeError("Input Hamiltonian object does not support C-level access.")
+
+    if not isinstance(hamiltonian.frame, StaticFrame):
+        raise TypeError(
+            "Leapfrog integration is currently only supported for StaticFrame, "
+            f"not {hamiltonian.frame.__class__.__name__}"
+        )
+
+    cdef:
+        # temporary scalars
+        int i, j, k
+        int n = w0.shape[0]
+        int ndim = w0.shape[1]
+        int half_ndim = ndim // 2
+
+        int ntimes = len(t)
+        double dt = t[1]-t[0]
+
+         # Integrator coefficients
+        double two_13 = 2 ** (1./3.)
+        double[::1] cs = np.array([
+            1. / (2. * (2. - two_13)),
+            (1. - two_13) / (2.*(2. - two_13)),
+            (1. - two_13) / (2.*(2. - two_13)),
+            1. / (2.*(2. - two_13))
+        ], dtype='f8')
+
+        double[::1] ds = np.array([
+            0.,
+            1. / (2. - two_13),
+            -two_13 / (2. - two_13),
+            1. / (2. - two_13)
+        ], dtype='f8')
+
+        # temporary array containers
+        double[::1] grad = np.zeros(half_ndim)
+        double[:, ::1] v_jm1_2 = np.zeros((n, half_ndim))
+
+        # return arrays
+        double[:, :, ::1] all_w
+        double[:, ::1] tmp_w = np.zeros((n, ndim))
+
+        # whoa, so many dots
+        CPotential cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
+        CPotential *c_particle_potentials[MAX_NBODY]
+        unsigned nbody = 0
+
+    if store_all:
+        all_w = np.zeros((ntimes, n, ndim))
+
+        # save initial conditions
+        all_w[0, :, :] = w0.copy()
+
+    for pot in particle_potentials:
+        if not isinstance(pot, NullPotential):
+            nbody += 1
+
+    # Extract the CPotential objects from the particle potentials.
+    for i in range(n):
+        c_particle_potentials[i] = &(<CPotentialWrapper>(particle_potentials[i].c_instance)).cpotential
+
+    tmp_w = w0.copy()
+
+    with nogil:
+
+        for j in range(1, ntimes, 1):
+            for i in range(n):
+                c_ruth4_step_nbody(
+                    &cp, half_ndim, t[j], dt,
+                    &c_particle_potentials[0], &tmp_w[0, 0], nbody, i,
+                    &cs[0], &ds[0],
+                    &tmp_w[i, 0], &grad[0]
+                )
 
                 if store_all:
                     for k in range(ndim):

--- a/gala/integrate/setup_package.py
+++ b/gala/integrate/setup_package.py
@@ -1,5 +1,5 @@
-from distutils.core import Extension
 from collections import defaultdict
+from distutils.core import Extension
 
 
 def get_extensions():
@@ -11,32 +11,33 @@ def get_extensions():
     mac_incl_path = "/usr/include/malloc"
 
     cfg = defaultdict(list)
-    cfg['include_dirs'].append(np.get_include())
-    cfg['include_dirs'].append(mac_incl_path)
-    cfg['include_dirs'].append('gala/potential')
-    cfg['extra_compile_args'].append('--std=gnu99')
-    cfg['sources'].append('gala/integrate/cyintegrators/leapfrog.pyx')
-    cfg['sources'].append('gala/potential/potential/src/cpotential.c')
-    exts.append(Extension('gala.integrate.cyintegrators.leapfrog', **cfg))
+    cfg["include_dirs"].append(np.get_include())
+    cfg["include_dirs"].append(mac_incl_path)
+    cfg["include_dirs"].append("gala/potential")
+    cfg["include_dirs"].append("gala/dynamics/nbody")
+    cfg["extra_compile_args"].append("--std=gnu99")
+    cfg["sources"].append("gala/integrate/cyintegrators/leapfrog.pyx")
+    cfg["sources"].append("gala/potential/potential/src/cpotential.c")
+    exts.append(Extension("gala.integrate.cyintegrators.leapfrog", **cfg))
 
     cfg = defaultdict(list)
-    cfg['include_dirs'].append(np.get_include())
-    cfg['include_dirs'].append(mac_incl_path)
-    cfg['include_dirs'].append('gala/potential')
-    cfg['extra_compile_args'].append('--std=gnu99')
-    cfg['sources'].append('gala/potential/hamiltonian/src/chamiltonian.c')
-    cfg['sources'].append('gala/potential/potential/src/cpotential.c')
-    cfg['sources'].append('gala/integrate/cyintegrators/dop853.pyx')
-    cfg['sources'].append('gala/integrate/cyintegrators/dopri/dop853.c')
-    exts.append(Extension('gala.integrate.cyintegrators.dop853', **cfg))
+    cfg["include_dirs"].append(np.get_include())
+    cfg["include_dirs"].append(mac_incl_path)
+    cfg["include_dirs"].append("gala/potential")
+    cfg["extra_compile_args"].append("--std=gnu99")
+    cfg["sources"].append("gala/potential/hamiltonian/src/chamiltonian.c")
+    cfg["sources"].append("gala/potential/potential/src/cpotential.c")
+    cfg["sources"].append("gala/integrate/cyintegrators/dop853.pyx")
+    cfg["sources"].append("gala/integrate/cyintegrators/dopri/dop853.c")
+    exts.append(Extension("gala.integrate.cyintegrators.dop853", **cfg))
 
     cfg = defaultdict(list)
-    cfg['include_dirs'].append(np.get_include())
-    cfg['include_dirs'].append(mac_incl_path)
-    cfg['include_dirs'].append('gala/potential')
-    cfg['extra_compile_args'].append('--std=gnu99')
-    cfg['sources'].append('gala/integrate/cyintegrators/ruth4.pyx')
-    cfg['sources'].append('gala/potential/potential/src/cpotential.c')
-    exts.append(Extension('gala.integrate.cyintegrators.ruth4', **cfg))
+    cfg["include_dirs"].append(np.get_include())
+    cfg["include_dirs"].append(mac_incl_path)
+    cfg["include_dirs"].append("gala/potential")
+    cfg["extra_compile_args"].append("--std=gnu99")
+    cfg["sources"].append("gala/integrate/cyintegrators/ruth4.pyx")
+    cfg["sources"].append("gala/potential/potential/src/cpotential.c")
+    exts.append(Extension("gala.integrate.cyintegrators.ruth4", **cfg))
 
     return exts

--- a/gala/integrate/setup_package.py
+++ b/gala/integrate/setup_package.py
@@ -35,6 +35,7 @@ def get_extensions():
     cfg["include_dirs"].append(np.get_include())
     cfg["include_dirs"].append(mac_incl_path)
     cfg["include_dirs"].append("gala/potential")
+    cfg["include_dirs"].append("gala/dynamics/nbody")
     cfg["extra_compile_args"].append("--std=gnu99")
     cfg["sources"].append("gala/integrate/cyintegrators/ruth4.pyx")
     cfg["sources"].append("gala/potential/potential/src/cpotential.c")

--- a/gala/potential/potential/src/cpotential.c
+++ b/gala/potential/potential/src/cpotential.c
@@ -226,3 +226,29 @@ void c_nbody_acceleration(CPotential **pots, double t, double *qp,
         }
     }
 }
+
+// TODO: this is a hack to get nbody leapfrog working
+void c_nbody_gradient_symplectic(
+    CPotential **pots, double t, double *w,
+    double *nbody_w, int nbody, int nbody_i,
+    int ndim, double *grad
+) {
+    int i, j, k;
+    CPotential *body_pot;
+    double f2[ndim];
+
+    for (j=0; j < nbody; j++) { // the particles generating force
+        body_pot = pots[j];
+
+        if ((body_pot->null == 1) || (j == nbody_i))
+            continue;
+
+        for (i=0; i < body_pot->n_components; i++) {
+            (body_pot->q0)[i] = &nbody_w[j * 2 * ndim]; // p-s ndim
+        }
+
+        c_gradient(body_pot, t, w, &f2[0]);
+        for (k=0; k < ndim; k++)
+            grad[k] += f2[k];
+    }
+}

--- a/gala/potential/potential/src/cpotential.h
+++ b/gala/potential/potential/src/cpotential.h
@@ -47,3 +47,8 @@ extern double c_mass_enclosed(CPotential *p, double t, double *q, double G, doub
 // TODO: move this elsewhere?
 void c_nbody_acceleration(CPotential **pots, double t, double *qp,
                           int norbits, int nbody, int ndim, double *acc);
+void c_nbody_gradient_symplectic(
+    CPotential **pots, double t, double *q,
+    double *nbody_q, int nbody, int nbody_i,
+    int ndim, double *grad
+);


### PR DESCRIPTION
### Describe your changes

This adds a minor speedup for `DirectNBody` orbit integration, and adds the ability to use Leapfrog or Ruth integration schemes with the N-body integration functionality.

### Checklist

* [x] Did you add tests? - need to parametrize the nbody test to run with different integrators
* [ ] Did you add documentation for your changes?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?
