### PR TITLE
Added "from_r0" to Burkert potential

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ New Features
   computing basis function coefficients for the SCF potential from discrete particles.
 
 - Added the Burkert potential as a built-in cpotential.
+- Added a method to generate the Burkert potential with just r0 as an input
 
 Bug fixes
 ---------

--- a/gala/potential/potential/builtin/core.py
+++ b/gala/potential/potential/builtin/core.py
@@ -415,6 +415,8 @@ class BurkertPotential(CPotentialBase):
 
         Initialize a Burkert potential from the core radius, ``r0``.
 
+        See Equations 4 and 5 of Mori & Burkert.
+
         Parameters
         ----------
         r0 : :class:`~astropy.units.Quantity`, numeric [length]

--- a/gala/potential/potential/builtin/core.py
+++ b/gala/potential/potential/builtin/core.py
@@ -407,6 +407,22 @@ class BurkertPotential(CPotentialBase):
 
     Wrapper = BurkertWrapper
 
+    
+    @staticmethod
+    def from_r0(r0, units=None):
+        r"""
+        from_r0(r0, units=None)
+
+        Initialize a Burkert potential from the core radius, ``r0``.
+
+        Parameters
+        ----------
+        r0 : :class:`~astropy.units.Quantity`, numeric [length]
+            The core radius of the Burkert potential.
+        """
+        rho_d0 = 1.46e-24 * (r0 / (3.07 * u.kpc))**(-2/3) * (u.g / u.cm**3)
+        return BurkertPotential(rho=rho_d0, r0=r0, units=units)
+
 
 # ============================================================================
 # Flattened, axisymmetric models

--- a/gala/potential/potential/builtin/core.py
+++ b/gala/potential/potential/builtin/core.py
@@ -408,8 +408,8 @@ class BurkertPotential(CPotentialBase):
     Wrapper = BurkertWrapper
 
     
-    @staticmethod
-    def from_r0(r0, units=None):
+    @classmethod
+    def from_r0(cls, r0, units=None):
         r"""
         from_r0(r0, units=None)
 
@@ -422,7 +422,7 @@ class BurkertPotential(CPotentialBase):
             The core radius of the Burkert potential.
         """
         rho_d0 = 1.46e-24 * (r0 / (3.07 * u.kpc))**(-2/3) * (u.g / u.cm**3)
-        return BurkertPotential(rho=rho_d0, r0=r0, units=units)
+        return cls(rho=rho_d0, r0=r0, units=units)
 
 
 # ============================================================================

--- a/gala/potential/potential/builtin/core.py
+++ b/gala/potential/potential/builtin/core.py
@@ -421,7 +421,8 @@ class BurkertPotential(CPotentialBase):
         r0 : :class:`~astropy.units.Quantity`, numeric [length]
             The core radius of the Burkert potential.
         """
-        rho_d0 = 1.46e-24 * (r0 / (3.07 * u.kpc))**(-2/3) * (u.g / u.cm**3)
+        a = 0.021572405792749372 * u.Msun / u.pc**3  # converted: 1.46e-24 g/cm**3
+        rho_d0 = a * (r0 / (3.07 * u.kpc))**(-2/3)
         return cls(rho=rho_d0, r0=r0, units=units)
 
 

--- a/gala/potential/potential/builtin/core.py
+++ b/gala/potential/potential/builtin/core.py
@@ -414,7 +414,6 @@ class BurkertPotential(CPotentialBase):
         from_r0(r0, units=None)
 
         Initialize a Burkert potential from the core radius, ``r0``.
-
         See Equations 4 and 5 of Mori & Burkert.
 
         Parameters

--- a/gala/potential/potential/tests/test_all_builtin.py
+++ b/gala/potential/potential/tests/test_all_builtin.py
@@ -553,3 +553,14 @@ class TestBurkert(PotentialTestBase):
     @pytest.mark.skip(reason="Hessian not implemented for Burkert potential")
     def test_hessian(self):
         pass
+
+    def test_from_r0(self):
+        # Test against values from Zhu+2023
+        pot = p.BurkertPotential.from_r0(r0=11.87 * u.kpc, units=galactic)
+
+        rho = pot.parameters['rho'].to(u.g / u.cm ** 3)
+        rho_check = 5.93e-25 * u.g / u.cm ** 3
+
+        # Check a 1% tolerance on inferred density against published values
+        assert abs(rho - rho_check) / rho_check < 0.01
+


### PR DESCRIPTION
### Added a method to generate the Burkert potential from just the r0

This is standard practice, as it is ultimately a 1-parameter potential. The relationship between density and core radius is described in Equations 4 and 5 of Mori & Burkert 2000. 

### Checklist

* [x] Did you add tests?
* [x] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?
