### PR TITLE
MNT: upgrade upload/download-artifact GitHub actions

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -34,7 +34,7 @@ jobs:
           cd docs
           make exectutorials
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: notebooks-for-${{ github.sha }}
           path: docs/tutorials

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,8 +70,9 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_SKIP: "*-win32 *musllinux* pp* *-manylinux_i686"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -94,8 +95,9 @@ jobs:
           pip install build
           python -m build -s .
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
 
   test_upload_pypi:
@@ -106,10 +108,15 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: sdist
           path: dist
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: wheels-*
 
       - name: Publish package distributions to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -127,7 +134,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
### Describe your changes

Hi, version 4 of upload-artifact and download-artifact were recently released.
Staying on old version is not viable long term because GitHub will sooner or later drop support for the old versions of node that these depend on.
Since migration to v4 is not as straightfoward as bumping the version number, I'm helping all astropy-related packages byt manually performing the necessary changes.


### Checklist

* [ ] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [ ] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [ ] Is the milestone set?
