### PR TITLE
Update mockstreams.rst

### DIFF
--- a/docs/dynamics/mockstreams.rst
+++ b/docs/dynamics/mockstreams.rst
@@ -207,7 +207,7 @@ earliest time, then a stream is generated forward from the past time. This is pa
     >>> gen_pal5 = ms.MockStreamGenerator(df, mw, progenitor_potential=pal5_pot)
     >>> pal5_stream, _ = gen_pal5.run(pal5_w0, pal5_mass,
     ...                               dt=-1 * u.Myr, n_steps=4000)
-    >>> pal5_stream_c = pal5_stream.to_coord_frame(coord.ICRS)
+    >>> pal5_stream_c = pal5_stream.to_coord_frame(coord.ICRS())
 
 .. plot::
     :align: center
@@ -228,7 +228,7 @@ earliest time, then a stream is generated forward from the past time. This is pa
     gen_pal5 = ms.MockStreamGenerator(df, mw, progenitor_potential=pal5_pot)
     pal5_stream, _ = gen_pal5.run(pal5_w0, pal5_mass,
                                   dt=-1 * u.Myr, n_steps=4000)
-    pal5_stream_c = pal5_stream.to_coord_frame(coord.ICRS)
+    pal5_stream_c = pal5_stream.to_coord_frame(coord.ICRS())
 
     fig, ax = plt.subplots(1, 1, figsize=(6, 4))
     ax.scatter(pal5_stream_c.ra.degree, pal5_stream_c.dec.degree,


### PR DESCRIPTION
Hi, 

I've updated the mocks stream generation page to run with modern astropy, but replacing  ICRS by ICRS()
Otherwise users will get:
```
ConvertError: Cannot transform from <class 'astropy.coordinates.builtin_frames.galactocentric.Galactocentric'> to <class 'abc.ABCMeta'>
```

     S
