### PR TITLE
Add short circuit for C potential evaluation when position does not require a shift/rotation

### DIFF
--- a/gala/potential/potential/ccompositepotential.pyx
+++ b/gala/potential/potential/ccompositepotential.pyx
@@ -44,6 +44,7 @@ cdef class CCompositePotentialWrapper(CPotentialWrapper):
         for i in range(n_components):
             self._n_params[i] = _cpotential_arr[i]._n_params[0]
             self.cpotential.n_params[i] = self._n_params[i]
+            self.cpotential.do_shift_rotate[i] = _cpotential_arr[i].do_shift_rotate[0]
 
         self.cpotential.n_dim = 0
 

--- a/gala/potential/potential/ccompositepotential.pyx
+++ b/gala/potential/potential/ccompositepotential.pyx
@@ -44,7 +44,7 @@ cdef class CCompositePotentialWrapper(CPotentialWrapper):
         for i in range(n_components):
             self._n_params[i] = _cpotential_arr[i]._n_params[0]
             self.cpotential.n_params[i] = self._n_params[i]
-            self.cpotential.do_shift_rotate[i] = _cpotential_arr[i].do_shift_rotate[0]
+            self.cpotential.do_shift_rotate[i] = _cpotential_arr[i].cpotential.do_shift_rotate[0]
 
         self.cpotential.n_dim = 0
 

--- a/gala/potential/potential/cpotential.pxd
+++ b/gala/potential/potential/cpotential.pxd
@@ -15,7 +15,7 @@ cdef extern from "potential/src/cpotential.h":
         int n_components      # number of potential components
         int n_dim             # coordinate system dimensionality
         int null              # shortcut flag to skip evaluation
-        int do_shift_rotate   # shortcut flag to skip pos/vel transformation
+        int* do_shift_rotate   # shortcut flag to skip pos/vel transformation
         densityfunc* density
         energyfunc* value
         gradientfunc* gradient

--- a/gala/potential/potential/cpotential.pxd
+++ b/gala/potential/potential/cpotential.pxd
@@ -15,6 +15,7 @@ cdef extern from "potential/src/cpotential.h":
         int n_components      # number of potential components
         int n_dim             # coordinate system dimensionality
         int null              # shortcut flag to skip evaluation
+        int do_shift_rotate   # shortcut flag to skip pos/vel transformation
         densityfunc* density
         energyfunc* value
         gradientfunc* gradient

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -88,8 +88,13 @@ cdef class CPotentialWrapper:
         self.cpotential.q0[0] = &(self._q0[0])
 
         # set the rotation matrix of the potentials
-        self._R = np.ascontiguousarray(np.array(R).ravel())
+        R = np.array(R)
+        self._R = np.ascontiguousarray(R.ravel())
         self.cpotential.R[0] = &(self._R[0])
+
+        # set a short-circuit flag if no shift/rotate is necessary
+        if np.all(q0 == 0.0) and np.all(R == np.eye(ndim)):
+            self.cpotential.do_shift_rotate = 0
 
     cpdef energy(self, double[:, ::1] q, double[::1] t):
         """

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -83,18 +83,21 @@ cdef class CPotentialWrapper:
         self.cpotential.hessian[0] = <hessianfunc>(nan_hessian)
 
         # set the origin of the potentials
-        self._q0 = np.array(q0)
+        _q0 = np.array(q0)
+        self._q0 = _q0
         assert len(self._q0) == n_dim
         self.cpotential.q0[0] = &(self._q0[0])
 
         # set the rotation matrix of the potentials
-        R = np.array(R)
-        self._R = np.ascontiguousarray(R.ravel())
+        _R = np.array(R)
+        self._R = np.ascontiguousarray(_R.ravel())
         self.cpotential.R[0] = &(self._R[0])
 
         # set a short-circuit flag if no shift/rotate is necessary
-        if np.all(q0 == 0.0) and np.all(R == np.eye(ndim)):
-            self.cpotential.do_shift_rotate = 0
+        if np.all(_q0 == 0.0) and np.all(_R == np.eye(n_dim)):
+            self.cpotential.do_shift_rotate[0] = 0
+        else:
+            self.cpotential.do_shift_rotate[0] = 1
 
     cpdef energy(self, double[:, ::1] q, double[::1] t):
         """

