### PR TITLE
Enable passing a multiprocessing/parallel pool when computing SCF coefficients

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
 
       # Coverage:
       - name: Upload coverage report to codecov
-        uses: codecov/codecov-action@4.1.0
+        uses: codecov/codecov-action@v4
         if: steps.check_files.outputs.files_exists == 'true' && runner.os == 'Linux'
         with:
           file: ./coverage.xml # optional

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 New Features
 ------------
 
+- Added an option to specify a multiprocessing or parallel processing pool when
+  computing basis function coefficients for the SCF potential from discrete particles.
 
 Bug fixes
 ---------

--- a/gala/potential/scf/tests/test_computecoeff_discrete.py
+++ b/gala/potential/scf/tests/test_computecoeff_discrete.py
@@ -1,26 +1,26 @@
 # coding: utf-8
 
+import multiprocessing
 import os
 
 # Third-party
 import numpy as np
-from astropy.utils.data import get_pkg_data_filename
-from astropy.constants import G
 import pytest
+from astropy.constants import G
+from astropy.utils.data import get_pkg_data_filename
 
 # Project
 import gala.potential as gp
-from gala.units import galactic
 from gala._cconfig import GSL_ENABLED
-from ..core import compute_coeffs_discrete
+from gala.units import galactic
+
 from .._bfe import potential
+from ..core import compute_coeffs_discrete
 
 _G = G.decompose(galactic).value
 
 if not GSL_ENABLED:
-    pytest.skip(
-        "skipping SCF tests: they depend on GSL", allow_module_level=True
-    )
+    pytest.skip("skipping SCF tests: they depend on GSL", allow_module_level=True)
 
 
 def test_plummer():
@@ -38,9 +38,7 @@ def test_plummer():
     nmax = 10
     lmax = 0
 
-    Snlm, Tnlm = compute_coeffs_discrete(
-        xyz, m_k, nmax=nmax, lmax=lmax, r_s=r_s
-    )
+    Snlm, Tnlm = compute_coeffs_discrete(xyz, m_k, nmax=nmax, lmax=lmax, r_s=r_s)
 
     x = np.logspace(-2, 1, 512)
     xyz = np.zeros((len(x), 3))
@@ -53,7 +51,8 @@ def test_plummer():
     assert np.allclose(true_pot, bfe_pot, rtol=1e-2)
 
 
-def test_coefficients():
+@pytest.mark.parametrize("pool", [None, multiprocessing.Pool(2)])
+def test_coefficients(pool):
     pos_path = os.path.abspath(get_pkg_data_filename("data/plummer-pos.dat.gz"))
     coeff_path = os.path.abspath(
         get_pkg_data_filename("data/plummer_coeff_nmax10_lmax5.txt")
@@ -71,14 +70,15 @@ def test_coefficients():
     lmax = 5
 
     Snlm, Tnlm = compute_coeffs_discrete(
-        xyz, m_k, nmax=nmax, lmax=lmax, r_s=r_s
+        xyz, m_k, nmax=nmax, lmax=lmax, r_s=r_s, pool=pool
     )
 
     assert np.allclose(Snlm_true, Snlm.flatten(), rtol=1e-3)
     assert np.allclose(Tnlm_true, Tnlm.flatten(), rtol=1e-3)
 
 
-def test_coeff_variances():
+@pytest.mark.parametrize("pool", [None, multiprocessing.Pool(2)])
+def test_coeff_variances(pool):
     pos_path = os.path.abspath(get_pkg_data_filename("data/plummer-pos.dat.gz"))
     coeff_path = os.path.abspath(
         get_pkg_data_filename("data/plummer_coeff_var_nmax10_lmax5.txt")
@@ -97,7 +97,7 @@ def test_coeff_variances():
     lmax = 5
 
     *_, STnlm_Cov = compute_coeffs_discrete(
-        xyz, m_k, nmax=nmax, lmax=lmax, r_s=r_s, compute_var=True
+        xyz, m_k, nmax=nmax, lmax=lmax, r_s=r_s, compute_var=True, pool=pool
     )
     assert np.allclose(Snlm_var_true, STnlm_Cov[0, 0].flatten(), rtol=1e-3)
     assert np.allclose(Tnlm_var_true, STnlm_Cov[1, 1].flatten(), rtol=1e-3)


### PR DESCRIPTION
### Describe your changes

This adds a keyword argument to the `compute_coeffs_discrete()` function to allow specifying a parallel processing pool when computing the coefficients for a particle collection. This parallelizes over (n,l,m), so it is faster when the number of particles is large and nmax, lmax is large.

### Checklist

* [x] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [x] Is the milestone set?
