### PR TITLE
Pass floats to agama setUnits instead of unit objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Bug fixes
   components that could be added to a composite potential. Now, arrays are allocated
   dynamically and there is no limit.
 
+- Some versions of Agama do not accept astropy.units objects as input to setUnits. Gala
+  now converts to floats to set the unit scales in agama when converting a potential to
+  Agama (using ``potential.as_interop("agama")``).
+
 API changes
 -----------
 

--- a/gala/potential/potential/interop.py
+++ b/gala/potential/potential/interop.py
@@ -130,9 +130,9 @@ if HAS_GALPY:
         pars["amp"] * ro * vo**2 / G / 2
     )
 
-    _galpy_to_gala[galpy_gp.LogarithmicHaloPotential][1][
-        "v_c"
-    ] = lambda pars, ro, vo: np.sqrt(pars["amp"] * vo**2)
+    _galpy_to_gala[galpy_gp.LogarithmicHaloPotential][1]["v_c"] = (
+        lambda pars, ro, vo: np.sqrt(pars["amp"] * vo**2)
+    )
 
     _galpy_to_gala[galpy_gp.TriaxialNFWPotential][1]["m"] = lambda pars, ro, vo: (
         pars["amp"] * ro * vo**2 / G * 4 * np.pi * pars["a"] ** 3
@@ -385,7 +385,12 @@ def gala_to_agama_potential(potential):
 
     import agama
 
-    agama.setUnits(**{k: potential.units[k] for k in ["length", "mass", "time"]})
+    units = {
+        "length": (1 * potential.units["length"]).to(u.kpc).value,
+        "mass": (1 * potential.units["mass"]).to(u.Msun).value,
+        "time": (1 * potential.units["time"]).to(u.Myr).value,
+    }
+    agama.setUnits(**units)
 
     if isinstance(potential, CompositePotential):
         pot = []


### PR DESCRIPTION
### Describe your changes

With a recent version of Agama (1.0.51), `agama.setUnits` appears to not work anymore with `astropy.units.Unit` objects passed in. It's simpler to pass in float values anyway, so we use that interface instead.

### Checklist

* [ ] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [ ] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [ ] Is the milestone set?
