### PR TITLE
Fix inefficient nbody orbit reorder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Bug fixes
   class to enable using the new (correct) parameter values, but the default will
   continue to use the Gala modified values (for backwards compatibility).
 
+- Improved internal efficiency of ``DirectNBody``.
+
 
 API changes
 -----------

--- a/gala/dynamics/nbody/core.py
+++ b/gala/dynamics/nbody/core.py
@@ -259,13 +259,7 @@ class DirectNBody:
                 frame=self.frame,
             )
 
-        # Reorder orbits:
-        remap_idx = np.zeros((orbits.shape[-1], orbits.shape[-1]), dtype=int)
-        remap_idx[idx, np.arange(orbits.shape[-1])] = 1
-        _, undo_idx = np.where(remap_idx == 1)
-
-        return orbits[..., undo_idx]
-        remap_idx[idx, np.arange(orbits.shape[-1])] = 1
-        _, undo_idx = np.where(remap_idx == 1)
+        # Reorder orbits to original order:
+        undo_idx = np.argsort(idx)
 
         return orbits[..., undo_idx]


### PR DESCRIPTION
### Describe your changes

The original code created an unnecessarily enormous array to do the reordering.


### Checklist

* [x] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [x] Is the milestone set?
