### PR TITLE
BLD: pin extension-helpers to 1.* following upstream recommendation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "setuptools_scm",
-    "extension-helpers",
+    "extension-helpers==1.*",
     "oldest-supported-numpy",
     "cython"
 ]


### PR DESCRIPTION
### Describe your changes

This is in response to https://github.com/astropy/extension-helpers/pull/72

### Checklist

* [N/A] Did you add tests?
* [N/A] Did you add documentation for your changes?
* [x] Did you reference any relevant issues?
* [ ] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [ ] Is the milestone set?