--- a/gala/potential/potential/src/cpotential.c
+++ b/gala/potential/potential/src/cpotential.c
@@ -300,8 +300,10 @@ void c_nbody_acceleration(CPotential **pots, double t, double *qp,
         if ((body_pot->null) == 1)
             continue;
 
-        for (i=0; i < body_pot->n_components; i++)
+        for (i=0; i < body_pot->n_components; i++) {
+            (body_pot->do_shift_rotate)[i] = 1;
             (body_pot->q0)[i] = &qp[j * ps_ndim];
+        }
 
         for (i=0; i < norbits; i++) {
             if (i != j) {
@@ -330,6 +332,7 @@ void c_nbody_gradient_symplectic(
             continue;
 
         for (i=0; i < body_pot->n_components; i++) {
+            (body_pot->do_shift_rotate)[i] = 1;
             (body_pot->q0)[i] = &nbody_w[j * 2 * ndim]; // p-s ndim
         }
 

--- a/gala/potential/potential/src/cpotential.c
+++ b/gala/potential/potential/src/cpotential.c
@@ -8,6 +8,7 @@ CPotential* allocate_cpotential(int n_components) {
     p->n_components = n_components;
     p->n_dim = 0;
     p->null = 0;
+    p->do_shift_rotate = 1;  // by default, do shift and rotate
 
     // Allocate arrays
     p->density = (densityfunc*)malloc(n_components * sizeof(densityfunc));

--- a/gala/potential/potential/src/cpotential.c
+++ b/gala/potential/potential/src/cpotential.c
@@ -8,7 +8,6 @@ CPotential* allocate_cpotential(int n_components) {
     p->n_components = n_components;
     p->n_dim = 0;
     p->null = 0;
-    p->do_shift_rotate = 1;  // by default, do shift and rotate
 
     // Allocate arrays
     p->density = (densityfunc*)malloc(n_components * sizeof(densityfunc));
@@ -19,6 +18,7 @@ CPotential* allocate_cpotential(int n_components) {
     p->parameters = (double**)malloc(n_components * sizeof(double*));
     p->q0 = (double**)malloc(n_components * sizeof(double*));
     p->R = (double**)malloc(n_components * sizeof(double*));
+    p->do_shift_rotate = (int*)malloc(n_components * sizeof(int));
 
     // Initialize with NULL pointers
     for (int i = 0; i < n_components; i++) {
@@ -41,6 +41,7 @@ void free_cpotential(CPotential* p) {
     free(p->parameters); // Note: doesn't free the actual parameter arrays
     free(p->q0);         // Note: doesn't free the actual q0 arrays
     free(p->R);          // Note: doesn't free the actual R arrays
+    free(p->do_shift_rotate);
     free(p);
 }
 
@@ -58,6 +59,7 @@ int resize_cpotential_arrays(CPotential* pot, int new_n_components) {
     pot->parameters = realloc(pot->parameters, new_n_components * sizeof(double*));
     pot->q0 = realloc(pot->q0, new_n_components * sizeof(double*));
     pot->R = realloc(pot->R, new_n_components * sizeof(double*));
+    pot->do_shift_rotate = realloc(pot->do_shift_rotate, new_n_components * sizeof(int));
 
     // Initialize new elements
     for (int i = pot->n_components; i < new_n_components; i++) {
@@ -119,6 +121,7 @@ double c_potential(CPotential *p, double t, double *qp) {
     double qp_trans[p->n_dim];
 
     for (i=0; i < p->n_components; i++) {
+        // TODO
         for (j=0; j < p->n_dim; j++)
             qp_trans[j] = 0.;
         apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, 0,
@@ -136,6 +139,7 @@ double c_density(CPotential *p, double t, double *qp) {
     double qp_trans[p->n_dim];
 
     for (i=0; i < p->n_components; i++) {
+        // TODO
         for (j=0; j < p->n_dim; j++)
             qp_trans[j] = 0.;
         apply_shift_rotate(qp, (p->q0)[i], (p->R)[i], p->n_dim, 0,
@@ -157,6 +161,7 @@ void c_gradient(CPotential *p, double t, double *qp, double *grad) {
         tmp_grad[i] = 0.;
         qp_trans[i] = 0.;
     }
+    // TODO
 
     for (i=0; i < p->n_components; i++) {
         for (j=0; j < p->n_dim; j++) {
@@ -176,6 +181,8 @@ void c_gradient(CPotential *p, double t, double *qp, double *grad) {
 void c_hessian(CPotential *p, double t, double *qp, double *hess) {
     int i;
     double qp_trans[p->n_dim];
+
+    // TODO
 
     for (i=0; i < pow(p->n_dim,2); i++) {
         hess[i] = 0.;

--- a/gala/potential/potential/src/cpotential.h
+++ b/gala/potential/potential/src/cpotential.h
@@ -8,7 +8,7 @@
         int n_components; // number of potential components
         int n_dim; // coordinate system dimensionality
         int null; // short circuit: if null, can skip evaluation
-        int do_shift_rotate; // short circuit: if 0, skip transforming pos/vel
+        int* do_shift_rotate; // short circuit: if 0, skip transforming pos/vel
 
         // arrays of pointers to each of the function types above
         densityfunc* density;

--- a/gala/potential/potential/src/cpotential.h
+++ b/gala/potential/potential/src/cpotential.h
@@ -7,7 +7,8 @@
     struct _CPotential {
         int n_components; // number of potential components
         int n_dim; // coordinate system dimensionality
-        int null; // a short circuit: if null, can skip evaluation
+        int null; // short circuit: if null, can skip evaluation
+        int do_shift_rotate; // short circuit: if 0, skip transforming pos/vel
 
         // arrays of pointers to each of the function types above
         densityfunc* density;

--- a/gala/potential/potential/tests/test_all_builtin.py
+++ b/gala/potential/potential/tests/test_all_builtin.py
@@ -1,24 +1,26 @@
 """
-    Test the builtin CPotential classes
+Test the builtin CPotential classes
 """
 
 # Third-party
-import numpy as np
 import astropy.table as at
 import astropy.units as u
-from astropy.utils.data import get_pkg_data_filename
+import numpy as np
 import pytest
+from astropy.utils.data import get_pkg_data_filename
 from scipy.spatial.transform import Rotation
+
+from gala._cconfig import GSL_ENABLED
+from gala.tests.optional_deps import HAS_SYMPY
+
+from ....units import DimensionlessUnitSystem, galactic, solarsystem
+from ...frame import ConstantRotatingFrame
+from .. import builtin as p
+from ..ccompositepotential import CCompositePotential
 
 # This project
 from ..core import CompositePotential
-from ..ccompositepotential import CCompositePotential
-from .. import builtin as p
-from ...frame import ConstantRotatingFrame
-from ....units import solarsystem, galactic, DimensionlessUnitSystem
-from .helpers import PotentialTestBase, CompositePotentialTestBase
-from gala._cconfig import GSL_ENABLED
-from gala.tests.optional_deps import HAS_SYMPY
+from .helpers import CompositePotentialTestBase, PotentialTestBase
 
 ##############################################################################
 # Python
@@ -26,8 +28,8 @@ from gala.tests.optional_deps import HAS_SYMPY
 
 
 class TestHarmonicOscillator1D(PotentialTestBase):
-    potential = p.HarmonicOscillatorPotential(omega=1.)
-    w0 = [1., 0.1]
+    potential = p.HarmonicOscillatorPotential(omega=1.0)
+    w0 = [1.0, 0.1]
     sympy_density = False
     check_finite_at_origin = False
 
@@ -37,8 +39,8 @@ class TestHarmonicOscillator1D(PotentialTestBase):
 
 
 class TestHarmonicOscillator2D(PotentialTestBase):
-    potential = p.HarmonicOscillatorPotential(omega=[1., 2])
-    w0 = [1., 0.5, 0., 0.1]
+    potential = p.HarmonicOscillatorPotential(omega=[1.0, 2])
+    w0 = [1.0, 0.5, 0.0, 0.1]
     sympy_density = False
     check_finite_at_origin = False
 
@@ -50,6 +52,7 @@ class TestHarmonicOscillator2D(PotentialTestBase):
     def test_against_sympy(self):
         pass
 
+
 ##############################################################################
 # Cython
 ##############################################################################
@@ -57,34 +60,41 @@ class TestHarmonicOscillator2D(PotentialTestBase):
 
 class TestNull(PotentialTestBase):
     potential = p.NullPotential()
-    w0 = [1., 0., 0., 0., 2*np.pi, 0.]
+    w0 = [1.0, 0.0, 0.0, 0.0, 2 * np.pi, 0.0]
 
     def test_mass_enclosed(self):
         for arr, shp in zip(self.w0s, self._valu_return_shapes):
-            g = self.potential.mass_enclosed(arr[:self.ndim])
+            g = self.potential.mass_enclosed(arr[: self.ndim])
             assert g.shape == shp
-            assert np.all(g == 0.)
+            assert np.all(g == 0.0)
 
-            g = self.potential.mass_enclosed(arr[:self.ndim], t=0.1)
-            g = self.potential.mass_enclosed(arr[:self.ndim], t=0.1*self.potential.units['time'])
+            g = self.potential.mass_enclosed(arr[: self.ndim], t=0.1)
+            g = self.potential.mass_enclosed(
+                arr[: self.ndim], t=0.1 * self.potential.units["time"]
+            )
 
             t = np.zeros(np.array(arr).shape[1:]) + 0.1
-            g = self.potential.mass_enclosed(arr[:self.ndim], t=t)
-            g = self.potential.mass_enclosed(arr[:self.ndim], t=t*self.potential.units['time'])
+            g = self.potential.mass_enclosed(arr[: self.ndim], t=t)
+            g = self.potential.mass_enclosed(
+                arr[: self.ndim], t=t * self.potential.units["time"]
+            )
 
     def test_circular_velocity(self):
         for arr, shp in zip(self.w0s, self._valu_return_shapes):
-            g = self.potential.circular_velocity(arr[:self.ndim])
+            g = self.potential.circular_velocity(arr[: self.ndim])
             assert g.shape == shp
-            assert np.all(g == 0.)
+            assert np.all(g == 0.0)
 
-            g = self.potential.circular_velocity(arr[:self.ndim], t=0.1)
-            g = self.potential.circular_velocity(arr[:self.ndim],
-                                                 t=0.1*self.potential.units['time'])
+            g = self.potential.circular_velocity(arr[: self.ndim], t=0.1)
+            g = self.potential.circular_velocity(
+                arr[: self.ndim], t=0.1 * self.potential.units["time"]
+            )
 
             t = np.zeros(np.array(arr).shape[1:]) + 0.1
-            g = self.potential.circular_velocity(arr[:self.ndim], t=t)
-            g = self.potential.circular_velocity(arr[:self.ndim], t=t*self.potential.units['time'])
+            g = self.potential.circular_velocity(arr[: self.ndim], t=t)
+            g = self.potential.circular_velocity(
+                arr[: self.ndim], t=t * self.potential.units["time"]
+            )
 
     @pytest.mark.skip(reason="Nothing to compare to for Null potential!")
     def test_against_sympy(self):
@@ -93,7 +103,7 @@ class TestNull(PotentialTestBase):
 
 class TestHenonHeiles(PotentialTestBase):
     potential = p.HenonHeilesPotential()
-    w0 = [1., 0., 0., 2*np.pi]
+    w0 = [1.0, 0.0, 0.0, 2 * np.pi]
     sympy_density = False
     check_finite_at_origin = False
 
@@ -103,64 +113,62 @@ class TestHenonHeiles(PotentialTestBase):
 
 
 class TestKepler(PotentialTestBase):
-    potential = p.KeplerPotential(units=solarsystem, m=1.)
-    w0 = [1., 0., 0., 0., 2*np.pi, 0.]
+    potential = p.KeplerPotential(units=solarsystem, m=1.0)
+    w0 = [1.0, 0.0, 0.0, 0.0, 2 * np.pi, 0.0]
     # show_plots = True
     check_finite_at_origin = False
 
 
 class TestKeplerUnitInput(PotentialTestBase):
-    potential = p.KeplerPotential(units=solarsystem, m=(1*u.Msun).to(u.Mjup))
-    w0 = [1., 0., 0., 0., 2*np.pi, 0.]
+    potential = p.KeplerPotential(units=solarsystem, m=(1 * u.Msun).to(u.Mjup))
+    w0 = [1.0, 0.0, 0.0, 0.0, 2 * np.pi, 0.0]
     check_finite_at_origin = False
 
 
 class TestIsochrone(PotentialTestBase):
-    potential = p.IsochronePotential(units=solarsystem, m=1., b=0.1)
-    w0 = [1., 0., 0., 0., 2*np.pi, 0.]
+    potential = p.IsochronePotential(units=solarsystem, m=1.0, b=0.1)
+    w0 = [1.0, 0.0, 0.0, 0.0, 2 * np.pi, 0.0]
 
 
 class TestIsochroneDimensionless(PotentialTestBase):
-    potential = p.IsochronePotential(units=DimensionlessUnitSystem(),
-                                     m=1., b=0.1)
-    w0 = [1., 0., 0., 0., 2*np.pi, 0.]
+    potential = p.IsochronePotential(units=DimensionlessUnitSystem(), m=1.0, b=0.1)
+    w0 = [1.0, 0.0, 0.0, 0.0, 2 * np.pi, 0.0]
 
 
 class TestHernquist(PotentialTestBase):
-    potential = p.HernquistPotential(units=galactic, m=1.E11, c=0.26)
-    w0 = [1., 0., 0., 0., 0.1, 0.1]
+    potential = p.HernquistPotential(units=galactic, m=1.0e11, c=0.26)
+    w0 = [1.0, 0.0, 0.0, 0.0, 0.1, 0.1]
 
 
 class TestPlummer(PotentialTestBase):
-    potential = p.PlummerPotential(units=galactic, m=1.E11, b=0.26)
-    w0 = [1., 0., 0., 0., 0.1, 0.1]
+    potential = p.PlummerPotential(units=galactic, m=1.0e11, b=0.26)
+    w0 = [1.0, 0.0, 0.0, 0.0, 0.1, 0.1]
 
 
 class TestJaffe(PotentialTestBase):
     check_finite_at_origin = False
-    potential = p.JaffePotential(units=galactic, m=1.E11, c=0.26)
-    w0 = [1., 0., 0., 0., 0.1, 0.1]
+    potential = p.JaffePotential(units=galactic, m=1.0e11, c=0.26)
+    w0 = [1.0, 0.0, 0.0, 0.0, 0.1, 0.1]
 
 
 class TestMiyamotoNagai(PotentialTestBase):
-    potential = p.MiyamotoNagaiPotential(units=galactic, m=1.E11, a=6.5, b=0.26)
-    w0 = [8., 0., 0., 0., 0.22, 0.1]
+    potential = p.MiyamotoNagaiPotential(units=galactic, m=1.0e11, a=6.5, b=0.26)
+    w0 = [8.0, 0.0, 0.0, 0.0, 0.22, 0.1]
     rotation = True
 
-    @pytest.mark.skipif(not HAS_SYMPY,
-                        reason="requires sympy to run this test")
+    @pytest.mark.skipif(not HAS_SYMPY, reason="requires sympy to run this test")
     def test_hessian_analytic(self):
+        import sympy as sy
         from astropy.constants import G
         from sympy import symbols
-        import sympy as sy
 
-        x, y, z = symbols('x y z')
+        x, y, z = symbols("x y z")
 
         usys = self.potential.units
-        GM = (G * self.potential.parameters['m']).decompose(usys).value
-        a = self.potential.parameters['a'].decompose(usys).value
-        b = self.potential.parameters['b'].decompose(usys).value
-        Phi = -GM / sy.sqrt(x**2 + y**2 + (a + sy.sqrt(z**2 + b**2))**2)
+        GM = (G * self.potential.parameters["m"]).decompose(usys).value
+        a = self.potential.parameters["a"].decompose(usys).value
+        b = self.potential.parameters["b"].decompose(usys).value
+        Phi = -GM / sy.sqrt(x**2 + y**2 + (a + sy.sqrt(z**2 + b**2)) ** 2)
 
         d2Phi_dx2 = sy.lambdify((x, y, z), sy.diff(Phi, x, 2))
         d2Phi_dy2 = sy.lambdify((x, y, z), sy.diff(Phi, y, 2))
@@ -189,9 +197,9 @@ class TestMiyamotoNagai(PotentialTestBase):
 
 class TestMN3(PotentialTestBase):
     potential = p.MN3ExponentialDiskPotential(
-        units=galactic, m=1.E11, h_R=3.5, h_z=0.26
+        units=galactic, m=1.0e11, h_R=3.5, h_z=0.26
     )
-    w0 = [8., 0., 0., 0., 0.22, 0.1]
+    w0 = [8.0, 0.0, 0.0, 0.0, 0.22, 0.1]
     rotation = True
 
     # TODO:
@@ -205,45 +213,45 @@ class TestMN3(PotentialTestBase):
 
 
 class TestSatoh(PotentialTestBase):
-    potential = p.SatohPotential(units=galactic, m=1.E11, a=6.5, b=0.26)
-    w0 = [8., 0., 0., 0., 0.22, 0.1]
+    potential = p.SatohPotential(units=galactic, m=1.0e11, a=6.5, b=0.26)
+    w0 = [8.0, 0.0, 0.0, 0.0, 0.22, 0.1]
     rotation = True
 
 
 class TestKuzmin(PotentialTestBase):
-    potential = p.KuzminPotential(units=galactic, m=1.E11, a=3.5)
-    w0 = [8., 0., 0., 0., 0.22, 0.1]
+    potential = p.KuzminPotential(units=galactic, m=1.0e11, a=3.5)
+    w0 = [8.0, 0.0, 0.0, 0.0, 0.22, 0.1]
     sympy_hessian = False
     sympy_density = False
     rotation = True
 
 
 class TestStone(PotentialTestBase):
-    potential = p.StonePotential(units=galactic, m=1E11, r_c=0.1, r_h=10.)
-    w0 = [8., 0., 0., 0., 0.18, 0.1]
+    potential = p.StonePotential(units=galactic, m=1e11, r_c=0.1, r_h=10.0)
+    w0 = [8.0, 0.0, 0.0, 0.0, 0.18, 0.1]
 
 
-@pytest.mark.skipif(not GSL_ENABLED,
-                    reason="requires GSL to run this test")
+@pytest.mark.skipif(not GSL_ENABLED, reason="requires GSL to run this test")
 class TestPowerLawCutoff(PotentialTestBase):
-    w0 = [8., 0., 0., 0., 0.1, 0.1]
+    w0 = [8.0, 0.0, 0.0, 0.0, 0.1, 0.1]
     atol = 1e-3
     sympy_density = False  # weird underflow issues??
     check_finite_at_origin = False
 
     def setup_method(self):
-        self.potential = p.PowerLawCutoffPotential(units=galactic,
-                                                   m=1E10, r_c=1., alpha=1.8)
+        self.potential = p.PowerLawCutoffPotential(
+            units=galactic, m=1e10, r_c=1.0, alpha=1.8
+        )
         super().setup_method()
 
 
 class TestSphericalNFW(PotentialTestBase):
-    potential = p.NFWPotential(units=galactic, m=1E11, r_s=12.)
+    potential = p.NFWPotential(units=galactic, m=1e11, r_s=12.0)
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
 
 
 class TestFlattenedNFW(PotentialTestBase):
-    potential = p.NFWPotential(units=galactic, m=1E11, r_s=12., c=0.7)
+    potential = p.NFWPotential(units=galactic, m=1e11, r_s=12.0, c=0.7)
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
     sympy_density = False  # not defined
     rotation = True
@@ -253,14 +261,14 @@ class TestFlattenedNFW(PotentialTestBase):
         Note: This is a regression test for Issue #254
         """
 
-        sph = p.NFWPotential(units=galactic, m=1E11, r_s=12.)
-        assert not u.allclose(self.potential.gradient(self.w0[:3]),
-                              sph.gradient(self.w0[:3]))
+        sph = p.NFWPotential(units=galactic, m=1e11, r_s=12.0)
+        assert not u.allclose(
+            self.potential.gradient(self.w0[:3]), sph.gradient(self.w0[:3])
+        )
 
 
 class TestTriaxialNFW(PotentialTestBase):
-    potential = p.NFWPotential(units=galactic, m=1E11, r_s=12.,
-                               a=1., b=0.95, c=0.9)
+    potential = p.NFWPotential(units=galactic, m=1e11, r_s=12.0, a=1.0, b=0.95, c=0.9)
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
     sympy_density = False  # not defined
     rotation = True
@@ -268,27 +276,33 @@ class TestTriaxialNFW(PotentialTestBase):
 
 class TestSphericalNFWFromCircVel(PotentialTestBase):
     potential = p.NFWPotential.from_circular_velocity(
-        v_c=220.*u.km/u.s,
-        r_s=20*u.kpc,
-        r_ref=8.*u.kpc,
-        units=galactic)
+        v_c=220.0 * u.km / u.s, r_s=20 * u.kpc, r_ref=8.0 * u.kpc, units=galactic
+    )
     w0 = [19.0, 2.7, -0.9, 0.00352238, -0.165134, 0.0075]
 
     def test_circ_vel(self):
-        for r_ref in [3., 8., 21.7234]:
+        for r_ref in [3.0, 8.0, 21.7234]:
             pot = p.NFWPotential.from_circular_velocity(
-                v_c=220.*u.km/u.s, r_s=20*u.kpc,
-                r_ref=r_ref*u.kpc, units=galactic)
-            vc = pot.circular_velocity([r_ref, 0, 0]*u.kpc)  # at ref. velocity
-            assert u.allclose(vc, 220*u.km/u.s)
+                v_c=220.0 * u.km / u.s,
+                r_s=20 * u.kpc,
+                r_ref=r_ref * u.kpc,
+                units=galactic,
+            )
+            vc = pot.circular_velocity([r_ref, 0, 0] * u.kpc)  # at ref. velocity
+            assert u.allclose(vc, 220 * u.km / u.s)
 
     def test_against_triaxial(self):
         this = p.NFWPotential.from_circular_velocity(
-            v_c=220.*u.km/u.s, r_s=20*u.kpc, units=galactic)
+            v_c=220.0 * u.km / u.s, r_s=20 * u.kpc, units=galactic
+        )
         other = p.LeeSutoTriaxialNFWPotential(
             units=galactic,
-            v_c=220.*u.km/u.s, r_s=20.*u.kpc,
-            a=1., b=1., c=1.)
+            v_c=220.0 * u.km / u.s,
+            r_s=20.0 * u.kpc,
+            a=1.0,
+            b=1.0,
+            c=1.0,
+        )
 
         v1 = this.energy(self.w0[:3])
         v2 = other.energy(self.w0[:3])
@@ -305,34 +319,37 @@ class TestSphericalNFWFromCircVel(PotentialTestBase):
     def test_mass_enclosed(self):
 
         # true mass profile
-        m = self.potential.parameters['m'].value
-        rs = self.potential.parameters['r_s'].value
+        m = self.potential.parameters["m"].value
+        rs = self.potential.parameters["r_s"].value
 
-        r = np.linspace(1., 400, 100)
-        fac = np.log(1 + r/rs) - (r/rs) / (1 + (r/rs))
+        r = np.linspace(1.0, 400, 100)
+        fac = np.log(1 + r / rs) - (r / rs) / (1 + (r / rs))
         true_mprof = m * fac
 
         R = np.zeros((3, len(r)))
         R[0, :] = r
         esti_mprof = self.potential.mass_enclosed(R)
 
-        assert np.allclose(true_mprof, esti_mprof.value, rtol=1E-6)
+        assert np.allclose(true_mprof, esti_mprof.value, rtol=1e-6)
 
 
 class TestNFW(PotentialTestBase):
-    potential = p.NFWPotential(m=6E11*u.Msun, r_s=20*u.kpc, a=1., b=0.9, c=0.75,
-                               units=galactic)
+    potential = p.NFWPotential(
+        m=6e11 * u.Msun, r_s=20 * u.kpc, a=1.0, b=0.9, c=0.75, units=galactic
+    )
     w0 = [19.0, 2.7, -0.9, 0.00352238, -0.15134, 0.0075]
     sympy_density = False  # like triaxial case
 
     def test_compare(self):
 
-        sph = p.NFWPotential(m=6E11*u.Msun, r_s=20*u.kpc, units=galactic)
-        fla = p.NFWPotential(m=6E11*u.Msun, r_s=20*u.kpc, c=0.8, units=galactic)
-        tri = p.NFWPotential(m=6E11*u.Msun, r_s=20*u.kpc, b=0.9, c=0.8, units=galactic)
+        sph = p.NFWPotential(m=6e11 * u.Msun, r_s=20 * u.kpc, units=galactic)
+        fla = p.NFWPotential(m=6e11 * u.Msun, r_s=20 * u.kpc, c=0.8, units=galactic)
+        tri = p.NFWPotential(
+            m=6e11 * u.Msun, r_s=20 * u.kpc, b=0.9, c=0.8, units=galactic
+        )
 
         xyz = np.zeros((3, 128))
-        xyz[0] = np.logspace(-1., 3, xyz.shape[1])
+        xyz[0] = np.logspace(-1.0, 3, xyz.shape[1])
 
         assert u.allclose(sph.energy(xyz), fla.energy(xyz))
         assert u.allclose(sph.energy(xyz), tri.energy(xyz))
@@ -345,10 +362,12 @@ class TestNFW(PotentialTestBase):
 
         # ---
 
-        tri = p.NFWPotential(m=6E11*u.Msun, r_s=20*u.kpc, a=0.9, c=0.8, units=galactic)
+        tri = p.NFWPotential(
+            m=6e11 * u.Msun, r_s=20 * u.kpc, a=0.9, c=0.8, units=galactic
+        )
 
         xyz = np.zeros((3, 128))
-        xyz[1] = np.logspace(-1., 3, xyz.shape[1])
+        xyz[1] = np.logspace(-1.0, 3, xyz.shape[1])
 
         assert u.allclose(sph.energy(xyz), fla.energy(xyz))
         assert u.allclose(sph.energy(xyz), tri.energy(xyz))
@@ -362,16 +381,17 @@ class TestNFW(PotentialTestBase):
         # ---
 
         xyz = np.zeros((3, 128))
-        xyz[0] = np.logspace(-1., 3, xyz.shape[1])
-        xyz[1] = np.logspace(-1., 3, xyz.shape[1])
+        xyz[0] = np.logspace(-1.0, 3, xyz.shape[1])
+        xyz[1] = np.logspace(-1.0, 3, xyz.shape[1])
 
         assert u.allclose(sph.energy(xyz), fla.energy(xyz))
         assert u.allclose(sph.gradient(xyz), fla.gradient(xyz))
 
 
 class TestLeeSutoTriaxialNFW(PotentialTestBase):
-    potential = p.LeeSutoTriaxialNFWPotential(units=galactic, v_c=0.35, r_s=12.,
-                                              a=1.3, b=1., c=0.8)
+    potential = p.LeeSutoTriaxialNFWPotential(
+        units=galactic, v_c=0.35, r_s=12.0, a=1.3, b=1.0, c=0.8
+    )
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
     rotation = True
 
@@ -381,33 +401,43 @@ class TestLeeSutoTriaxialNFW(PotentialTestBase):
 
 
 class TestLogarithmic(PotentialTestBase):
-    potential = p.LogarithmicPotential(units=galactic, v_c=0.17, r_h=10.,
-                                       q1=1.2, q2=1., q3=0.8)
+    potential = p.LogarithmicPotential(
+        units=galactic, v_c=0.17, r_h=10.0, q1=1.2, q2=1.0, q3=0.8
+    )
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
 
 
 class TestLongMuraliBar(PotentialTestBase):
-    potential = p.LongMuraliBarPotential(units=galactic, m=1E11,
-                                         a=4.*u.kpc, b=1*u.kpc, c=1.*u.kpc)
-    vc = potential.circular_velocity([19., 0, 0]*u.kpc).decompose(galactic).value[0]
-    w0 = [19.0, 0.2, -0.9, 0., vc, 0.]
+    potential = p.LongMuraliBarPotential(
+        units=galactic, m=1e11, a=4.0 * u.kpc, b=1 * u.kpc, c=1.0 * u.kpc
+    )
+    vc = potential.circular_velocity([19.0, 0, 0] * u.kpc).decompose(galactic).value[0]
+    w0 = [19.0, 0.2, -0.9, 0.0, vc, 0.0]
     rotation = True
 
 
 class TestLongMuraliBarRotate(PotentialTestBase):
     potential = p.LongMuraliBarPotential(
-        units=galactic, m=1E11,
-        a=4.*u.kpc, b=1*u.kpc, c=1.*u.kpc,
-        R=np.array([[0.63302222, 0.75440651, 0.17364818],
-                    [-0.76604444, 0.64278761, 0.],
-                    [-0.1116189, -0.13302222, 0.98480775]]))
-    vc = potential.circular_velocity([19., 0, 0]*u.kpc).decompose(galactic).value[0]
-    w0 = [19.0, 0.2, -0.9, 0., vc, 0.]
+        units=galactic,
+        m=1e11,
+        a=4.0 * u.kpc,
+        b=1 * u.kpc,
+        c=1.0 * u.kpc,
+        R=np.array(
+            [
+                [0.63302222, 0.75440651, 0.17364818],
+                [-0.76604444, 0.64278761, 0.0],
+                [-0.1116189, -0.13302222, 0.98480775],
+            ]
+        ),
+    )
+    vc = potential.circular_velocity([19.0, 0, 0] * u.kpc).decompose(galactic).value[0]
+    w0 = [19.0, 0.2, -0.9, 0.0, vc, 0.0]
 
     def test_hessian(self):
         # TODO: when hessian for rotated potentials implemented, remove this
         with pytest.raises(NotImplementedError):
-            self.potential.hessian([1., 2., 3.])
+            self.potential.hessian([1.0, 2.0, 3.0])
 
     @pytest.mark.skip(reason="Not implemented for rotated potentials")
     def test_against_sympy(self):
@@ -416,16 +446,20 @@ class TestLongMuraliBarRotate(PotentialTestBase):
 
 class TestLongMuraliBarRotationScipy(PotentialTestBase):
     potential = p.LongMuraliBarPotential(
-        units=galactic, m=1E11,
-        a=4.*u.kpc, b=1*u.kpc, c=1.*u.kpc,
-        R=Rotation.from_euler('zxz', [90., 0, 0.], degrees=True))
-    vc = potential.circular_velocity([19., 0, 0]*u.kpc).decompose(galactic).value[0]
-    w0 = [19.0, 0.2, -0.9, 0., vc, 0.]
+        units=galactic,
+        m=1e11,
+        a=4.0 * u.kpc,
+        b=1 * u.kpc,
+        c=1.0 * u.kpc,
+        R=Rotation.from_euler("zxz", [90.0, 0, 0.0], degrees=True),
+    )
+    vc = potential.circular_velocity([19.0, 0, 0] * u.kpc).decompose(galactic).value[0]
+    w0 = [19.0, 0.2, -0.9, 0.0, vc, 0.0]
 
     def test_hessian(self):
         # TODO: when hessian for rotated potentials implemented, remove this
         with pytest.raises(NotImplementedError):
-            self.potential.hessian([1., 2., 3.])
+            self.potential.hessian([1.0, 2.0, 3.0])
 
     @pytest.mark.skip(reason="Not implemented for rotated potentials")
     def test_against_sympy(self):
@@ -433,56 +467,54 @@ class TestLongMuraliBarRotationScipy(PotentialTestBase):
 
 
 class TestComposite(CompositePotentialTestBase):
-    p1 = p.LogarithmicPotential(units=galactic,
-                                v_c=0.17, r_h=10.,
-                                q1=1.2, q2=1., q3=0.8)
-    p2 = p.MiyamotoNagaiPotential(units=galactic,
-                                  m=1.E11, a=6.5, b=0.26)
+    p1 = p.LogarithmicPotential(
+        units=galactic, v_c=0.17, r_h=10.0, q1=1.2, q2=1.0, q3=0.8
+    )
+    p2 = p.MiyamotoNagaiPotential(units=galactic, m=1.0e11, a=6.5, b=0.26)
     potential = CompositePotential()
-    potential['disk'] = p2
-    potential['halo'] = p1
+    potential["disk"] = p2
+    potential["halo"] = p1
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
     rotation = True
 
 
 class TestCComposite(CompositePotentialTestBase):
-    p1 = p.LogarithmicPotential(units=galactic,
-                                v_c=0.17, r_h=10.,
-                                q1=1.2, q2=1., q3=0.8)
-    p2 = p.MiyamotoNagaiPotential(units=galactic,
-                                  m=1.E11, a=6.5, b=0.26)
+    p1 = p.LogarithmicPotential(
+        units=galactic, v_c=0.17, r_h=10.0, q1=1.2, q2=1.0, q3=0.8
+    )
+    p2 = p.MiyamotoNagaiPotential(units=galactic, m=1.0e11, a=6.5, b=0.26)
     potential = CCompositePotential()
-    potential['disk'] = p2
-    potential['halo'] = p1
+    potential["disk"] = p2
+    potential["halo"] = p1
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
     rotation = True
 
 
 class TestKepler3Body(CompositePotentialTestBase):
-    """ This implicitly tests the origin shift """
-    mu = 1/11.
+    """This implicitly tests the origin shift"""
+
+    mu = 1 / 11.0
     x1 = -mu
-    m1 = 1-mu
-    x2 = 1-mu
+    m1 = 1 - mu
+    x2 = 1 - mu
     m2 = mu
     potential = CCompositePotential()
-    potential['m1'] = p.KeplerPotential(m=m1, origin=[x1, 0, 0.])
-    potential['m2'] = p.KeplerPotential(m=m2, origin=[x2, 0, 0.])
+    potential["m1"] = p.KeplerPotential(m=m1, origin=[x1, 0, 0.0])
+    potential["m2"] = p.KeplerPotential(m=m2, origin=[x2, 0, 0.0])
 
-    Omega = np.array([0, 0, 1.])
+    Omega = np.array([0, 0, 1.0])
     frame = ConstantRotatingFrame(Omega=Omega)
-    w0 = [0.5, 0, 0, 0., 1.05800316, 0.]
+    w0 = [0.5, 0, 0, 0.0, 1.05800316, 0.0]
 
 
-@pytest.mark.skipif(not GSL_ENABLED,
-                    reason="requires GSL to run this test")
+@pytest.mark.skipif(not GSL_ENABLED, reason="requires GSL to run this test")
 class TestMultipoleInner(CompositePotentialTestBase):
-    potential_1 = p.NFWPotential(m=1E12, r_s=15., units=galactic)
+    potential_1 = p.NFWPotential(m=1e12, r_s=15.0, units=galactic)
     potential = potential_1 + p.MultipolePotential(
-        units=galactic, m=1E10, r_s=15., inner=True,
-        lmax=2, S10=1., S21=0.5)
-    vc = potential.circular_velocity([19., 0, 0]*u.kpc).decompose(galactic).value[0]
-    w0 = [19.0, 0.2, -0.9, 0., vc, 0.]
+        units=galactic, m=1e10, r_s=15.0, inner=True, lmax=2, S10=1.0, S21=0.5
+    )
+    vc = potential.circular_velocity([19.0, 0, 0] * u.kpc).decompose(galactic).value[0]
+    w0 = [19.0, 0.2, -0.9, 0.0, vc, 0.0]
 
     @pytest.mark.skip(reason="Not implemented for multipole potentials")
     def test_hessian(self):
@@ -493,15 +525,14 @@ class TestMultipoleInner(CompositePotentialTestBase):
         pass
 
 
-@pytest.mark.skipif(not GSL_ENABLED,
-                    reason="requires GSL to run this test")
+@pytest.mark.skipif(not GSL_ENABLED, reason="requires GSL to run this test")
 class TestMultipoleOuter(CompositePotentialTestBase):
-    potential_1 = p.NFWPotential(m=1E12, r_s=15., units=galactic)
+    potential_1 = p.NFWPotential(m=1e12, r_s=15.0, units=galactic)
     potential = potential_1 + p.MultipolePotential(
-        units=galactic, m=1E10, r_s=15., inner=False,
-        lmax=2, S10=1., S21=0.5)
-    vc = potential.circular_velocity([19., 0, 0]*u.kpc).decompose(galactic).value[0]
-    w0 = [19.0, 0.2, -0.9, 0., vc, 0.]
+        units=galactic, m=1e10, r_s=15.0, inner=False, lmax=2, S10=1.0, S21=0.5
+    )
+    vc = potential.circular_velocity([19.0, 0, 0] * u.kpc).decompose(galactic).value[0]
+    w0 = [19.0, 0.2, -0.9, 0.0, vc, 0.0]
     check_finite_at_origin = False
 
     @pytest.mark.skip(reason="Not implemented for multipole potentials")
@@ -513,18 +544,16 @@ class TestMultipoleOuter(CompositePotentialTestBase):
         pass
 
 
-@pytest.mark.skipif(not GSL_ENABLED,
-                    reason="requires GSL to run this test")
+@pytest.mark.skipif(not GSL_ENABLED, reason="requires GSL to run this test")
 class TestCylspline(PotentialTestBase):
     check_finite_at_origin = True
 
     def setup_method(self):
         self.potential = p.CylSplinePotential.from_file(
-            get_pkg_data_filename('pot_disk_506151.pot'),
-            units=galactic
+            get_pkg_data_filename("pot_disk_506151.pot"), units=galactic
         )
-        vc = self.potential.circular_velocity([19., 0, 0]*u.kpc).decompose(galactic)
-        self.w0 = [19.0, 0.2, -0.9, 0., vc.value[0], 0.]
+        vc = self.potential.circular_velocity([19.0, 0, 0] * u.kpc).decompose(galactic)
+        self.w0 = [19.0, 0.2, -0.9, 0.0, vc.value[0], 0.0]
         super().setup_method()
 
     @pytest.mark.skip(reason="Not implemented for cylspline potentials")
@@ -540,19 +569,21 @@ class TestCylspline(PotentialTestBase):
         pass
 
     def test_against_agama(self):
-        agama_tbl = at.QTable.read(get_pkg_data_filename('agama_cylspline_test.fits'))
+        agama_tbl = at.QTable.read(get_pkg_data_filename("agama_cylspline_test.fits"))
 
-        gala_ene = self.potential.energy(agama_tbl['xyz'].T)
-        gala_acc = self.potential.acceleration(agama_tbl['xyz'].T)
+        gala_ene = self.potential.energy(agama_tbl["xyz"].T)
+        gala_acc = self.potential.acceleration(agama_tbl["xyz"].T)
 
-        assert u.allclose(gala_ene, agama_tbl['pot'][:, 0], rtol=1e-3)
+        assert u.allclose(gala_ene, agama_tbl["pot"][:, 0], rtol=1e-3)
         for i in range(3):
-            assert u.allclose(gala_acc[i], agama_tbl['acc'][:, i], rtol=1e-2)
+            assert u.allclose(gala_acc[i], agama_tbl["acc"][:, i], rtol=1e-2)
 
 
 class TestBurkert(PotentialTestBase):
-    potential = p.BurkertPotential(units=galactic, rho=5e-25 * u.g / u.cm ** 3, r0=12 * u.kpc)
-    w0 = [1., 0., 0., 0., 0.1, 0.1]
+    potential = p.BurkertPotential(
+        units=galactic, rho=5e-25 * u.g / u.cm**3, r0=12 * u.kpc
+    )
+    w0 = [1.0, 0.0, 0.0, 0.0, 0.1, 0.1]
 
     check_finite_at_origin = False
 
@@ -568,9 +599,8 @@ class TestBurkert(PotentialTestBase):
         # Test against values from Zhu+2023
         pot = p.BurkertPotential.from_r0(r0=11.87 * u.kpc, units=galactic)
 
-        rho = pot.parameters['rho'].to(u.g / u.cm ** 3)
-        rho_check = 5.93e-25 * u.g / u.cm ** 3
+        rho = pot.parameters["rho"].to(u.g / u.cm**3)
+        rho_check = 5.93e-25 * u.g / u.cm**3
 
         # Check a 1% tolerance on inferred density against published values
         assert abs(rho - rho_check) / rho_check < 0.01
-


### PR DESCRIPTION
### Describe your changes

This brings a modest speedup to potential/density/gradient evaluations, which also speeds up orbit integration.


### Checklist

* [x] Did you add tests?
* [x] Did you add documentation for your changes?
* [x] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?
