### PR TITLE
GSL warnings for discrete SCF functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Bug fixes
 - Fixed the YAML output to use ``default_flow_style=None`` for serializing potential
   objects, which leads to a more efficient array output.
 
+- ``scf.compute_coeffs_discrete`` now raises an error if GSL is not enabled rather than silently returning
+  zeros
+
 API changes
 -----------
 

--- a/gala/potential/scf/core.py
+++ b/gala/potential/scf/core.py
@@ -207,6 +207,16 @@ def compute_coeffs_discrete(
         matrix of the coefficients.
 
     """
+    from gala._cconfig import GSL_ENABLED
+
+    if not GSL_ENABLED:
+        raise ValueError(
+            "Gala was compiled without GSL and so this function "
+            "will not work.  See the gala documentation for more "
+            "information about installing and using GSL with "
+            "gala: http://gala.adrian.pw/en/latest/install.html"
+        )
+
     lmin = 0
     lstride = 1
 

--- a/gala/potential/scf/core.py
+++ b/gala/potential/scf/core.py
@@ -36,6 +36,11 @@ def compute_coeffs(
     Computing the coefficients involves computing triple integrals which are
     computationally expensive.
 
+    .. warning::
+
+        GSL is required for this function, see the
+        `Installation instructions <http://gala.adrian.pw/en/latest/install.html>`_ for more details
+
     Parameters
     ----------
     density_func : function, callable
@@ -171,6 +176,11 @@ def compute_coeffs_discrete(
     Compute the expansion coefficients for representing the density distribution
     of input points as a basis function expansion. The points, ``xyz``, are
     assumed to be samples from the density distribution.
+
+    .. warning::
+
+        GSL is required for this function, see the
+        `Installation instructions <http://gala.adrian.pw/en/latest/install.html>`_ for more details
 
     Parameters
     ----------


### PR DESCRIPTION
### Describe your changes

I've added the same check that `compute_coeffs` has to `compute_coeffs_discrete` so that you get an error message rather than a list of zeros as your output if `GSL_ENABLED` is `False`.

I also added some warnings to the docstrings about the needs for GSL for these functions, obviously feel free to delete those.

### Checklist

* [ ] Did you add tests?
* [x] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?
