### PR TITLE
Enable dense output for dop853 integrator (and refactor the way integration is done here)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,12 @@ New Features
   simulations, especially for N-body simulations.
 
 - Added options ``error_if_fail`` and ``log_output`` to integrator kwargs for the
-  dop853 integrator. ``error_if_fail`` controls whether Python will raise an error if
-  the C integrator fails to integrate an orbit, and ``log_output`` will log the output
-  of the integrator (primarily for errors) to stdout.
+  dop853 integrator, along with some other arguments that are passed directly to the C
+  integrator (e.g., ``nstiff``). ``error_if_fail`` controls whether Python will raise
+  an error if the C integrator fails to integrate an orbit, and ``log_output`` will log
+  the output of the integrator (primarily for errors) to stdout. See the docstring for `
+  ``gala.integrate.DOP853Integrator`` for more information about all of the available
+  options for the integrator.
 
 Bug fixes
 ---------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ New Features
 - Added a new ``SimulationUnitSystem`` class for handling unit systems in
   simulations, especially for N-body simulations.
 
+- Added options ``error_if_fail`` and ``log_output`` to integrator kwargs for the
+  dop853 integrator. ``error_if_fail`` controls whether Python will raise an error if
+  the C integrator fails to integrate an orbit, and ``log_output`` will log the output
+  of the integrator (primarily for errors) to stdout.
+
 Bug fixes
 ---------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Bug fixes
 API changes
 -----------
 
+- Gala has ``save_all`` and ``store_all`` flags for saving all orbits at every
+  timestep. The ``store_all`` flag is now deprecated and will be removed in a future
+  release. The``save_all`` flag should be used instead.
+
 Other
 -----
 
@@ -32,6 +36,11 @@ Other
   potential, density, gradient, and hessian values. This leads to some free performance
   improvements in existing code!
 
+- Refactored the way integration is done with the DOP853 integrator. The integrator now
+  uses the dense output feature (which uses interpolation) to compute the output values
+  at the requested times. This is a significant performance improvement for large
+  numbers of orbits, and also allows for much faster results when integrating over long
+  timescales.
 
 1.9.1 (2024-08-26)
 ==================

--- a/gala/dynamics/lyapunov/dop853_lyapunov.pyx
+++ b/gala/dynamics/lyapunov/dop853_lyapunov.pyx
@@ -38,7 +38,8 @@ cdef extern from "dopri/dop853.h":
 cpdef dop853_lyapunov_max(hamiltonian, double[::1] w0,
                           double dt, int n_steps, double t0,
                           double d0, int n_steps_per_pullback, int noffset_orbits,
-                          double atol=1E-10, double rtol=1E-10, int nmax=0):
+                          double atol=1E-10, double rtol=1E-10, int nmax=0,
+                          unsigned log_output=0):
     cdef:
         int i, j, k, jiter
         int res
@@ -87,7 +88,8 @@ cpdef dop853_lyapunov_max(hamiltonian, double[::1] w0,
         dop853_step(cp, &cf, <FcnEqDiff> Fwrapper,
                     &w[0], t[j-1], t[j], dt0, ndim,
                     norbits, 0, args, # 0 is for nbody, ignored here
-                    atol, rtol, nmax)
+                    atol, rtol, nmax,
+                    err_if_fail=1, log_output=log_output)
 
         # store position of main orbit
         for i in range(norbits):
@@ -116,7 +118,8 @@ cpdef dop853_lyapunov_max(hamiltonian, double[::1] w0,
 cpdef dop853_lyapunov_max_dont_save(hamiltonian, double[::1] w0,
                                     double dt, int n_steps, double t0,
                                     double d0, int n_steps_per_pullback, int noffset_orbits,
-                                    double atol=1E-10, double rtol=1E-10, int nmax=0):
+                                    double atol=1E-10, double rtol=1E-10, int nmax=0,
+                                    unsigned log_output=0):
     cdef:
         int i, j, k, jiter
         int res
@@ -161,7 +164,8 @@ cpdef dop853_lyapunov_max_dont_save(hamiltonian, double[::1] w0,
         dop853_step(cp, &cf, <FcnEqDiff> Fwrapper,
                     &w[0], t[j-1], t[j], dt0, ndim,
                     norbits, 0, args, # 0 is for nbody, ignored here
-                    atol, rtol, nmax)
+                    atol, rtol, nmax,
+                    err_if_fail=1, log_output=log_output)
 
         if (j % n_steps_per_pullback) == 0:
             # get magnitude of deviation vector

--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -130,11 +130,14 @@ cpdef mockstream_dop853(nbody, double[::1] time,
 
         # First have to integrate the nbody orbits so we have their positions at
         # each timestep
-        nbody_w = dop853_helper_save_all(cp, &cf,
-                                         <FcnEqDiff> Fwrapper_direct_nbody,
-                                         nbody_w0, time,
-                                         ndim, nbodies, nbodies, args, ntimes,
-                                         atol, rtol, nmax, 0)
+        nbody_w = dop853_helper_save_all(
+            cp, &cf,
+            <FcnEqDiff> Fwrapper_direct_nbody,
+            nbody_w0, time,
+            ndim, nbodies, nbodies, args, ntimes,
+            atol, rtol, nmax,
+            err_if_fail=1
+        )
 
         n = 0
         for i in range(ntimes):

--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -50,11 +50,14 @@ cdef extern from "dopri/dop853.h":
                                unsigned norbits, unsigned nbody, void *args) nogil
 
 
-cpdef mockstream_dop853(nbody, double[::1] time,
-                        double[:, ::1] stream_w0, double[::1] stream_t1,
-                        double tfinal, int[::1] nstream,
-                        double atol=1E-10, double rtol=1E-10, int nmax=0,
-                        int progress=0):
+cpdef mockstream_dop853(
+    nbody, double[::1] time,
+    double[:, ::1] stream_w0, double[::1] stream_t1,
+    double tfinal, int[::1] nstream,
+    double atol=1E-10, double rtol=1E-10, int nmax=0,
+    int progress=0,
+    int err_if_fail=1, int log_output=0
+):
     """
     Parameters
     ----------
@@ -72,10 +75,6 @@ cpdef mockstream_dop853(nbody, double[::1] time,
     instance passed in. ``nstreamparticles`` are the stream test particles.
     ``nstream`` is the array containing the number of stream particles released
     at each timestep.
-
-    TODO
-    ----
-    - `dt0` should be customizable in the Python interface.
 
     """
 
@@ -117,6 +116,8 @@ cpdef mockstream_dop853(nbody, double[::1] time,
     if c_particle_potentials == NULL:
         raise MemoryError("Failed to allocate memory for particle potentials")
 
+    # TODO: reconfigure this to use dense output?
+
     try:
         # set the potential objects of the progenitor (index 0) and any other
         # massive bodies included in the stream generation
@@ -136,7 +137,7 @@ cpdef mockstream_dop853(nbody, double[::1] time,
             nbody_w0, time,
             ndim, nbodies, nbodies, args, ntimes,
             atol, rtol, nmax,
-            err_if_fail=1
+            err_if_fail=err_if_fail, log_output=log_output
         )
 
         n = 0

--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -24,8 +24,7 @@ from libc.math cimport sqrt
 from libc.stdlib cimport malloc, free
 from cpython.exc cimport PyErr_CheckSignals
 
-from ...integrate.cyintegrators.dop853 cimport (dop853_step,
-                                                dop853_helper_save_all)
+from ...integrate.cyintegrators.dop853 cimport dop853_step, dop853_helper
 from ...potential.potential.cpotential cimport CPotentialWrapper, CPotential
 from ...potential.frame.cframe cimport CFrameWrapper, CFrameType
 from ...potential.potential.builtin.cybuiltin import NullWrapper
@@ -131,13 +130,14 @@ cpdef mockstream_dop853(
 
         # First have to integrate the nbody orbits so we have their positions at
         # each timestep
-        nbody_w = dop853_helper_save_all(
+        nbody_w = dop853_helper(
             cp, &cf,
             <FcnEqDiff> Fwrapper_direct_nbody,
             nbody_w0, time,
             ndim, nbodies, nbodies, args, ntimes,
             atol, rtol, nmax, dt_max,
-            err_if_fail=err_if_fail, log_output=log_output
+            nstiff=-1,  # disable stiffness check
+            err_if_fail=err_if_fail, log_output=log_output, save_all=1,
         )
 
         n = 0

--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -88,7 +88,7 @@ cpdef mockstream_dop853(
 
         # Time-stepping parameters:
         int ntimes = time.shape[0]
-        double dt0 = 1.
+        double dt0 = time[1] - time[0]
 
         # whoa, so many dots
         CPotential* cp = (<CPotentialWrapper>(nbody.H.potential.c_instance)).cpotential
@@ -154,13 +154,14 @@ cpdef mockstream_dop853(
             dop853_step(cp, &cf, <FcnEqDiff> Fwrapper_direct_nbody,
                         &w_tmp[0, 0], stream_t1[i], tfinal, dt0,
                         ndim, nbodies+nstream[i], nbodies, args,
-                        atol, rtol, nmax)
+                        atol, rtol, nmax,
+                        err_if_fail=err_if_fail, log_output=log_output)
+
+            PyErr_CheckSignals()
 
             for j in range(nstream[i]):
                 for k in range(ndim):
                     w_final[nbodies+n+j, k] = w_tmp[nbodies+j, k]
-
-            PyErr_CheckSignals()
 
             n += nstream[i]
 
@@ -197,7 +198,8 @@ cpdef mockstream_dop853_animate(nbody, double[::1] t,
                                 output_every=1, output_filename='',
                                 overwrite=False, check_filesize=True,
                                 double atol=1E-10, double rtol=1E-10,
-                                int nmax=0, int progress=0, double dt0=1.):
+                                int nmax=0, int progress=0,
+                                int err_if_fail=1, int log_output=0):
     """
     Parameters
     ----------
@@ -215,10 +217,6 @@ cpdef mockstream_dop853_animate(nbody, double[::1] t,
     ``nstream`` is the array containing the number of stream particles released
     at each timestep.
 
-    TODO
-    ----
-    - `dt0` should be customizable in the Python interface.
-
     """
 
     cdef:
@@ -227,6 +225,7 @@ cpdef mockstream_dop853_animate(nbody, double[::1] t,
 
         # Time-stepping parameters:
         int ntimes = t.shape[0]
+        double dt0 = t[1] - t[0]
 
         # whoa, so many dots
         CPotential* cp = (<CPotentialWrapper>(nbody.H.potential.c_instance)).cpotential
@@ -328,7 +327,8 @@ cpdef mockstream_dop853_animate(nbody, double[::1] t,
             dop853_step(cp, &cf, <FcnEqDiff> Fwrapper_direct_nbody,
                         &w[0, 0], t[i-1], t[i], dt0,
                         ndim, nbodies+n, nbodies, args,
-                        atol, rtol, nmax)
+                        atol, rtol, nmax,
+                        err_if_fail=err_if_fail, log_output=log_output)
 
             PyErr_CheckSignals()
 

--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -54,7 +54,7 @@ cpdef mockstream_dop853(
     nbody, double[::1] time,
     double[:, ::1] stream_w0, double[::1] stream_t1,
     double tfinal, int[::1] nstream,
-    double atol=1E-10, double rtol=1E-10, int nmax=0,
+    double atol=1E-10, double rtol=1E-10, int nmax=0, double dt_max=0.0,
     int progress=0,
     int err_if_fail=1, int log_output=0
 ):
@@ -136,7 +136,7 @@ cpdef mockstream_dop853(
             <FcnEqDiff> Fwrapper_direct_nbody,
             nbody_w0, time,
             ndim, nbodies, nbodies, args, ntimes,
-            atol, rtol, nmax,
+            atol, rtol, nmax, dt_max,
             err_if_fail=err_if_fail, log_output=log_output
         )
 

--- a/gala/dynamics/mockstream/mockstream_generator.py
+++ b/gala/dynamics/mockstream/mockstream_generator.py
@@ -123,6 +123,7 @@ class MockStreamGenerator:
         check_filesize=True,
         overwrite=False,
         progress=False,
+        log_output=False,
         **time_spec,
     ):
         """
@@ -243,15 +244,20 @@ class MockStreamGenerator:
         for t1, n in zip(unq_t1s, nstream):
             all_nstream[np.isclose(orbit_t, t1)] = n
 
+        nstream_idx = np.where(all_nstream != 0)[0]
+        if 0 not in nstream_idx:
+            nstream_idx = np.insert(nstream_idx, 0, 0)
+
         if output_every is None:
             raw_nbody, raw_stream = mockstream_dop853(
                 nbody0,
-                orbit_t[all_nstream != 0],
+                orbit_t[nstream_idx],
                 w0,
                 unq_t1s,
                 orbit_t[-1],
-                all_nstream[all_nstream != 0].astype("i4"),
+                all_nstream[nstream_idx].astype("i4"),
                 progress=int(progress),
+                log_output=int(log_output),
             )
         else:  # store snapshots
             if output_filename is None:
@@ -270,6 +276,7 @@ class MockStreamGenerator:
                 check_filesize=check_filesize,
                 overwrite=overwrite,
                 progress=int(progress),
+                log_output=int(log_output),
             )
 
         x_unit = units["length"]

--- a/gala/dynamics/mockstream/tests/test_mockstream_class.py
+++ b/gala/dynamics/mockstream/tests/test_mockstream_class.py
@@ -1,10 +1,8 @@
-# Third-party
 import astropy.units as u
 import numpy as np
 import pytest
 
-# Custom
-from ..core import MockStream
+from gala.dynamics.mockstream import MockStream
 
 
 def test_init():

--- a/gala/dynamics/nbody/core.py
+++ b/gala/dynamics/nbody/core.py
@@ -216,11 +216,11 @@ class DirectNBody:
 
         if Integrator == LeapfrogIntegrator:
             _, ws = leapfrog_integrate_nbody(
-                self.H, reorg_w0, t, pps, store_all=int(self.save_all)
+                self.H, reorg_w0, t, pps, save_all=int(self.save_all)
             )
         elif Integrator == Ruth4Integrator:
             _, ws = ruth4_integrate_nbody(
-                self.H, reorg_w0, t, pps, store_all=int(self.save_all)
+                self.H, reorg_w0, t, pps, save_all=int(self.save_all)
             )
         elif Integrator == DOPRI853Integrator:
             ws = direct_nbody_dop853(reorg_w0, t, self.H, pps, save_all=self.save_all)

--- a/gala/dynamics/nbody/core.py
+++ b/gala/dynamics/nbody/core.py
@@ -216,14 +216,26 @@ class DirectNBody:
 
         if Integrator == LeapfrogIntegrator:
             _, ws = leapfrog_integrate_nbody(
-                self.H, reorg_w0, t, pps, save_all=int(self.save_all)
+                self.H,
+                reorg_w0,
+                t,
+                pps,
+                save_all=int(self.save_all),
+                **Integrator_kwargs,
             )
         elif Integrator == Ruth4Integrator:
             _, ws = ruth4_integrate_nbody(
-                self.H, reorg_w0, t, pps, save_all=int(self.save_all)
+                self.H,
+                reorg_w0,
+                t,
+                pps,
+                save_all=int(self.save_all),
+                **Integrator_kwargs,
             )
         elif Integrator == DOPRI853Integrator:
-            ws = direct_nbody_dop853(reorg_w0, t, self.H, pps, save_all=self.save_all)
+            ws = direct_nbody_dop853(
+                reorg_w0, t, self.H, pps, save_all=self.save_all, **Integrator_kwargs
+            )
         else:
             raise NotImplementedError(
                 "N-body integration is currently not supported with the {Integrator} "

--- a/gala/dynamics/nbody/nbody.pyx
+++ b/gala/dynamics/nbody/nbody.pyx
@@ -110,18 +110,24 @@ cpdef direct_nbody_dop853(double [:, ::1] w0, double[::1] t,
         args = <void *>(c_particle_potentials)
 
         if save_all:
-            all_w = dop853_helper_save_all(cp, &cf,
-                                          <FcnEqDiff> Fwrapper_direct_nbody,
-                                          w0, t,
-                                          ndim, nparticles, nbody, args,
-                                          ntimes, atol, rtol, nmax, 0)
+            all_w = dop853_helper_save_all(
+                cp, &cf,
+                <FcnEqDiff> Fwrapper_direct_nbody,
+                w0, t,
+                ndim, nparticles, nbody, args,
+                ntimes, atol, rtol, nmax,
+                err_if_fail=1
+            )
             return np.array(all_w)
         else:
-            final_w = dop853_helper(cp, &cf,
-                                  <FcnEqDiff> Fwrapper_direct_nbody,
-                                  w0, t,
-                                  ndim, nparticles, nbody, args, ntimes,
-                                  atol, rtol, nmax, 0)
+            final_w = dop853_helper(
+                cp, &cf,
+                <FcnEqDiff> Fwrapper_direct_nbody,
+                w0, t,
+                ndim, nparticles, nbody, args, ntimes,
+                atol, rtol, nmax,
+                err_if_fail=1
+            )
             return np.array(final_w).reshape(nparticles, ndim)
 
     finally:

--- a/gala/dynamics/nbody/nbody.pyx
+++ b/gala/dynamics/nbody/nbody.pyx
@@ -47,7 +47,7 @@ cpdef direct_nbody_dop853(
     double [:, ::1] w0, double[::1] t,
     hamiltonian, list particle_potentials,
     save_all=True,
-    double atol=1E-10, double rtol=1E-10, int nmax=0,
+    double atol=1E-10, double rtol=1E-10, int nmax=0, double dt_max=0.0,
     int err_if_fail=1, int log_output=0
 ):
     """Integrate orbits from initial conditions ``w0`` over the time grid ``t``
@@ -118,7 +118,8 @@ cpdef direct_nbody_dop853(
                 <FcnEqDiff> Fwrapper_direct_nbody,
                 w0, t,
                 ndim, nparticles, nbody, args,
-                ntimes, atol, rtol, nmax,
+                ntimes,
+                atol, rtol, nmax, dt_max,
                 err_if_fail=err_if_fail, log_output=log_output
             )
             return np.array(all_w)
@@ -127,8 +128,9 @@ cpdef direct_nbody_dop853(
                 cp, &cf,
                 <FcnEqDiff> Fwrapper_direct_nbody,
                 w0, t,
-                ndim, nparticles, nbody, args, ntimes,
-                atol, rtol, nmax,
+                ndim, nparticles, nbody, args,
+                ntimes,
+                atol, rtol, nmax, dt_max,
                 err_if_fail=err_if_fail, log_output=log_output
             )
             return np.array(final_w).reshape(nparticles, ndim)

--- a/gala/dynamics/nbody/nbody.pyx
+++ b/gala/dynamics/nbody/nbody.pyx
@@ -43,10 +43,13 @@ cdef extern from "dopri/dop853.h":
                                CPotential *p, CFrameType *fr, unsigned norbits,
                                unsigned nbody, void *args)
 
-cpdef direct_nbody_dop853(double [:, ::1] w0, double[::1] t,
-                          hamiltonian, list particle_potentials,
-                          save_all=True,
-                          double atol=1E-10, double rtol=1E-10, int nmax=0):
+cpdef direct_nbody_dop853(
+    double [:, ::1] w0, double[::1] t,
+    hamiltonian, list particle_potentials,
+    save_all=True,
+    double atol=1E-10, double rtol=1E-10, int nmax=0,
+    int err_if_fail=1, int log_output=0
+):
     """Integrate orbits from initial conditions ``w0`` over the time grid ``t``
     using direct N-body force calculation in the external potential provided via
     the ``hamiltonian`` argument.
@@ -116,7 +119,7 @@ cpdef direct_nbody_dop853(double [:, ::1] w0, double[::1] t,
                 w0, t,
                 ndim, nparticles, nbody, args,
                 ntimes, atol, rtol, nmax,
-                err_if_fail=1
+                err_if_fail=err_if_fail, log_output=log_output
             )
             return np.array(all_w)
         else:
@@ -126,7 +129,7 @@ cpdef direct_nbody_dop853(double [:, ::1] w0, double[::1] t,
                 w0, t,
                 ndim, nparticles, nbody, args, ntimes,
                 atol, rtol, nmax,
-                err_if_fail=1
+                err_if_fail=err_if_fail, log_output=log_output
             )
             return np.array(final_w).reshape(nparticles, ndim)
 

--- a/gala/dynamics/nbody/tests/test_nbody.py
+++ b/gala/dynamics/nbody/tests/test_nbody.py
@@ -85,8 +85,18 @@ class TestDirectNBody:
         "Integrator", [DOPRI853Integrator, Ruth4Integrator, LeapfrogIntegrator]
     )
     def test_directnbody_integrate(self, Integrator):
-        # TODO: this is really a unit test, but we should have some functional tests
-        # that check that the orbit integration is making sense!
+        """
+        TODO: this is really a unit test, but we should have some functional tests
+        that check that the orbit integration is making sense!
+
+        Here, nbody1 has two test mass particles (massless) and nbody2 has
+        one potential with mass [1] and one without [0]. This means that the orbit of
+        particle [1] should be the same in both cases, but the orbit of particle [0]
+        should be different (because it feels the mass of the other particle in one
+        case).
+        """
+
+        atol = 1e-10 * u.pc
 
         # First, compare with/without mass with no external potential:
         nbody1 = DirectNBody(self.w0, particle_potentials=[None, None], units=self.usys)
@@ -103,8 +113,8 @@ class TestDirectNBody:
 
         dx0 = orbits1[:, 0].xyz - orbits2[:, 0].xyz
         dx1 = orbits1[:, 1].xyz - orbits2[:, 1].xyz
-        assert u.allclose(np.abs(dx1), 0 * u.pc, atol=1e-13 * u.pc)
         assert np.abs(dx0).max() > 50 * u.pc
+        assert u.allclose(np.abs(dx1), 0 * u.pc, atol=atol)
 
         # Now compare with/without mass with external potential:
         nbody1 = DirectNBody(
@@ -129,7 +139,7 @@ class TestDirectNBody:
 
         dx0 = orbits1[:, 0].xyz - orbits2[:, 0].xyz
         dx1 = orbits1[:, 1].xyz - orbits2[:, 1].xyz
-        assert u.allclose(np.abs(dx1), 0 * u.pc, atol=1e-13 * u.pc)
+        assert u.allclose(np.abs(dx1), 0 * u.pc, atol=atol)
         assert np.abs(dx0).max() > 50 * u.pc
 
     def test_directnbody_acceleration(self):

--- a/gala/dynamics/tests/test_nonlinear.py
+++ b/gala/dynamics/tests/test_nonlinear.py
@@ -3,10 +3,10 @@ import numpy as np
 
 # Project
 from ... import potential as gp
-from ...potential import Hamiltonian
-from ..nonlinear import lyapunov_max, fast_lyapunov_max, surface_of_section
 from ...integrate import DOPRI853Integrator
+from ...potential import Hamiltonian
 from ...units import galactic
+from ..nonlinear import fast_lyapunov_max, lyapunov_max, surface_of_section
 
 
 class TestForcedPendulum(object):
@@ -195,7 +195,9 @@ class TestLogarithmic(object):
         X0 = -0.2
         y0 = 0.0
         E0 = -0.4059
-        Y0 = np.squeeze(np.sqrt(E0 - self.hamiltonian.potential.energy([x0, y0, 0.0]).value))
+        Y0 = np.squeeze(
+            np.sqrt(E0 - self.hamiltonian.potential.energy([x0, y0, 0.0]).value)
+        )
         chaotic_w0 = [x0, y0, 0.0, X0, Y0, 0.0]
 
         # initial conditions from LP-VI documentation:
@@ -224,35 +226,11 @@ class TestLogarithmic(object):
             )
             lyap = np.mean(lyap, axis=1)
 
-            # also just integrate the orbit to compare dE scaling
-            orbit2 = self.hamiltonian.integrate_orbit(
-                w0, dt=self.dt, n_steps=self.n_steps, Integrator=DOPRI853Integrator
-            )
-
-            # lyapunov exp
-            # pl.figure()
-            # pl.loglog(lyap, marker='')
-            # pl.savefig(os.path.join(str(tmpdir),"log_lyap_max_{}.png".format(ii)))
-
             # energy conservation
             E = orbit[:, 0].energy().value  # returns 3 orbits
-            dE = np.abs(E[1:] - E[0])
+            dE = np.abs((E[1:] - E[0]) / E[0])
 
-            E = orbit2.energy().value
-            dE_ww = np.abs(E[1:] - E[0])
-
-            # import matplotlib.pyplot as plt
-            # plt.semilogy(dE, marker='')
-            # plt.semilogy(dE_ww, marker='')
-
-            # fig, axes = plt.subplots(1, 2, figsize=(10, 5))
-            # axes[0].plot(orbit.pos[0, :, 0], orbit.pos[1, :, 0], marker='') # ignore offset orbits
-            # axes[1].plot(orbit2.pos[0], orbit2.pos[1], marker='')
-            # fig.savefig(os.path.join(str(tmpdir),"log_orbit_lyap_max_{}.png".format(ii)))
-
-            # plt.show()
-
-            assert np.allclose(dE_ww[-100:], dE[-100:], rtol=1e-1)
+            assert np.all(dE < 1e-10)
 
     def test_compare_fast(self, tmpdir):
         n_steps_per_pullback = 10

--- a/gala/integrate/core.py
+++ b/gala/integrate/core.py
@@ -1,4 +1,4 @@
-""" Base class for integrators. """
+"""Base class for integrators."""
 
 from abc import ABCMeta, abstractmethod
 
@@ -7,7 +7,7 @@ import numpy as np
 from astropy.utils.decorators import deprecated
 
 # This project
-from gala.units import UnitSystem, DimensionlessUnitSystem
+from gala.units import DimensionlessUnitSystem, UnitSystem
 
 __all__ = ["Integrator"]
 
@@ -19,12 +19,10 @@ class Integrator(metaclass=ABCMeta):
         func_args=(),
         func_units=None,
         progress=False,
-        store_all=True,
+        save_all=True,
     ):
         if not hasattr(func, "__call__"):
-            raise ValueError(
-                "func must be a callable object, e.g., a function."
-            )
+            raise ValueError("func must be a callable object, e.g., a function.")
 
         self.F = func
         self._func_args = func_args
@@ -38,12 +36,13 @@ class Integrator(metaclass=ABCMeta):
         self._func_units = func_units
 
         self.progress = bool(progress)
-        self.store_all = store_all
+        self.save_all = save_all
 
     def _get_range_func(self):
         if self.progress:
             try:
                 from tqdm import trange
+
                 return trange
             except ImportError:
                 raise ImportError(
@@ -71,7 +70,7 @@ class Integrator(metaclass=ABCMeta):
         self.ndim, self.norbits = arr_w0.shape
         self.ndim = self.ndim // 2
 
-        if self.store_all:
+        if self.save_all:
             return_shape = (2 * self.ndim, n_steps + 1, self.norbits)
         else:
             return_shape = (2 * self.ndim, self.norbits)
@@ -108,8 +107,8 @@ class Integrator(metaclass=ABCMeta):
         from ..dynamics import Orbit
 
         orbit = Orbit(
-            pos=w[:self.ndim] * pos_unit,
-            vel=w[self.ndim:] * vel_unit,
+            pos=w[: self.ndim] * pos_unit,
+            vel=w[self.ndim :] * vel_unit,
             t=t * t_unit,
         )
         return orbit

--- a/gala/integrate/cyintegrators/dop853.pxd
+++ b/gala/integrate/cyintegrators/dop853.pxd
@@ -13,21 +13,42 @@ cdef extern from "dopri/dop853.h":
                               CPotential *p, CFrameType *fr, unsigned norbits,
                               unsigned nbody, void *args) nogil
 
+    ctypedef struct Dop853DenseState:
+        double *rcont1
+        double *rcont2
+        double *rcont3
+        double *rcont4
+        double *rcont5
+        double *rcont6
+        double *rcont7
+        double *rcont8
+        double xold
+        double hout
+        unsigned nrds
+        unsigned *indir
+
+    double contd8(unsigned ii, double x)
+    # Thread-safe dense output function
+    double contd8_threadsafe(Dop853DenseState *state, unsigned ii, double x)
+
 cdef void dop853_step(CPotential *cp, CFrameType *cf, FcnEqDiff F,
                       double *w, double t1, double t2, double dt0,
                       int ndim, int norbits, int nbody, void *args,
                       double atol, double rtol, int nmax)  except *
 
-cdef dop853_helper(CPotential *cp, CFrameType *cf, FcnEqDiff F,
-                   double[:,::1] w0, double[::1] t,
-                   int ndim, int norbits, int nbody, void *args, int ntimes,
-                   double atol, double rtol, int nmax, int progress)
+cdef dop853_helper(
+    CPotential *cp, CFrameType *cf, FcnEqDiff F,
+    double[:,::1] w0, double[::1] t,
+    int ndim, int norbits, int nbody, void *args, int ntimes,
+    double atol, double rtol, int nmax, unsigned err_if_fail
+)
 
-cdef dop853_helper_save_all(CPotential *cp, CFrameType *cf, FcnEqDiff F,
-                            double[:,::1] w0, double[::1] t,
-                            int ndim, int norbits, int nbody, void *args,
-                            int ntimes, double atol, double rtol, int nmax,
-                            int progress)
+cdef dop853_helper_save_all(
+    CPotential *cp, CFrameType *cf, FcnEqDiff F,
+    double[:,::1] w0, double[::1] t,
+    int ndim, int norbits, int nbody, void *args,
+    int ntimes, double atol, double rtol, int nmax, unsigned err_if_fail
+)
 
 # cpdef dop853_integrate_hamiltonian(hamiltonian, double[:,::1] w0, double[::1] t,
 #                                    double atol=?, double rtol=?, int nmax=?)

--- a/gala/integrate/cyintegrators/dop853.pxd
+++ b/gala/integrate/cyintegrators/dop853.pxd
@@ -41,7 +41,7 @@ cdef dop853_helper(
     CPotential *cp, CFrameType *cf, FcnEqDiff F,
     double[:,::1] w0, double[::1] t,
     int ndim, int norbits, int nbody, void *args, int ntimes,
-    double atol, double rtol, int nmax,
+    double atol, double rtol, int nmax, double dt_max,
     unsigned err_if_fail, unsigned log_output
 )
 
@@ -49,7 +49,7 @@ cdef dop853_helper_save_all(
     CPotential *cp, CFrameType *cf, FcnEqDiff F,
     double[:,::1] w0, double[::1] t,
     int ndim, int norbits, int nbody, void *args,
-    int ntimes, double atol, double rtol, int nmax,
+    int ntimes, double atol, double rtol, int nmax, double dt_max,
     unsigned err_if_fail, unsigned log_output
 )
 

--- a/gala/integrate/cyintegrators/dop853.pxd
+++ b/gala/integrate/cyintegrators/dop853.pxd
@@ -34,7 +34,8 @@ cdef extern from "dopri/dop853.h":
 cdef void dop853_step(CPotential *cp, CFrameType *cf, FcnEqDiff F,
                       double *w, double t1, double t2, double dt0,
                       int ndim, int norbits, int nbody, void *args,
-                      double atol, double rtol, int nmax)  except *
+                      double atol, double rtol, int nmax,
+                      unsigned err_if_fail, unsigned log_output,)
 
 cdef dop853_helper(
     CPotential *cp, CFrameType *cf, FcnEqDiff F,

--- a/gala/integrate/cyintegrators/dop853.pxd
+++ b/gala/integrate/cyintegrators/dop853.pxd
@@ -40,14 +40,16 @@ cdef dop853_helper(
     CPotential *cp, CFrameType *cf, FcnEqDiff F,
     double[:,::1] w0, double[::1] t,
     int ndim, int norbits, int nbody, void *args, int ntimes,
-    double atol, double rtol, int nmax, unsigned err_if_fail
+    double atol, double rtol, int nmax,
+    unsigned err_if_fail, unsigned log_output
 )
 
 cdef dop853_helper_save_all(
     CPotential *cp, CFrameType *cf, FcnEqDiff F,
     double[:,::1] w0, double[::1] t,
     int ndim, int norbits, int nbody, void *args,
-    int ntimes, double atol, double rtol, int nmax, unsigned err_if_fail
+    int ntimes, double atol, double rtol, int nmax,
+    unsigned err_if_fail, unsigned log_output
 )
 
 # cpdef dop853_integrate_hamiltonian(hamiltonian, double[:,::1] w0, double[::1] t,

--- a/gala/integrate/cyintegrators/dop853.pxd
+++ b/gala/integrate/cyintegrators/dop853.pxd
@@ -42,15 +42,10 @@ cdef dop853_helper(
     double[:,::1] w0, double[::1] t,
     int ndim, int norbits, int nbody, void *args, int ntimes,
     double atol, double rtol, int nmax, double dt_max,
-    unsigned err_if_fail, unsigned log_output
-)
-
-cdef dop853_helper_save_all(
-    CPotential *cp, CFrameType *cf, FcnEqDiff F,
-    double[:,::1] w0, double[::1] t,
-    int ndim, int norbits, int nbody, void *args,
-    int ntimes, double atol, double rtol, int nmax, double dt_max,
-    unsigned err_if_fail, unsigned log_output
+    int nstiff,
+    unsigned err_if_fail,
+    unsigned log_output,
+    unsigned save_all=?
 )
 
 # cpdef dop853_integrate_hamiltonian(hamiltonian, double[:,::1] w0, double[::1] t,

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -240,7 +240,7 @@ cdef dop853_helper_save_all(
 
 cpdef dop853_integrate_hamiltonian(
     hamiltonian, double[:, ::1] w0, double[::1] t,
-    double atol=1E-10, double rtol=1E-10, int nmax=0, int store_all=1,
+    double atol=1E-10, double rtol=1E-10, int nmax=0, int save_all=1,
     int err_if_fail=1, int log_output=0
 ):
     """
@@ -266,7 +266,7 @@ cpdef dop853_integrate_hamiltonian(
         CFrameType cf = (<CFrameWrapper>(hamiltonian.frame.c_instance)).cframe
 
     # 0 below is for nbody - we ignore that in this test particle integration
-    if store_all:
+    if save_all:
         all_w = dop853_helper_save_all(
             cp, &cf, <FcnEqDiff> Fwrapper,
             w0, t,

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -152,6 +152,7 @@ cdef dop853_helper(
     double atol,
     double rtol,
     int nmax,
+    double dt_max,
     unsigned err_if_fail,
     unsigned log_output
 ):
@@ -178,7 +179,7 @@ cdef dop853_helper(
         0.0,  # fac1: Step size control parameter
         0.0,  # fac2: Step size control parameter
         0.0,  # beta: Stabilizatin for step size control
-        0.0,  # hmax: maximum allowed step size
+        dt_max,  # hmax: maximum allowed step size
         t[1] - t[0],  # h: Initial step size
         nmax,  # nmax: maximum number of integration steps
         0,  # meth
@@ -212,6 +213,7 @@ cdef dop853_helper_save_all(
     double atol,
     double rtol,
     int nmax,
+    double dt_max,
     unsigned err_if_fail,
     unsigned log_output
 ):
@@ -248,7 +250,7 @@ cdef dop853_helper_save_all(
         0.0,  # fac1: Step size control parameter (0.0 = use default)
         0.0,  # fac2: Step size control parameter (0.0 = use default)
         0.0,  # beta: Stabilizatin for step size control (0.0 = use default)
-        0.0,  # hmax: maximum allowed step size (0.0 = no limit)
+        dt_max,  # hmax: maximum allowed step size (0.0 = no limit)
         t[1] - t[0],  # h: Initial step size
         nmax,  # nmax:  maximum number of integration steps (0 = 100_000)
         1,  # meth:  set to 1 and don't think about it
@@ -270,8 +272,8 @@ cdef dop853_helper_save_all(
 
 cpdef dop853_integrate_hamiltonian(
     hamiltonian, double[:, ::1] w0, double[::1] t,
-    double atol=1E-10, double rtol=1E-10, int nmax=0, int save_all=1,
-    int err_if_fail=1, int log_output=0
+    double atol=1E-10, double rtol=1E-10, int nmax=0, double dt_max = 0.,
+    int save_all=1, int err_if_fail=1, int log_output=0
 ):
     """
     CAUTION: Interpretation of axes is different here! We need the
@@ -301,7 +303,7 @@ cpdef dop853_integrate_hamiltonian(
             cp, &cf, <FcnEqDiff> Fwrapper,
             w0, t,
             ndim, norbits, 0, args, ntimes,
-            atol, rtol, nmax,
+            atol, rtol, nmax, dt_max,
             err_if_fail=err_if_fail, log_output=log_output
         )
         return np.asarray(t), np.asarray(all_w)
@@ -310,7 +312,7 @@ cpdef dop853_integrate_hamiltonian(
             cp, &cf, <FcnEqDiff> Fwrapper,
             w0, t,
             ndim, norbits, 0, args, ntimes,
-            atol, rtol, nmax,
+            atol, rtol, nmax, dt_max,
             err_if_fail=err_if_fail, log_output=log_output
         )
         return np.asarray(t[-1:]), np.asarray(w)

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -230,7 +230,7 @@ cdef dop853_helper(
 cpdef dop853_integrate_hamiltonian(
     hamiltonian, double[:, ::1] w0, double[::1] t,
     double atol=1E-10, double rtol=1E-10, int nmax=0, double dt_max = 0.,
-    int save_all=1, int err_if_fail=1, int log_output=0
+    int nstiff=0, int save_all=1, int err_if_fail=1, int log_output=0
 ):
     """
     CAUTION: Interpretation of axes is different here! We need the
@@ -260,7 +260,7 @@ cpdef dop853_integrate_hamiltonian(
         w0, t,
         ndim, norbits, 0, args, ntimes,
         atol, rtol, nmax, dt_max,
-        nstiff=0,
+        nstiff=nstiff,
         save_all=save_all, err_if_fail=err_if_fail, log_output=log_output
     )
     if save_all:

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -238,8 +238,11 @@ cdef dop853_helper_save_all(
     return np.asarray(output_w).reshape((ntimes, norbits, ndim))
 
 
-cpdef dop853_integrate_hamiltonian(hamiltonian, double[:, ::1] w0, double[::1] t,
-                                   double atol=1E-10, double rtol=1E-10, int nmax=0, int store_all=1):
+cpdef dop853_integrate_hamiltonian(
+    hamiltonian, double[:, ::1] w0, double[::1] t,
+    double atol=1E-10, double rtol=1E-10, int nmax=0, int store_all=1,
+    int err_if_fail=1, int log_output=0
+):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -269,7 +272,7 @@ cpdef dop853_integrate_hamiltonian(hamiltonian, double[:, ::1] w0, double[::1] t
             w0, t,
             ndim, norbits, 0, args, ntimes,
             atol, rtol, nmax,
-            err_if_fail=1, log_output=1  # TODO: make customizable
+            err_if_fail=err_if_fail, log_output=log_output
         )
         return np.asarray(t), np.asarray(all_w)
     else:
@@ -278,6 +281,6 @@ cpdef dop853_integrate_hamiltonian(hamiltonian, double[:, ::1] w0, double[::1] t
             w0, t,
             ndim, norbits, 0, args, ntimes,
             atol, rtol, nmax,
-            err_if_fail=1, log_output=1  # TODO: make customizable
+            err_if_fail=err_if_fail, log_output=log_output
         )
         return np.asarray(t[-1:]), np.asarray(w)

--- a/gala/integrate/cyintegrators/dopri/dop853.c
+++ b/gala/integrate/cyintegrators/dopri/dop853.c
@@ -1,61 +1,24 @@
 #include <math.h>
 #include <stdio.h>
 // #include <malloc.h>
-#include <stdlib.h>
+#include "dop853.h"
 #include <limits.h>
 #include <memory.h>
-#include "dop853.h"
+#include <stdlib.h>
 
-static long nfcn, nstep, naccpt, nrejct;
-static double *yy1, *k1, *k2, *k3, *k4, *k5, *k6, *k7, *k8, *k9, *k10;
-
-long nfcnRead(void)
-{
-  return nfcn;
-
-} /* nfcnRead */
-
-long nstepRead(void)
-{
-  return nstep;
-
-} /* stepRead */
-
-long naccptRead(void)
-{
-  return naccpt;
-
-} /* naccptRead */
-
-long nrejctRead(void)
-{
-  return nrejct;
-
-} /* nrejct */
-
-static double sign(double a, double b)
-{
+static double sign(double a, double b) {
   return (b < 0.0) ? -fabs(a) : fabs(a);
 
 } /* sign */
 
-static double min_d(double a, double b)
-{
-  return (a < b) ? a : b;
+static double min_d(double a, double b) { return (a < b) ? a : b; } /* min_d */
 
-} /* min_d */
+static double max_d(double a, double b) { return (a > b) ? a : b; } /* max_d */
 
-static double max_d(double a, double b)
-{
-  return (a > b) ? a : b;
-
-} /* max_d */
-
-static double hinit(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
-                    double x, double *y,
+static double hinit(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr,
+                    unsigned norbits, unsigned nbody, void *args, double x, double *y,
                     double posneg, double *f0, double *f1, double *yy1, int iord,
-                    double hmax, double *atoler, double *rtoler, int itoler)
-{
+                    double hmax, double *atoler, double *rtoler, int itoler) {
   double dnf, dny, atoli, rtoli, sk, h, h1, der2, der12, sqr;
   unsigned i;
 
@@ -65,8 +28,7 @@ static double hinit(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, un
   rtoli = rtoler[0];
 
   if (!itoler)
-    for (i = 0; i < n; i++)
-    {
+    for (i = 0; i < n; i++) {
       sk = atoli + rtoli * fabs(y[i]);
       sqr = f0[i] / sk;
       dnf += sqr * sqr;
@@ -74,8 +36,7 @@ static double hinit(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, un
       dny += sqr * sqr;
     }
   else
-    for (i = 0; i < n; i++)
-    {
+    for (i = 0; i < n; i++) {
       sk = atoler[i] + rtoler[i] * fabs(y[i]);
       sqr = f0[i] / sk;
       dnf += sqr * sqr;
@@ -99,15 +60,13 @@ static double hinit(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, un
   /* estimate the second derivative of the solution */
   der2 = 0.0;
   if (!itoler)
-    for (i = 0; i < n; i++)
-    {
+    for (i = 0; i < n; i++) {
       sk = atoli + rtoli * fabs(y[i]);
       sqr = (f1[i] - f0[i]) / sk;
       der2 += sqr * sqr;
     }
   else
-    for (i = 0; i < n; i++)
-    {
+    for (i = 0; i < n; i++) {
       sk = atoler[i] + rtoler[i] * fabs(y[i]);
       sqr = (f1[i] - f0[i]) / sk;
       der2 += sqr * sqr;
@@ -127,15 +86,16 @@ static double hinit(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, un
 } /* hinit */
 
 /* core integrator */
-static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
-                  double x, double *y, double xend,
-                  double hmax, double h, double *rtoler, double *atoler,
-                  int itoler, FILE *fileout, SolTrait solout, int iout,
-                  long nmax, double uround, int meth, long nstiff, double safe,
-                  double beta, double fac1, double fac2, unsigned *icont,
-                  Dop853DenseState *dense_state,
-                  double *output_times, int n_output_times, double *output_y)
-{
+static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr,
+                  unsigned norbits, unsigned nbody, void *args, double x, double *y,
+                  double xend, double hmax, double h, double *rtoler, double *atoler,
+                  int itoler, FILE *fileout, SolTrait solout, int iout, long nmax,
+                  double uround, int meth, long nstiff, double safe, double beta,
+                  double fac1, double fac2, unsigned *icont,
+                  Dop853DenseState *dense_state, double *yy1, double *k1, double *k2,
+                  double *k3, double *k4, double *k5, double *k6, double *k7,
+                  double *k8, double *k9, double *k10, double *output_times,
+                  int n_output_times, double *output_y) {
   double facold, expo1, fac, facc1, facc2, fac11, posneg, xph;
   double atoli, rtoli, hlamb, err, sk, hnew, yd0, ydiff, bspl;
   double stnum, stden, sqr, err2, erri, deno;
@@ -157,10 +117,13 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
   double d61, d66, d67, d68, d69, d610, d611, d612, d613, d614, d615, d616;
   double d71, d76, d77, d78, d79, d710, d711, d712, d713, d714, d715, d716;
   int output_idx = 0;
+  long nfcn = 0;
+  long nstep = 0;
+  long naccpt = 0;
+  long nrejct = 0;
 
   /* initialisations */
-  switch (meth)
-  {
+  switch (meth) {
   case 1:
 
     c2 = 0.526001519587677318785587544488E-01;
@@ -350,24 +313,22 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
   iord = 8;
 
   if (h == 0.0)
-    h = hinit(n, fcn, p, fr, norbits, nbody, args, x, y, posneg, k1, k2, k3, iord, hmax, atoler, rtoler, itoler);
+    h = hinit(n, fcn, p, fr, norbits, nbody, args, x, y, posneg, k1, k2, k3, iord, hmax,
+              atoler, rtoler, itoler);
 
   nfcn += 2;
   reject = 0;
   if (dense_state)
     dense_state->xold = x;
 
-  if (iout)
-  {
+  if (iout) {
     irtrn = 1;
-    if (dense_state)
-    {
+    if (dense_state) {
       dense_state->hout = 1.0;
       dense_state->xold = x;
     }
     solout(naccpt + 1, x, x, y, n, &irtrn);
-    if (irtrn < 0)
-    {
+    if (irtrn < 0) {
       if (fileout)
         fprintf(fileout, "Exit of dop853 at x = %.16e\r\n", x);
       return 2;
@@ -375,30 +336,29 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
   }
 
   /* basic integration step */
-  while (1)
-  {
-    if (dense_state)
-    {
+  while (1) {
+    if (dense_state) {
       dense_state->xold = x;
       dense_state->hout = h;
     }
 
-    if (nstep > nmax)
-    {
+    if (nstep > nmax) {
       if (fileout)
-        fprintf(fileout, "Exit of dop853 at x = %.16e, more than nmax = %li are needed\r\n", x, nmax);
+        fprintf(fileout,
+                "Exit of dop853 at x = %.16e, more than nmax = %li are needed - nstep "
+                "= %li\n",
+                x, nmax, nstep);
       return -2;
     }
 
-    if (0.1 * fabs(h) <= fabs(x) * uround)
-    {
+    if (0.1 * fabs(h) <= fabs(x) * uround) {
       if (fileout)
-        fprintf(fileout, "Exit of dop853 at x = %.16e, step size too small h = %.16e\r\n", x, h);
+        fprintf(fileout,
+                "Exit of dop853 at x = %.16e, step size too small h = %.16e\r\n", x, h);
       return -3;
     }
 
-    if ((x + 1.01 * h - xend) * posneg > 0.0)
-    {
+    if ((x + 1.01 * h - xend) * posneg > 0.0) {
       h = xend - x;
       last = 1;
     }
@@ -443,12 +403,11 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
     xph = x + h;
     for (i = 0; i < n; i++)
       yy1[i] = y[i] + h * (a121 * k1[i] + a124 * k4[i] + a125 * k5[i] + a126 * k6[i] +
-                           a127 * k7[i] + a128 * k8[i] + a129 * k9[i] +
-                           a1210 * k10[i] + a1211 * k2[i]);
+                           a127 * k7[i] + a128 * k8[i] + a129 * k9[i] + a1210 * k10[i] +
+                           a1211 * k2[i]);
     fcn(n, xph, yy1, k3, p, fr, norbits, nbody, args);
     nfcn += 11;
-    for (i = 0; i < n; i++)
-    {
+    for (i = 0; i < n; i++) {
       k4[i] = b1 * k1[i] + b6 * k6[i] + b7 * k7[i] + b8 * k8[i] + b9 * k9[i] +
               b10 * k10[i] + b11 * k2[i] + b12 * k3[i];
       k5[i] = y[i] + h * k4[i];
@@ -458,8 +417,7 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
     err = 0.0;
     err2 = 0.0;
     if (!itoler) // Scalar tolerances
-      for (i = 0; i < n; i++)
-      {
+      for (i = 0; i < n; i++) {
         sk = atoli + rtoli * max_d(fabs(y[i]), fabs(k5[i]));
         erri = k4[i] - bhh1 * k1[i] - bhh2 * k9[i] - bhh3 * k3[i];
         sqr = erri / sk;
@@ -470,8 +428,7 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
         err += sqr * sqr;
       }
     else
-      for (i = 0; i < n; i++)
-      {
+      for (i = 0; i < n; i++) {
         sk = atoler[i] + rtoler[i] * max_d(fabs(y[i]), fabs(k5[i]));
         erri = k4[i] - bhh1 * k1[i] - bhh2 * k9[i] - bhh3 * k3[i];
         sqr = erri / sk;
@@ -494,8 +451,7 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
     fac = max_d(facc2, min_d(facc1, fac / safe));
     hnew = h / fac;
 
-    if (err <= 1.0)
-    {
+    if (err <= 1.0) {
       /* step accepted */
 
       facold = max_d(err, 1.0E-4);
@@ -504,12 +460,10 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
       nfcn++;
 
       /* stiffness detection */
-      if (!(naccpt % nstiff) || (iasti > 0))
-      {
+      if (!(naccpt % nstiff) || (iasti > 0)) {
         stnum = 0.0;
         stden = 0.0;
-        for (i = 0; i < n; i++)
-        {
+        for (i = 0; i < n; i++) {
           sqr = k4[i] - k3[i];
           stnum += sqr * sqr;
           sqr = k5[i] - yy1[i];
@@ -517,20 +471,16 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
         }
         if (stden > 0.0)
           hlamb = h * sqrt(stnum / stden);
-        if (hlamb > 6.1)
-        {
+        if (hlamb > 6.1) {
           nonsti = 0;
           iasti++;
           if (iasti == 15)
             if (fileout)
               fprintf(fileout, "The problem seems to become stiff at x = %.16e\r\n", x);
-            else
-            {
+            else {
               return -4;
             }
-        }
-        else
-        {
+        } else {
           nonsti++;
           if (nonsti == 6)
             iasti = 0;
@@ -541,30 +491,32 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
       // if (iout == 2)
       // APW: modified because I don't think this logic is correct. We should enter
       // below if we are doing dense output, which is not the same as iout == 2
-      if (dense_state)
-      {
+      if (dense_state) {
         /* save the first function evaluations */
         if (dense_state->nrds == n)
-          for (i = 0; i < n; i++)
-          {
+          for (i = 0; i < n; i++) {
             dense_state->rcont1[i] = y[i];
             ydiff = k5[i] - y[i];
             dense_state->rcont2[i] = ydiff;
             bspl = h * k1[i] - ydiff;
             dense_state->rcont3[i] = bspl;
             dense_state->rcont4[i] = ydiff - h * k4[i] - bspl;
-            dense_state->rcont5[i] = d41 * k1[i] + d46 * k6[i] + d47 * k7[i] + d48 * k8[i] +
-                                     d49 * k9[i] + d410 * k10[i] + d411 * k2[i] + d412 * k3[i];
-            dense_state->rcont6[i] = d51 * k1[i] + d56 * k6[i] + d57 * k7[i] + d58 * k8[i] +
-                                     d59 * k9[i] + d510 * k10[i] + d511 * k2[i] + d512 * k3[i];
-            dense_state->rcont7[i] = d61 * k1[i] + d66 * k6[i] + d67 * k7[i] + d68 * k8[i] +
-                                     d69 * k9[i] + d610 * k10[i] + d611 * k2[i] + d612 * k3[i];
-            dense_state->rcont8[i] = d71 * k1[i] + d76 * k6[i] + d77 * k7[i] + d78 * k8[i] +
-                                     d79 * k9[i] + d710 * k10[i] + d711 * k2[i] + d712 * k3[i];
+            dense_state->rcont5[i] = d41 * k1[i] + d46 * k6[i] + d47 * k7[i] +
+                                     d48 * k8[i] + d49 * k9[i] + d410 * k10[i] +
+                                     d411 * k2[i] + d412 * k3[i];
+            dense_state->rcont6[i] = d51 * k1[i] + d56 * k6[i] + d57 * k7[i] +
+                                     d58 * k8[i] + d59 * k9[i] + d510 * k10[i] +
+                                     d511 * k2[i] + d512 * k3[i];
+            dense_state->rcont7[i] = d61 * k1[i] + d66 * k6[i] + d67 * k7[i] +
+                                     d68 * k8[i] + d69 * k9[i] + d610 * k10[i] +
+                                     d611 * k2[i] + d612 * k3[i];
+            dense_state->rcont8[i] = d71 * k1[i] + d76 * k6[i] + d77 * k7[i] +
+                                     d78 * k8[i] + d79 * k9[i] + d710 * k10[i] +
+                                     d711 * k2[i] + d712 * k3[i];
           }
-        else
-          for (j = 0; j < dense_state->nrds; j++)
-          {
+        else {
+          fprintf(fileout, "Error: SHOULD NEVER GET HERE\n");
+          for (j = 0; j < dense_state->nrds; j++) {
             i = icont[j];
             dense_state->rcont1[j] = y[i];
             ydiff = k5[i] - y[i];
@@ -572,83 +524,98 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
             bspl = h * k1[i] - ydiff;
             dense_state->rcont3[j] = bspl;
             dense_state->rcont4[j] = ydiff - h * k4[i] - bspl;
-            dense_state->rcont5[j] = d41 * k1[i] + d46 * k6[i] + d47 * k7[i] + d48 * k8[i] +
-                                     d49 * k9[i] + d410 * k10[i] + d411 * k2[i] + d412 * k3[i];
-            dense_state->rcont6[j] = d51 * k1[i] + d56 * k6[i] + d57 * k7[i] + d58 * k8[i] +
-                                     d59 * k9[i] + d510 * k10[i] + d511 * k2[i] + d512 * k3[i];
-            dense_state->rcont7[j] = d61 * k1[i] + d66 * k6[i] + d67 * k7[i] + d68 * k8[i] +
-                                     d69 * k9[i] + d610 * k10[i] + d611 * k2[i] + d612 * k3[i];
-            dense_state->rcont8[j] = d71 * k1[i] + d76 * k6[i] + d77 * k7[i] + d78 * k8[i] +
-                                     d79 * k9[i] + d710 * k10[i] + d711 * k2[i] + d712 * k3[i];
+            dense_state->rcont5[j] = d41 * k1[i] + d46 * k6[i] + d47 * k7[i] +
+                                     d48 * k8[i] + d49 * k9[i] + d410 * k10[i] +
+                                     d411 * k2[i] + d412 * k3[i];
+            dense_state->rcont6[j] = d51 * k1[i] + d56 * k6[i] + d57 * k7[i] +
+                                     d58 * k8[i] + d59 * k9[i] + d510 * k10[i] +
+                                     d511 * k2[i] + d512 * k3[i];
+            dense_state->rcont7[j] = d61 * k1[i] + d66 * k6[i] + d67 * k7[i] +
+                                     d68 * k8[i] + d69 * k9[i] + d610 * k10[i] +
+                                     d611 * k2[i] + d612 * k3[i];
+            dense_state->rcont8[j] = d71 * k1[i] + d76 * k6[i] + d77 * k7[i] +
+                                     d78 * k8[i] + d79 * k9[i] + d710 * k10[i] +
+                                     d711 * k2[i] + d712 * k3[i];
           }
+        }
 
         /* the next three function evaluations */
         for (i = 0; i < n; i++)
-          yy1[i] = y[i] + h * (a141 * k1[i] + a147 * k7[i] + a148 * k8[i] +
-                               a149 * k9[i] + a1410 * k10[i] + a1411 * k2[i] +
-                               a1412 * k3[i] + a1413 * k4[i]);
+          yy1[i] = y[i] +
+                   h * (a141 * k1[i] + a147 * k7[i] + a148 * k8[i] + a149 * k9[i] +
+                        a1410 * k10[i] + a1411 * k2[i] + a1412 * k3[i] + a1413 * k4[i]);
         fcn(n, x + c14 * h, yy1, k10, p, fr, norbits, nbody, args);
         for (i = 0; i < n; i++)
-          yy1[i] = y[i] + h * (a151 * k1[i] + a156 * k6[i] + a157 * k7[i] + a158 * k8[i] +
-                               a1511 * k2[i] + a1512 * k3[i] + a1513 * k4[i] +
-                               a1514 * k10[i]);
+          yy1[i] = y[i] +
+                   h * (a151 * k1[i] + a156 * k6[i] + a157 * k7[i] + a158 * k8[i] +
+                        a1511 * k2[i] + a1512 * k3[i] + a1513 * k4[i] + a1514 * k10[i]);
         fcn(n, x + c15 * h, yy1, k2, p, fr, norbits, nbody, args);
         for (i = 0; i < n; i++)
-          yy1[i] = y[i] + h * (a161 * k1[i] + a166 * k6[i] + a167 * k7[i] + a168 * k8[i] +
-                               a169 * k9[i] + a1613 * k4[i] + a1614 * k10[i] +
-                               a1615 * k2[i]);
+          yy1[i] = y[i] +
+                   h * (a161 * k1[i] + a166 * k6[i] + a167 * k7[i] + a168 * k8[i] +
+                        a169 * k9[i] + a1613 * k4[i] + a1614 * k10[i] + a1615 * k2[i]);
         fcn(n, x + c16 * h, yy1, k3, p, fr, norbits, nbody, args);
         nfcn += 3;
 
         /* final preparation */
         if (dense_state->nrds == n)
-          for (i = 0; i < n; i++)
-          {
-            dense_state->rcont5[i] = h * (dense_state->rcont5[i] + d413 * k4[i] + d414 * k10[i] +
-                                          d415 * k2[i] + d416 * k3[i]);
-            dense_state->rcont6[i] = h * (dense_state->rcont6[i] + d513 * k4[i] + d514 * k10[i] +
-                                          d515 * k2[i] + d516 * k3[i]);
-            dense_state->rcont7[i] = h * (dense_state->rcont7[i] + d613 * k4[i] + d614 * k10[i] +
-                                          d615 * k2[i] + d616 * k3[i]);
-            dense_state->rcont8[i] = h * (dense_state->rcont8[i] + d713 * k4[i] + d714 * k10[i] +
-                                          d715 * k2[i] + d716 * k3[i]);
+          for (i = 0; i < n; i++) {
+            dense_state->rcont5[i] = h * (dense_state->rcont5[i] + d413 * k4[i] +
+                                          d414 * k10[i] + d415 * k2[i] + d416 * k3[i]);
+            dense_state->rcont6[i] = h * (dense_state->rcont6[i] + d513 * k4[i] +
+                                          d514 * k10[i] + d515 * k2[i] + d516 * k3[i]);
+            dense_state->rcont7[i] = h * (dense_state->rcont7[i] + d613 * k4[i] +
+                                          d614 * k10[i] + d615 * k2[i] + d616 * k3[i]);
+            dense_state->rcont8[i] = h * (dense_state->rcont8[i] + d713 * k4[i] +
+                                          d714 * k10[i] + d715 * k2[i] + d716 * k3[i]);
           }
         else
-          for (j = 0; j < dense_state->nrds; j++)
-          {
+          for (j = 0; j < dense_state->nrds; j++) {
             i = icont[j];
-            dense_state->rcont5[j] = h * (dense_state->rcont5[j] + d413 * k4[i] + d414 * k10[i] +
-                                          d415 * k2[i] + d416 * k3[i]);
-            dense_state->rcont6[j] = h * (dense_state->rcont6[j] + d513 * k4[i] + d514 * k10[i] +
-                                          d515 * k2[i] + d516 * k3[i]);
-            dense_state->rcont7[j] = h * (dense_state->rcont7[j] + d613 * k4[i] + d614 * k10[i] +
-                                          d615 * k2[i] + d616 * k3[i]);
-            dense_state->rcont8[j] = h * (dense_state->rcont8[j] + d713 * k4[i] + d714 * k10[i] +
-                                          d715 * k2[i] + d716 * k3[i]);
+            dense_state->rcont5[j] = h * (dense_state->rcont5[j] + d413 * k4[i] +
+                                          d414 * k10[i] + d415 * k2[i] + d416 * k3[i]);
+            dense_state->rcont6[j] = h * (dense_state->rcont6[j] + d513 * k4[i] +
+                                          d514 * k10[i] + d515 * k2[i] + d516 * k3[i]);
+            dense_state->rcont7[j] = h * (dense_state->rcont7[j] + d613 * k4[i] +
+                                          d614 * k10[i] + d615 * k2[i] + d616 * k3[i]);
+            dense_state->rcont8[j] = h * (dense_state->rcont8[j] + d713 * k4[i] +
+                                          d714 * k10[i] + d715 * k2[i] + d716 * k3[i]);
           }
       }
 
       // After each accepted step, fill output_y for all output_times in this interval
-      if (dense_state && output_times && output_y && n_output_times > 0)
-      {
+      unsigned idx;
+      if (dense_state && output_times && output_y && n_output_times > 0) {
         double x0 = dense_state->xold;
         double h = dense_state->hout;
         double x1 = x0 + h;
 
         // For each output time in [x0, x1], fill output_y
-        while (output_idx < n_output_times)
-        {
+
+        while (output_idx < n_output_times) {
           double t_out = output_times[output_idx];
-          if ((x0 <= t_out && t_out <= x1) || (x1 <= t_out && t_out <= x0))
-          {
-            for (unsigned i = 0; i < dense_state->nrds; i++)
-            {
-              output_y[output_idx * dense_state->nrds + i] = contd8_threadsafe(dense_state, i, t_out);
+          if ((x0 <= t_out && t_out <= x1) || (x1 <= t_out && t_out <= x0)) {
+            // printf("output_idx = %u, t_out = %.16e\r\n", output_idx, t_out);
+            for (unsigned i = 0; i < dense_state->nrds; i++) {
+              idx = output_idx * dense_state->nrds + i;
+              // ENABLE THIS TO CHECK FOR OUT OF BOUNDS
+              // if (idx >= (n_output_times * dense_state->nrds)) {
+              //   fprintf(fileout, "ERROR: output index out of bounds: %d >= %d\n", idx,
+              //           n_output_times * dense_state->nrds);
+              //   return -5;
+              // }
+
+              // double val = contd8_threadsafe(dense_state, i, t_out);
+              // if (isnan(val)) {
+              //     fprintf(fileout, "NAN returned from contd8_threadsafe at output_idx=%u, i=%u\n", output_idx, i);
+              //     exit(1);
+              // }
+              // output_y[idx] = val;
+              output_y[idx] = contd8_threadsafe(dense_state, i, t_out);
+
             }
             output_idx++;
-          }
-          else
-          {
+          } else {
             break;
           }
         }
@@ -658,11 +625,9 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
       memcpy(y, k5, n * sizeof(double));
       x = xph;
 
-      if (iout)
-      {
+      if (iout) {
         solout(naccpt + 1, x, x, y, n, &irtrn);
-        if (irtrn < 0)
-        {
+        if (irtrn < 0) {
           if (fileout)
             fprintf(fileout, "Exit of dop853 at x = %.16e\r\n", x);
           return 2;
@@ -670,14 +635,18 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
       }
 
       /* normal exit */
-      if (last)
-      {
+      if (last) {
         // After the integration loop, or in the 'last' block:
-        if (output_idx == n_output_times)
-        {
-          for (unsigned i = 0; i < dense_state->nrds; i++)
-          {
-            output_y[(n_output_times - 1) * dense_state->nrds + i] = y[i];
+        if (dense_state && output_idx == n_output_times) {
+          for (unsigned i = 0; i < dense_state->nrds; i++) {
+            idx = (n_output_times - 1) * dense_state->nrds + i;
+            // ENABLE THIS TO CHECK FOR OUT OF BOUNDS
+            // if (idx >= (n_output_times * dense_state->nrds)) {
+            //   fprintf(fileout, "ERROR: output index out of bounds: %d >= %d\n", idx,
+            //           n_output_times * dense_state->nrds);
+            //   return -5;
+            // }
+            output_y[idx] = y[i];
           }
         }
         return 1;
@@ -689,9 +658,7 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
         hnew = posneg * min_d(fabs(hnew), fabs(h));
 
       reject = 0;
-    }
-    else
-    {
+    } else {
       /* step rejected */
       hnew = h / min_d(facc1, fac11 / safe);
       reject = 1;
@@ -706,23 +673,20 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsi
 } /* dopcor */
 
 /* front-end */
-int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
-           double x, double *y, double xend, double *rtoler,
-           double *atoler, int itoler, SolTrait solout, int iout, FILE *fileout, double uround,
-           double safe, double fac1, double fac2, double beta, double hmax, double h,
-           long nmax, int meth, long nstiff, unsigned nrdens, unsigned *icont, unsigned licont,
-           Dop853DenseState *dense_state,
-           double *output_times, int n_output_times, double *output_y)
-{
-  int arret, idid;
+int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits,
+           unsigned nbody, void *args, double x, double *y, double xend, double *rtoler,
+           double *atoler, int itoler, SolTrait solout, int iout, FILE *fileout,
+           double uround, double safe, double fac1, double fac2, double beta,
+           double hmax, double h, long nmax, int meth, long nstiff, unsigned nrdens,
+           unsigned *icont, unsigned licont, Dop853DenseState *dense_state,
+           double *output_times, int n_output_times, double *output_y) {
+  int arret = 0;
+  int idid;
   unsigned i;
-
-  /* initialisations */
-  nfcn = nstep = naccpt = nrejct = arret = 0;
+  double *yy1, *k1, *k2, *k3, *k4, *k5, *k6, *k7, *k8, *k9, *k10;
 
   /* n, the dimension of the system */
-  if (n == UINT_MAX)
-  {
+  if (n == UINT_MAX) {
     if (fileout)
       fprintf(fileout, "System too big, max. n = %u\r\n", UINT_MAX - 1);
     arret = 1;
@@ -731,8 +695,7 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
   /* nmax, the maximal number of steps */
   if (!nmax)
     nmax = 100000;
-  else if (nmax <= 0)
-  {
+  else if (nmax <= 0) {
     if (fileout)
       fprintf(fileout, "Wrong input, nmax = %li\r\n", nmax);
     arret = 1;
@@ -741,8 +704,7 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
   /* meth, coefficients of the method */
   if (!meth)
     meth = 1;
-  else if ((meth <= 0) || (meth >= 2))
-  {
+  else if ((meth <= 0) || (meth >= 2)) {
     if (fileout)
       fprintf(fileout, "Curious input, meth = %i\r\n", meth);
     arret = 1;
@@ -755,43 +717,44 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
     nstiff = nmax + 10;
 
   /* iout, switch for calling solout */
-  if ((iout < 0) || (iout > 2))
-  {
+  if ((iout < 0) || (iout > 2)) {
     if (fileout)
       fprintf(fileout, "Wrong input, iout = %i\r\n", iout);
     arret = 1;
   }
 
   /* nrdens, number of dense output components */
-  if (nrdens > n)
-  {
+  if (nrdens > n) {
     if (fileout)
       fprintf(fileout, "Curious input, nrdens = %u\r\n", nrdens);
     arret = 1;
-  }
-  else if (nrdens)
-  {
-    if (!dense_state)
-    {
+  } else if (nrdens) {
+    // ADDED BY APW:
+    if (nrdens != n) {
+      if (fileout) {
+        fprintf(fileout, "Warning: nrdens = %u, but not all components are dense\n",
+                nrdens);
+        arret = 1;
+      }
+    }
+
+    if (!dense_state) {
       if (fileout)
         fprintf(fileout, "Dense state must be pre-allocated\r\n");
       arret = 1;
     }
     /* control of length of icont */
-    if (nrdens == n)
-    {
+    if (nrdens == n) {
       if (icont && fileout)
-        fprintf(fileout, "Warning : when nrdens = n there is no need allocating memory for icont\r\n");
+        fprintf(fileout, "Warning : when nrdens = n there is no need allocating memory "
+                         "for icont\r\n");
       dense_state->nrds = n;
-    }
-    else if (licont < nrdens)
-    {
+    } else if (licont < nrdens) {
       if (fileout)
-        fprintf(fileout, "Insufficient storage for icont, min. licont = %u\r\n", nrdens);
+        fprintf(fileout, "Insufficient storage for icont, min. licont = %u\r\n",
+                nrdens);
       arret = 1;
-    }
-    else
-    {
+    } else {
       if ((iout < 2) && fileout)
         fprintf(fileout, "Warning : put iout = 2 for dense output\r\n");
       dense_state->nrds = nrdens;
@@ -800,27 +763,24 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
       for (i = 0; i < nrdens; i++)
         dense_state->indir[icont[i]] = i;
     }
-  }
-  else
-  {
+  } else {
     dense_state = NULL; // Defensive: ensure not used
   }
 
   /* uround, smallest number satisfying 1.0+uround > 1.0 */
   if (uround == 0.0)
     uround = 2.3E-16;
-  else if ((uround <= 1.0E-35) || (uround >= 1.0))
-  {
+  else if ((uround <= 1.0E-35) || (uround >= 1.0)) {
     if (fileout)
-      fprintf(fileout, "Which machine do you have ? Your uround was : %.16e\r\n", uround);
+      fprintf(fileout, "Which machine do you have ? Your uround was : %.16e\r\n",
+              uround);
     arret = 1;
   }
 
   /* safety factor */
   if (safe == 0.0)
     safe = 0.9;
-  else if ((safe >= 1.0) || (safe <= 1.0E-4))
-  {
+  else if ((safe >= 1.0) || (safe <= 1.0E-4)) {
     if (fileout)
       fprintf(fileout, "Curious input for safety factor, safe = %.16e\r\n", safe);
     arret = 1;
@@ -837,8 +797,7 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
     beta = 0.0;
   else if (beta < 0.0)
     beta = 0.0;
-  else if (beta > 0.2)
-  {
+  else if (beta > 0.2) {
     if (fileout)
       fprintf(fileout, "Curious input for beta : beta = %.16e\r\n", beta);
     arret = 1;
@@ -861,16 +820,43 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
   k9 = (double *)malloc(n * sizeof(double));
   k10 = (double *)malloc(n * sizeof(double));
 
-  if (!yy1 || !k1 || !k2 || !k3 || !k4 || !k5 || !k6 || !k7 || !k8 || !k9 || !k10)
-  {
+  if (!yy1 || !k1 || !k2 || !k3 || !k4 || !k5 || !k6 || !k7 || !k8 || !k9 || !k10) {
     if (fileout)
       fprintf(fileout, "Not enough free memory for the method\r\n");
     arret = 1;
   }
 
   /* when a failure has occured, we return -1 */
-  if (arret)
-  {
+  if (arret) {
+    if (k10)
+      free(k10);
+    if (k9)
+      free(k9);
+    if (k8)
+      free(k8);
+    if (k7)
+      free(k7);
+    if (k6)
+      free(k6);
+    if (k5)
+      free(k5);
+    if (k4)
+      free(k4);
+    if (k3)
+      free(k3);
+    if (k2)
+      free(k2);
+    if (k1)
+      free(k1);
+    if (yy1)
+      free(yy1);
+    return -1;
+  } else {
+    idid =
+        dopcor(n, fcn, p, fr, norbits, nbody, args, x, y, xend, hmax, h, rtoler, atoler,
+               itoler, fileout, solout, iout, nmax, uround, meth, nstiff, safe, beta,
+               fac1, fac2, icont, nrdens > 0 ? dense_state : NULL, yy1, k1, k2, k3, k4,
+               k5, k6, k7, k8, k9, k10, output_times, n_output_times, output_y);
     if (k10)
       free(k10);
     if (k9)
@@ -894,72 +880,55 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
     if (yy1)
       free(yy1);
 
-    return -1;
-  }
-  else
-  {
-    idid = dopcor(n, fcn, p, fr, norbits, nbody, args, x, y, xend, hmax, h, rtoler, atoler, itoler, fileout,
-                  solout, iout, nmax, uround, meth, nstiff, safe, beta, fac1, fac2, icont, nrdens > 0 ? dense_state : NULL,
-                  output_times, n_output_times, output_y);
-    free(k10);
-    free(k9);
-    free(k8);
-    free(k7);
-    free(k6);
-    free(k5); /* reverse order freeing too increase chances */
-    free(k4); /* of efficient dynamic memory managing       */
-    free(k3);
-    free(k2);
-    free(k1);
-    free(yy1);
-
     return idid;
   }
 
 } /* dop853 */
 
 // Thread-safe dense output function
-double contd8_threadsafe(Dop853DenseState *state, unsigned ii, double x)
-{
-  if (!state)
-  {
+double contd8_threadsafe(Dop853DenseState *state, unsigned ii, double x) {
+  if (!state) {
     fprintf(stderr, "contd8_threadsafe: state is NULL\n");
     return 0.0;
   }
   if (!state->rcont1 || !state->rcont2 || !state->rcont3 || !state->rcont4 ||
-      !state->rcont5 || !state->rcont6 || !state->rcont7 || !state->rcont8)
-  {
+      !state->rcont5 || !state->rcont6 || !state->rcont7 || !state->rcont8) {
     fprintf(stderr, "contd8_threadsafe: one or more rcont arrays are NULL\n");
     return 0.0;
   }
-  if (ii >= state->nrds)
-  {
-    fprintf(stderr, "contd8_threadsafe: ii=%u out of bounds (nrds=%u)\n", ii, state->nrds);
+  if (ii >= state->nrds) {
+    fprintf(stderr, "contd8_threadsafe: ii=%u out of bounds (nrds=%u)\n", ii,
+            state->nrds);
     return 0.0;
   }
   unsigned i;
-  if (!state->indir)
-  {
+  if (!state->indir) {
     i = ii;
-  }
-  else
-  {
+  } else {
     i = state->indir[ii];
   }
-  if (i == UINT_MAX)
-  {
-    fprintf(stderr, "contd8_threadsafe: No dense output available for %uth component\n", ii);
+  if (i == UINT_MAX) {
+    fprintf(stderr, "contd8_threadsafe: No dense output available for %uth component\n",
+            ii);
     return 0.0;
   }
   double s = (x - state->xold) / state->hout;
   double s1 = 1.0 - s;
-  return state->rcont1[i] + s * (state->rcont2[i] + s1 * (state->rcont3[i] + s * (state->rcont4[i] + s1 * (state->rcont5[i] + s * (state->rcont6[i] + s1 * (state->rcont7[i] + s * state->rcont8[i]))))));
+  return state->rcont1[i] +
+         s * (state->rcont2[i] +
+              s1 * (state->rcont3[i] +
+                    s * (state->rcont4[i] +
+                         s1 * (state->rcont5[i] +
+                               s * (state->rcont6[i] +
+                                    s1 * (state->rcont7[i] + s * state->rcont8[i]))))));
 }
 
 // Allocate a Dop853DenseState and its arrays
-Dop853DenseState *dop853_dense_state_alloc(unsigned nrdens, unsigned n)
-{
+Dop853DenseState *dop853_dense_state_alloc(unsigned nrdens, unsigned n) {
   Dop853DenseState *state = (Dop853DenseState *)malloc(sizeof(Dop853DenseState));
+  if (nrdens != n) {
+    printf("alloc: nrdens != n\n");
+  }
   if (!state)
     return NULL;
   state->rcont1 = (double *)malloc(nrdens * sizeof(double));
@@ -973,18 +942,15 @@ Dop853DenseState *dop853_dense_state_alloc(unsigned nrdens, unsigned n)
   state->nrds = nrdens;
   state->xold = 0.0;
   state->hout = 0.0;
-  if (nrdens < n)
-  {
+  if (nrdens < n) {
     state->indir = (unsigned *)malloc(n * sizeof(unsigned));
-  }
-  else
-  {
+  } else {
     state->indir = NULL;
   }
   if (!state->rcont1 || !state->rcont2 || !state->rcont3 || !state->rcont4 ||
       !state->rcont5 || !state->rcont6 || !state->rcont7 || !state->rcont8 ||
-      (nrdens < n && !state->indir))
-  {
+      (nrdens < n && !state->indir)) {
+    printf("ERROR: freeing dense_state early\n");
     dop853_dense_state_free(state, n);
     return NULL;
   }
@@ -992,8 +958,7 @@ Dop853DenseState *dop853_dense_state_alloc(unsigned nrdens, unsigned n)
 }
 
 // Free a Dop853DenseState and its arrays
-void dop853_dense_state_free(Dop853DenseState *state, unsigned n)
-{
+void dop853_dense_state_free(Dop853DenseState *state, unsigned n) {
   if (!state)
     return;
   if (state->rcont1)
@@ -1018,27 +983,22 @@ void dop853_dense_state_free(Dop853DenseState *state, unsigned n)
 }
 
 /* ADDED BY APW */
-void Fwrapper(unsigned full_ndim, double t, double *w, double *f,
-              CPotential *p, CFrameType *fr, unsigned norbits, unsigned na,
-              void *args)
-{
+void Fwrapper(unsigned full_ndim, double t, double *w, double *f, CPotential *p,
+              CFrameType *fr, unsigned norbits, unsigned na, void *args) {
   /* na can be ignored here - used in nbody wrapper below */
 
   int i;
   unsigned ndim = full_ndim / norbits; // phase-space dimensionality
 
-  for (i = 0; i < norbits; i++)
-  {
+  for (i = 0; i < norbits; i++) {
     // call gradient function
     hamiltonian_gradient(p, fr, t, &w[i * ndim], &f[i * ndim]);
   }
 }
 
 void Fwrapper_direct_nbody(unsigned full_ndim, double t, double *w, double *f,
-                           CPotential *p, CFrameType *fr,
-                           unsigned norbits, unsigned nbody,
-                           void *args)
-{
+                           CPotential *p, CFrameType *fr, unsigned norbits,
+                           unsigned nbody, void *args) {
   /* Here, the extra args are actually the array of CPotential objects that
      represent the potentials of the individual particles.
   */
@@ -1055,11 +1015,9 @@ void Fwrapper_direct_nbody(unsigned full_ndim, double t, double *w, double *f,
 }
 
 /* Needed for Lyapunov */
-double six_norm(double *x)
-{
+double six_norm(double *x) {
   double norm = 0;
-  for (int i = 0; i < 6; i++)
-  {
+  for (int i = 0; i < 6; i++) {
     norm = norm + x[i] * x[i];
   }
   return sqrt(norm);

--- a/gala/integrate/cyintegrators/dopri/dop853.c
+++ b/gala/integrate/cyintegrators/dopri/dop853.c
@@ -6,84 +6,57 @@
 #include <memory.h>
 #include "dop853.h"
 
+static long nfcn, nstep, naccpt, nrejct;
+static double *yy1, *k1, *k2, *k3, *k4, *k5, *k6, *k7, *k8, *k9, *k10;
 
-static long      nfcn, nstep, naccpt, nrejct;
-static double    hout, xold, xout;
-static unsigned  nrds, *indir;
-static double    *yy1, *k1, *k2, *k3, *k4, *k5, *k6, *k7, *k8, *k9, *k10;
-static double    *rcont1, *rcont2, *rcont3, *rcont4;
-static double    *rcont5, *rcont6, *rcont7, *rcont8;
-
-
-long nfcnRead (void)
+long nfcnRead(void)
 {
   return nfcn;
 
 } /* nfcnRead */
 
-
-long nstepRead (void)
+long nstepRead(void)
 {
   return nstep;
 
 } /* stepRead */
 
-
-long naccptRead (void)
+long naccptRead(void)
 {
   return naccpt;
 
 } /* naccptRead */
 
-
-long nrejctRead (void)
+long nrejctRead(void)
 {
   return nrejct;
 
 } /* nrejct */
 
-
-double hRead (void)
+static double sign(double a, double b)
 {
-  return hout;
-
-} /* hRead */
-
-
-double xRead (void)
-{
-  return xout;
-
-} /* xRead */
-
-
-static double sign (double a, double b)
-{
-  return (b < 0.0)? -fabs(a) : fabs(a);
+  return (b < 0.0) ? -fabs(a) : fabs(a);
 
 } /* sign */
 
-
-static double min_d (double a, double b)
+static double min_d(double a, double b)
 {
-  return (a < b)?a:b;
+  return (a < b) ? a : b;
 
 } /* min_d */
 
-
-static double max_d (double a, double b)
+static double max_d(double a, double b)
 {
-  return (a > b)?a:b;
+  return (a > b) ? a : b;
 
 } /* max_d */
 
-
-static double hinit (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
-        double x, double* y,
-	      double posneg, double* f0, double* f1, double* yy1, int iord,
-	      double hmax, double* atoler, double* rtoler, int itoler)
+static double hinit(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
+                    double x, double *y,
+                    double posneg, double *f0, double *f1, double *yy1, int iord,
+                    double hmax, double *atoler, double *rtoler, int itoler)
 {
-  double   dnf, dny, atoli, rtoli, sk, h, h1, der2, der12, sqr;
+  double dnf, dny, atoli, rtoli, sk, h, h1, der2, der12, sqr;
   unsigned i;
 
   dnf = 0.0;
@@ -96,32 +69,32 @@ static double hinit (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, u
     {
       sk = atoli + rtoli * fabs(y[i]);
       sqr = f0[i] / sk;
-      dnf += sqr*sqr;
+      dnf += sqr * sqr;
       sqr = y[i] / sk;
-      dny += sqr*sqr;
+      dny += sqr * sqr;
     }
   else
     for (i = 0; i < n; i++)
     {
       sk = atoler[i] + rtoler[i] * fabs(y[i]);
       sqr = f0[i] / sk;
-      dnf += sqr*sqr;
+      dnf += sqr * sqr;
       sqr = y[i] / sk;
-      dny += sqr*sqr;
+      dny += sqr * sqr;
     }
 
   if ((dnf <= 1.0E-10) || (dny <= 1.0E-10))
     h = 1.0E-6;
   else
-    h = sqrt (dny/dnf) * 0.01;
+    h = sqrt(dny / dnf) * 0.01;
 
-  h = min_d (h, hmax);
-  h = sign (h, posneg);
+  h = min_d(h, hmax);
+  h = sign(h, posneg);
 
   /* perform an explicit Euler step */
   for (i = 0; i < n; i++)
     yy1[i] = y[i] + h * f0[i];
-  fcn (n, x+h, yy1, f1, p, fr, norbits, nbody, args);
+  fcn(n, x + h, yy1, f1, p, fr, norbits, nbody, args);
 
   /* estimate the second derivative of the solution */
   der2 = 0.0;
@@ -130,265 +103,270 @@ static double hinit (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, u
     {
       sk = atoli + rtoli * fabs(y[i]);
       sqr = (f1[i] - f0[i]) / sk;
-      der2 += sqr*sqr;
+      der2 += sqr * sqr;
     }
   else
     for (i = 0; i < n; i++)
     {
       sk = atoler[i] + rtoler[i] * fabs(y[i]);
       sqr = (f1[i] - f0[i]) / sk;
-      der2 += sqr*sqr;
+      der2 += sqr * sqr;
     }
-  der2 = sqrt (der2) / h;
+  der2 = sqrt(der2) / h;
 
   /* step size is computed such that h**iord * max_d(norm(f0),norm(der2)) = 0.01 */
-  der12 = max_d (fabs(der2), sqrt(dnf));
+  der12 = max_d(fabs(der2), sqrt(dnf));
   if (der12 <= 1.0E-15)
-    h1 = max_d (1.0E-6, fabs(h)*1.0E-3);
+    h1 = max_d(1.0E-6, fabs(h) * 1.0E-3);
   else
-    h1 = pow (0.01/der12, 1.0/(double)iord);
-  h = min_d (100.0 * fabs(h), min_d (h1, hmax));
+    h1 = pow(0.01 / der12, 1.0 / (double)iord);
+  h = min_d(100.0 * fabs(h), min_d(h1, hmax));
 
-  return sign (h, posneg);
+  return sign(h, posneg);
 
 } /* hinit */
 
-
 /* core integrator */
-static int dopcor (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
-       double x, double* y, double xend,
-		   double hmax, double h, double* rtoler, double* atoler,
-		   int itoler, FILE* fileout, SolTrait solout, int iout,
-		   long nmax, double uround, int meth, long nstiff, double safe,
-		   double beta, double fac1, double fac2, unsigned* icont)
+static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
+                  double x, double *y, double xend,
+                  double hmax, double h, double *rtoler, double *atoler,
+                  int itoler, FILE *fileout, SolTrait solout, int iout,
+                  long nmax, double uround, int meth, long nstiff, double safe,
+                  double beta, double fac1, double fac2, unsigned *icont,
+                  Dop853DenseState *dense_state)
 {
-  double   facold, expo1, fac, facc1, facc2, fac11, posneg, xph;
-  double   atoli, rtoli, hlamb, err, sk, hnew, yd0, ydiff, bspl;
-  double   stnum, stden, sqr, err2, erri, deno;
-  int      iasti, iord, irtrn, reject, last, nonsti;
+  double facold, expo1, fac, facc1, facc2, fac11, posneg, xph;
+  double atoli, rtoli, hlamb, err, sk, hnew, yd0, ydiff, bspl;
+  double stnum, stden, sqr, err2, erri, deno;
+  int iasti, iord, irtrn, reject, last, nonsti;
   unsigned i, j;
-  double   c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c14, c15, c16;
-  double   b1, b6, b7, b8, b9, b10, b11, b12, bhh1, bhh2, bhh3;
-  double   er1, er6, er7, er8, er9, er10, er11, er12;
-  double   a21, a31, a32, a41, a43, a51, a53, a54, a61, a64, a65, a71, a74, a75, a76;
-  double   a81, a84, a85, a86, a87, a91, a94, a95, a96, a97, a98;
-  double   a101, a104, a105, a106, a107, a108, a109;
-  double   a111, a114, a115, a116, a117, a118, a119, a1110;
-  double   a121, a124, a125, a126, a127, a128, a129, a1210, a1211;
-  double   a141, a147, a148, a149, a1410, a1411, a1412, a1413;
-  double   a151, a156, a157, a158, a1511, a1512, a1513, a1514;
-  double   a161, a166, a167, a168, a169, a1613, a1614, a1615;
-  double   d41, d46, d47, d48, d49, d410, d411, d412, d413, d414, d415, d416;
-  double   d51, d56, d57, d58, d59, d510, d511, d512, d513, d514, d515, d516;
-  double   d61, d66, d67, d68, d69, d610, d611, d612, d613, d614, d615, d616;
-  double   d71, d76, d77, d78, d79, d710, d711, d712, d713, d714, d715, d716;
+  double c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c14, c15, c16;
+  double b1, b6, b7, b8, b9, b10, b11, b12, bhh1, bhh2, bhh3;
+  double er1, er6, er7, er8, er9, er10, er11, er12;
+  double a21, a31, a32, a41, a43, a51, a53, a54, a61, a64, a65, a71, a74, a75, a76;
+  double a81, a84, a85, a86, a87, a91, a94, a95, a96, a97, a98;
+  double a101, a104, a105, a106, a107, a108, a109;
+  double a111, a114, a115, a116, a117, a118, a119, a1110;
+  double a121, a124, a125, a126, a127, a128, a129, a1210, a1211;
+  double a141, a147, a148, a149, a1410, a1411, a1412, a1413;
+  double a151, a156, a157, a158, a1511, a1512, a1513, a1514;
+  double a161, a166, a167, a168, a169, a1613, a1614, a1615;
+  double d41, d46, d47, d48, d49, d410, d411, d412, d413, d414, d415, d416;
+  double d51, d56, d57, d58, d59, d510, d511, d512, d513, d514, d515, d516;
+  double d61, d66, d67, d68, d69, d610, d611, d612, d613, d614, d615, d616;
+  double d71, d76, d77, d78, d79, d710, d711, d712, d713, d714, d715, d716;
 
   /* initialisations */
   switch (meth)
   {
-    case 1:
+  case 1:
 
-      c2  = 0.526001519587677318785587544488E-01;
-      c3  = 0.789002279381515978178381316732E-01;
-      c4  = 0.118350341907227396726757197510E+00;
-      c5  = 0.281649658092772603273242802490E+00;
-      c6  = 0.333333333333333333333333333333E+00;
-      c7  = 0.25E+00;
-      c8  = 0.307692307692307692307692307692E+00;
-      c9  = 0.651282051282051282051282051282E+00;
-      c10 = 0.6E+00;
-      c11 = 0.857142857142857142857142857142E+00;
-      c14 = 0.1E+00;
-      c15 = 0.2E+00;
-      c16 = 0.777777777777777777777777777778E+00;
+    c2 = 0.526001519587677318785587544488E-01;
+    c3 = 0.789002279381515978178381316732E-01;
+    c4 = 0.118350341907227396726757197510E+00;
+    c5 = 0.281649658092772603273242802490E+00;
+    c6 = 0.333333333333333333333333333333E+00;
+    c7 = 0.25E+00;
+    c8 = 0.307692307692307692307692307692E+00;
+    c9 = 0.651282051282051282051282051282E+00;
+    c10 = 0.6E+00;
+    c11 = 0.857142857142857142857142857142E+00;
+    c14 = 0.1E+00;
+    c15 = 0.2E+00;
+    c16 = 0.777777777777777777777777777778E+00;
 
-      b1 =   5.42937341165687622380535766363E-2;
-      b6 =   4.45031289275240888144113950566E0;
-      b7 =   1.89151789931450038304281599044E0;
-      b8 =  -5.8012039600105847814672114227E0;
-      b9 =   3.1116436695781989440891606237E-1;
-      b10 = -1.52160949662516078556178806805E-1;
-      b11 =  2.01365400804030348374776537501E-1;
-      b12 =  4.47106157277725905176885569043E-2;
+    b1 = 5.42937341165687622380535766363E-2;
+    b6 = 4.45031289275240888144113950566E0;
+    b7 = 1.89151789931450038304281599044E0;
+    b8 = -5.8012039600105847814672114227E0;
+    b9 = 3.1116436695781989440891606237E-1;
+    b10 = -1.52160949662516078556178806805E-1;
+    b11 = 2.01365400804030348374776537501E-1;
+    b12 = 4.47106157277725905176885569043E-2;
 
-      bhh1 = 0.244094488188976377952755905512E+00;
-      bhh2 = 0.733846688281611857341361741547E+00;
-      bhh3 = 0.220588235294117647058823529412E-01;
+    bhh1 = 0.244094488188976377952755905512E+00;
+    bhh2 = 0.733846688281611857341361741547E+00;
+    bhh3 = 0.220588235294117647058823529412E-01;
 
-      er1  =  0.1312004499419488073250102996E-01;
-      er6  = -0.1225156446376204440720569753E+01;
-      er7  = -0.4957589496572501915214079952E+00;
-      er8  =  0.1664377182454986536961530415E+01;
-      er9  = -0.3503288487499736816886487290E+00;
-      er10 =  0.3341791187130174790297318841E+00;
-      er11 =  0.8192320648511571246570742613E-01;
-      er12 = -0.2235530786388629525884427845E-01;
+    er1 = 0.1312004499419488073250102996E-01;
+    er6 = -0.1225156446376204440720569753E+01;
+    er7 = -0.4957589496572501915214079952E+00;
+    er8 = 0.1664377182454986536961530415E+01;
+    er9 = -0.3503288487499736816886487290E+00;
+    er10 = 0.3341791187130174790297318841E+00;
+    er11 = 0.8192320648511571246570742613E-01;
+    er12 = -0.2235530786388629525884427845E-01;
 
-      a21 =    5.26001519587677318785587544488E-2;
-      a31 =    1.97250569845378994544595329183E-2;
-      a32 =    5.91751709536136983633785987549E-2;
-      a41 =    2.95875854768068491816892993775E-2;
-      a43 =    8.87627564304205475450678981324E-2;
-      a51 =    2.41365134159266685502369798665E-1;
-      a53 =   -8.84549479328286085344864962717E-1;
-      a54 =    9.24834003261792003115737966543E-1;
-      a61 =    3.7037037037037037037037037037E-2;
-      a64 =    1.70828608729473871279604482173E-1;
-      a65 =    1.25467687566822425016691814123E-1;
-      a71 =    3.7109375E-2;
-      a74 =    1.70252211019544039314978060272E-1;
-      a75 =    6.02165389804559606850219397283E-2;
-      a76 =   -1.7578125E-2;
+    a21 = 5.26001519587677318785587544488E-2;
+    a31 = 1.97250569845378994544595329183E-2;
+    a32 = 5.91751709536136983633785987549E-2;
+    a41 = 2.95875854768068491816892993775E-2;
+    a43 = 8.87627564304205475450678981324E-2;
+    a51 = 2.41365134159266685502369798665E-1;
+    a53 = -8.84549479328286085344864962717E-1;
+    a54 = 9.24834003261792003115737966543E-1;
+    a61 = 3.7037037037037037037037037037E-2;
+    a64 = 1.70828608729473871279604482173E-1;
+    a65 = 1.25467687566822425016691814123E-1;
+    a71 = 3.7109375E-2;
+    a74 = 1.70252211019544039314978060272E-1;
+    a75 = 6.02165389804559606850219397283E-2;
+    a76 = -1.7578125E-2;
 
-      a81 =    3.70920001185047927108779319836E-2;
-      a84 =    1.70383925712239993810214054705E-1;
-      a85 =    1.07262030446373284651809199168E-1;
-      a86 =   -1.53194377486244017527936158236E-2;
-      a87 =    8.27378916381402288758473766002E-3;
-      a91 =    6.24110958716075717114429577812E-1;
-      a94 =   -3.36089262944694129406857109825E0;
-      a95 =   -8.68219346841726006818189891453E-1;
-      a96 =    2.75920996994467083049415600797E1;
-      a97 =    2.01540675504778934086186788979E1;
-      a98 =   -4.34898841810699588477366255144E1;
-      a101 =   4.77662536438264365890433908527E-1;
-      a104 =  -2.48811461997166764192642586468E0;
-      a105 =  -5.90290826836842996371446475743E-1;
-      a106 =   2.12300514481811942347288949897E1;
-      a107 =   1.52792336328824235832596922938E1;
-      a108 =  -3.32882109689848629194453265587E1;
-      a109 =  -2.03312017085086261358222928593E-2;
+    a81 = 3.70920001185047927108779319836E-2;
+    a84 = 1.70383925712239993810214054705E-1;
+    a85 = 1.07262030446373284651809199168E-1;
+    a86 = -1.53194377486244017527936158236E-2;
+    a87 = 8.27378916381402288758473766002E-3;
+    a91 = 6.24110958716075717114429577812E-1;
+    a94 = -3.36089262944694129406857109825E0;
+    a95 = -8.68219346841726006818189891453E-1;
+    a96 = 2.75920996994467083049415600797E1;
+    a97 = 2.01540675504778934086186788979E1;
+    a98 = -4.34898841810699588477366255144E1;
+    a101 = 4.77662536438264365890433908527E-1;
+    a104 = -2.48811461997166764192642586468E0;
+    a105 = -5.90290826836842996371446475743E-1;
+    a106 = 2.12300514481811942347288949897E1;
+    a107 = 1.52792336328824235832596922938E1;
+    a108 = -3.32882109689848629194453265587E1;
+    a109 = -2.03312017085086261358222928593E-2;
 
-      a111 =  -9.3714243008598732571704021658E-1;
-      a114 =   5.18637242884406370830023853209E0;
-      a115 =   1.09143734899672957818500254654E0;
-      a116 =  -8.14978701074692612513997267357E0;
-      a117 =  -1.85200656599969598641566180701E1;
-      a118 =   2.27394870993505042818970056734E1;
-      a119 =   2.49360555267965238987089396762E0;
-      a1110 = -3.0467644718982195003823669022E0;
-      a121 =   2.27331014751653820792359768449E0;
-      a124 =  -1.05344954667372501984066689879E1;
-      a125 =  -2.00087205822486249909675718444E0;
-      a126 =  -1.79589318631187989172765950534E1;
-      a127 =   2.79488845294199600508499808837E1;
-      a128 =  -2.85899827713502369474065508674E0;
-      a129 =  -8.87285693353062954433549289258E0;
-      a1210 =  1.23605671757943030647266201528E1;
-      a1211 =  6.43392746015763530355970484046E-1;
+    a111 = -9.3714243008598732571704021658E-1;
+    a114 = 5.18637242884406370830023853209E0;
+    a115 = 1.09143734899672957818500254654E0;
+    a116 = -8.14978701074692612513997267357E0;
+    a117 = -1.85200656599969598641566180701E1;
+    a118 = 2.27394870993505042818970056734E1;
+    a119 = 2.49360555267965238987089396762E0;
+    a1110 = -3.0467644718982195003823669022E0;
+    a121 = 2.27331014751653820792359768449E0;
+    a124 = -1.05344954667372501984066689879E1;
+    a125 = -2.00087205822486249909675718444E0;
+    a126 = -1.79589318631187989172765950534E1;
+    a127 = 2.79488845294199600508499808837E1;
+    a128 = -2.85899827713502369474065508674E0;
+    a129 = -8.87285693353062954433549289258E0;
+    a1210 = 1.23605671757943030647266201528E1;
+    a1211 = 6.43392746015763530355970484046E-1;
 
-      a141 =  5.61675022830479523392909219681E-2;
-      a147 =  2.53500210216624811088794765333E-1;
-      a148 = -2.46239037470802489917441475441E-1;
-      a149 = -1.24191423263816360469010140626E-1;
-      a1410 =  1.5329179827876569731206322685E-1;
-      a1411 =  8.20105229563468988491666602057E-3;
-      a1412 =  7.56789766054569976138603589584E-3;
-      a1413 = -8.298E-3;
+    a141 = 5.61675022830479523392909219681E-2;
+    a147 = 2.53500210216624811088794765333E-1;
+    a148 = -2.46239037470802489917441475441E-1;
+    a149 = -1.24191423263816360469010140626E-1;
+    a1410 = 1.5329179827876569731206322685E-1;
+    a1411 = 8.20105229563468988491666602057E-3;
+    a1412 = 7.56789766054569976138603589584E-3;
+    a1413 = -8.298E-3;
 
-      a151 =  3.18346481635021405060768473261E-2;
-      a156 =  2.83009096723667755288322961402E-2;
-      a157 =  5.35419883074385676223797384372E-2;
-      a158 = -5.49237485713909884646569340306E-2;
-      a1511 = -1.08347328697249322858509316994E-4;
-      a1512 =  3.82571090835658412954920192323E-4;
-      a1513 = -3.40465008687404560802977114492E-4;
-      a1514 =  1.41312443674632500278074618366E-1;
-      a161 = -4.28896301583791923408573538692E-1;
-      a166 = -4.69762141536116384314449447206E0;
-      a167 =  7.68342119606259904184240953878E0;
-      a168 =  4.06898981839711007970213554331E0;
-      a169 =  3.56727187455281109270669543021E-1;
-      a1613 = -1.39902416515901462129418009734E-3;
-      a1614 =  2.9475147891527723389556272149E0;
-      a1615 = -9.15095847217987001081870187138E0;
+    a151 = 3.18346481635021405060768473261E-2;
+    a156 = 2.83009096723667755288322961402E-2;
+    a157 = 5.35419883074385676223797384372E-2;
+    a158 = -5.49237485713909884646569340306E-2;
+    a1511 = -1.08347328697249322858509316994E-4;
+    a1512 = 3.82571090835658412954920192323E-4;
+    a1513 = -3.40465008687404560802977114492E-4;
+    a1514 = 1.41312443674632500278074618366E-1;
+    a161 = -4.28896301583791923408573538692E-1;
+    a166 = -4.69762141536116384314449447206E0;
+    a167 = 7.68342119606259904184240953878E0;
+    a168 = 4.06898981839711007970213554331E0;
+    a169 = 3.56727187455281109270669543021E-1;
+    a1613 = -1.39902416515901462129418009734E-3;
+    a1614 = 2.9475147891527723389556272149E0;
+    a1615 = -9.15095847217987001081870187138E0;
 
-      d41  = -0.84289382761090128651353491142E+01;
-      d46  =  0.56671495351937776962531783590E+00;
-      d47  = -0.30689499459498916912797304727E+01;
-      d48  =  0.23846676565120698287728149680E+01;
-      d49  =  0.21170345824450282767155149946E+01;
-      d410 = -0.87139158377797299206789907490E+00;
-      d411 =  0.22404374302607882758541771650E+01;
-      d412 =  0.63157877876946881815570249290E+00;
-      d413 = -0.88990336451333310820698117400E-01;
-      d414 =  0.18148505520854727256656404962E+02;
-      d415 = -0.91946323924783554000451984436E+01;
-      d416 = -0.44360363875948939664310572000E+01;
+    d41 = -0.84289382761090128651353491142E+01;
+    d46 = 0.56671495351937776962531783590E+00;
+    d47 = -0.30689499459498916912797304727E+01;
+    d48 = 0.23846676565120698287728149680E+01;
+    d49 = 0.21170345824450282767155149946E+01;
+    d410 = -0.87139158377797299206789907490E+00;
+    d411 = 0.22404374302607882758541771650E+01;
+    d412 = 0.63157877876946881815570249290E+00;
+    d413 = -0.88990336451333310820698117400E-01;
+    d414 = 0.18148505520854727256656404962E+02;
+    d415 = -0.91946323924783554000451984436E+01;
+    d416 = -0.44360363875948939664310572000E+01;
 
-      d51  =  0.10427508642579134603413151009E+02;
-      d56  =  0.24228349177525818288430175319E+03;
-      d57  =  0.16520045171727028198505394887E+03;
-      d58  = -0.37454675472269020279518312152E+03;
-      d59  = -0.22113666853125306036270938578E+02;
-      d510 =  0.77334326684722638389603898808E+01;
-      d511 = -0.30674084731089398182061213626E+02;
-      d512 = -0.93321305264302278729567221706E+01;
-      d513 =  0.15697238121770843886131091075E+02;
-      d514 = -0.31139403219565177677282850411E+02;
-      d515 = -0.93529243588444783865713862664E+01;
-      d516 =  0.35816841486394083752465898540E+02;
+    d51 = 0.10427508642579134603413151009E+02;
+    d56 = 0.24228349177525818288430175319E+03;
+    d57 = 0.16520045171727028198505394887E+03;
+    d58 = -0.37454675472269020279518312152E+03;
+    d59 = -0.22113666853125306036270938578E+02;
+    d510 = 0.77334326684722638389603898808E+01;
+    d511 = -0.30674084731089398182061213626E+02;
+    d512 = -0.93321305264302278729567221706E+01;
+    d513 = 0.15697238121770843886131091075E+02;
+    d514 = -0.31139403219565177677282850411E+02;
+    d515 = -0.93529243588444783865713862664E+01;
+    d516 = 0.35816841486394083752465898540E+02;
 
-      d61 =  0.19985053242002433820987653617E+02;
-      d66 = -0.38703730874935176555105901742E+03;
-      d67 = -0.18917813819516756882830838328E+03;
-      d68 =  0.52780815920542364900561016686E+03;
-      d69 = -0.11573902539959630126141871134E+02;
-      d610 =  0.68812326946963000169666922661E+01;
-      d611 = -0.10006050966910838403183860980E+01;
-      d612 =  0.77771377980534432092869265740E+00;
-      d613 = -0.27782057523535084065932004339E+01;
-      d614 = -0.60196695231264120758267380846E+02;
-      d615 =  0.84320405506677161018159903784E+02;
-      d616 =  0.11992291136182789328035130030E+02;
+    d61 = 0.19985053242002433820987653617E+02;
+    d66 = -0.38703730874935176555105901742E+03;
+    d67 = -0.18917813819516756882830838328E+03;
+    d68 = 0.52780815920542364900561016686E+03;
+    d69 = -0.11573902539959630126141871134E+02;
+    d610 = 0.68812326946963000169666922661E+01;
+    d611 = -0.10006050966910838403183860980E+01;
+    d612 = 0.77771377980534432092869265740E+00;
+    d613 = -0.27782057523535084065932004339E+01;
+    d614 = -0.60196695231264120758267380846E+02;
+    d615 = 0.84320405506677161018159903784E+02;
+    d616 = 0.11992291136182789328035130030E+02;
 
-      d71  = -0.25693933462703749003312586129E+02;
-      d76  = -0.15418974869023643374053993627E+03;
-      d77  = -0.23152937917604549567536039109E+03;
-      d78  =  0.35763911791061412378285349910E+03;
-      d79  =  0.93405324183624310003907691704E+02;
-      d710 = -0.37458323136451633156875139351E+02;
-      d711 =  0.10409964950896230045147246184E+03;
-      d712 =  0.29840293426660503123344363579E+02;
-      d713 = -0.43533456590011143754432175058E+02;
-      d714 =  0.96324553959188282948394950600E+02;
-      d715 = -0.39177261675615439165231486172E+02;
-      d716 = -0.14972683625798562581422125276E+03;
+    d71 = -0.25693933462703749003312586129E+02;
+    d76 = -0.15418974869023643374053993627E+03;
+    d77 = -0.23152937917604549567536039109E+03;
+    d78 = 0.35763911791061412378285349910E+03;
+    d79 = 0.93405324183624310003907691704E+02;
+    d710 = -0.37458323136451633156875139351E+02;
+    d711 = 0.10409964950896230045147246184E+03;
+    d712 = 0.29840293426660503123344363579E+02;
+    d713 = -0.43533456590011143754432175058E+02;
+    d714 = 0.96324553959188282948394950600E+02;
+    d715 = -0.39177261675615439165231486172E+02;
+    d716 = -0.14972683625798562581422125276E+03;
 
-      break;
+    break;
   }
 
   facold = 1.0E-4;
-  expo1 = 1.0/8.0 - beta * 0.2;
+  expo1 = 1.0 / 8.0 - beta * 0.2;
   facc1 = 1.0 / fac1;
   facc2 = 1.0 / fac2;
-  posneg = sign (1.0, xend-x);
+  posneg = sign(1.0, xend - x);
 
   /* initial preparations */
   atoli = atoler[0];
   rtoli = rtoler[0];
-  last  = 0;
+  last = 0;
   hlamb = 0.0;
   iasti = 0;
-  fcn (n, x, y, k1, p, fr, norbits, nbody, args);
-  hmax = fabs (hmax);
+  fcn(n, x, y, k1, p, fr, norbits, nbody, args);
+  hmax = fabs(hmax);
   iord = 8;
+
   if (h == 0.0)
-    h = hinit (n, fcn, p, fr, norbits, nbody, args, x, y, posneg, k1, k2, k3, iord, hmax, atoler, rtoler, itoler);
+    h = hinit(n, fcn, p, fr, norbits, nbody, args, x, y, posneg, k1, k2, k3, iord, hmax, atoler, rtoler, itoler);
+
   nfcn += 2;
   reject = 0;
-  xold = x;
+  if (dense_state)
+    dense_state->xold = x;
 
   if (iout)
   {
     irtrn = 1;
-    hout = 1.0;
-    xout = x;
-    solout (naccpt+1, xold, x, y, n, &irtrn);
+    if (dense_state) {
+      dense_state->hout = 1.0;
+      dense_state->xold = x;
+    }
+    solout(naccpt + 1, x, x, y, n, &irtrn);
     if (irtrn < 0)
     {
       if (fileout)
-	fprintf (fileout, "Exit of dop853 at x = %.16e\r\n", x);
+        fprintf(fileout, "Exit of dop853 at x = %.16e\r\n", x);
       return 2;
     }
   }
@@ -399,22 +377,26 @@ static int dopcor (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, uns
     if (nstep > nmax)
     {
       if (fileout)
-	fprintf (fileout, "Exit of dop853 at x = %.16e, more than nmax = %li are needed\r\n", x, nmax);
-      xout = x;
-      hout = h;
+        fprintf(fileout, "Exit of dop853 at x = %.16e, more than nmax = %li are needed\r\n", x, nmax);
+      if (dense_state) {
+        dense_state->xold = x;
+        dense_state->hout = h;
+      }
       return -2;
     }
 
     if (0.1 * fabs(h) <= fabs(x) * uround)
     {
       if (fileout)
-	fprintf (fileout, "Exit of dop853 at x = %.16e, step size too small h = %.16e\r\n", x, h);
-      xout = x;
-      hout = h;
+        fprintf(fileout, "Exit of dop853 at x = %.16e, step size too small h = %.16e\r\n", x, h);
+      if (dense_state) {
+        dense_state->xold = x;
+        dense_state->hout = h;
+      }
       return -3;
     }
 
-    if ((x + 1.01*h - xend) * posneg > 0.0)
+    if ((x + 1.01 * h - xend) * posneg > 0.0)
     {
       h = xend - x;
       last = 1;
@@ -425,265 +407,269 @@ static int dopcor (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, uns
     /* the twelve stages */
     for (i = 0; i < n; i++)
       yy1[i] = y[i] + h * a21 * k1[i];
-    fcn (n, x+c2*h, yy1, k2, p, fr, norbits, nbody, args);
+    fcn(n, x + c2 * h, yy1, k2, p, fr, norbits, nbody, args);
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a31*k1[i] + a32*k2[i]);
-    fcn (n, x+c3*h, yy1, k3, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a31 * k1[i] + a32 * k2[i]);
+    fcn(n, x + c3 * h, yy1, k3, p, fr, norbits, nbody, args);
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a41*k1[i] + a43*k3[i]);
-    fcn (n, x+c4*h, yy1, k4, p, fr, norbits, nbody, args);
-    for (i = 0; i <n; i++)
-      yy1[i] = y[i] + h * (a51*k1[i] + a53*k3[i] + a54*k4[i]);
-    fcn (n, x+c5*h, yy1, k5, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a41 * k1[i] + a43 * k3[i]);
+    fcn(n, x + c4 * h, yy1, k4, p, fr, norbits, nbody, args);
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a61*k1[i] + a64*k4[i] + a65*k5[i]);
-    fcn (n, x+c6*h, yy1, k6, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a51 * k1[i] + a53 * k3[i] + a54 * k4[i]);
+    fcn(n, x + c5 * h, yy1, k5, p, fr, norbits, nbody, args);
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a71*k1[i] + a74*k4[i] + a75*k5[i] + a76*k6[i]);
-    fcn (n, x+c7*h, yy1, k7, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a61 * k1[i] + a64 * k4[i] + a65 * k5[i]);
+    fcn(n, x + c6 * h, yy1, k6, p, fr, norbits, nbody, args);
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a81*k1[i] + a84*k4[i] + a85*k5[i] + a86*k6[i] +
-			  a87*k7[i]);
-    fcn (n, x+c8*h, yy1, k8, p, fr, norbits, nbody, args);
-    for (i = 0; i <n; i++)
-      yy1[i] = y[i] + h * (a91*k1[i] + a94*k4[i] + a95*k5[i] + a96*k6[i] +
-			  a97*k7[i] + a98*k8[i]);
-    fcn (n, x+c9*h, yy1, k9, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a71 * k1[i] + a74 * k4[i] + a75 * k5[i] + a76 * k6[i]);
+    fcn(n, x + c7 * h, yy1, k7, p, fr, norbits, nbody, args);
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a101*k1[i] + a104*k4[i] + a105*k5[i] + a106*k6[i] +
-			  a107*k7[i] + a108*k8[i] + a109*k9[i]);
-    fcn (n, x+c10*h, yy1, k10, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a81 * k1[i] + a84 * k4[i] + a85 * k5[i] + a86 * k6[i] +
+                           a87 * k7[i]);
+    fcn(n, x + c8 * h, yy1, k8, p, fr, norbits, nbody, args);
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a111*k1[i] + a114*k4[i] + a115*k5[i] + a116*k6[i] +
-			  a117*k7[i] + a118*k8[i] + a119*k9[i] + a1110*k10[i]);
-    fcn (n, x+c11*h, yy1, k2, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a91 * k1[i] + a94 * k4[i] + a95 * k5[i] + a96 * k6[i] +
+                           a97 * k7[i] + a98 * k8[i]);
+    fcn(n, x + c9 * h, yy1, k9, p, fr, norbits, nbody, args);
+    for (i = 0; i < n; i++)
+      yy1[i] = y[i] + h * (a101 * k1[i] + a104 * k4[i] + a105 * k5[i] + a106 * k6[i] +
+                           a107 * k7[i] + a108 * k8[i] + a109 * k9[i]);
+    fcn(n, x + c10 * h, yy1, k10, p, fr, norbits, nbody, args);
+    for (i = 0; i < n; i++)
+      yy1[i] = y[i] + h * (a111 * k1[i] + a114 * k4[i] + a115 * k5[i] + a116 * k6[i] +
+                           a117 * k7[i] + a118 * k8[i] + a119 * k9[i] + a1110 * k10[i]);
+    fcn(n, x + c11 * h, yy1, k2, p, fr, norbits, nbody, args);
     xph = x + h;
     for (i = 0; i < n; i++)
-      yy1[i] = y[i] + h * (a121*k1[i] + a124*k4[i] + a125*k5[i] + a126*k6[i] +
-			  a127*k7[i] + a128*k8[i] + a129*k9[i] +
-			  a1210*k10[i] + a1211*k2[i]);
-    fcn (n, xph, yy1, k3, p, fr, norbits, nbody, args);
+      yy1[i] = y[i] + h * (a121 * k1[i] + a124 * k4[i] + a125 * k5[i] + a126 * k6[i] +
+                           a127 * k7[i] + a128 * k8[i] + a129 * k9[i] +
+                           a1210 * k10[i] + a1211 * k2[i]);
+    fcn(n, xph, yy1, k3, p, fr, norbits, nbody, args);
     nfcn += 11;
     for (i = 0; i < n; i++)
     {
-      k4[i] = b1*k1[i] + b6*k6[i] + b7*k7[i] + b8*k8[i] + b9*k9[i] +
-	      b10*k10[i] + b11*k2[i] + b12*k3[i];
+      k4[i] = b1 * k1[i] + b6 * k6[i] + b7 * k7[i] + b8 * k8[i] + b9 * k9[i] +
+              b10 * k10[i] + b11 * k2[i] + b12 * k3[i];
       k5[i] = y[i] + h * k4[i];
     }
 
     /* error estimation */
     err = 0.0;
     err2 = 0.0;
-    if (!itoler)
+    if (!itoler)  // Scalar tolerances
       for (i = 0; i < n; i++)
       {
-	sk = atoli + rtoli * max_d (fabs(y[i]), fabs(k5[i]));
-	erri = k4[i] - bhh1*k1[i] - bhh2*k9[i] - bhh3*k3[i];
-	sqr = erri / sk;
-	err2 += sqr*sqr;
-	erri = er1*k1[i] + er6*k6[i] + er7*k7[i] + er8*k8[i] + er9*k9[i] +
-	       er10 * k10[i] + er11*k2[i] + er12*k3[i];
-	sqr = erri / sk;
-	err += sqr*sqr;
+        sk = atoli + rtoli * max_d(fabs(y[i]), fabs(k5[i]));
+        erri = k4[i] - bhh1 * k1[i] - bhh2 * k9[i] - bhh3 * k3[i];
+        sqr = erri / sk;
+        err2 += sqr * sqr;
+        erri = er1 * k1[i] + er6 * k6[i] + er7 * k7[i] + er8 * k8[i] + er9 * k9[i] +
+               er10 * k10[i] + er11 * k2[i] + er12 * k3[i];
+        sqr = erri / sk;
+        err += sqr * sqr;
       }
     else
       for (i = 0; i < n; i++)
       {
-	sk = atoler[i] + rtoler[i] * max_d (fabs(y[i]), fabs(k5[i]));
-	erri = k4[i] - bhh1*k1[i] - bhh2*k9[i] - bhh3*k3[i];
-	sqr = erri / sk;
-	err2 += sqr*sqr;
-	erri = er1*k1[i] + er6*k6[i] + er7*k7[i] + er8*k8[i] + er9*k9[i] +
-	       er10 * k10[i] + er11*k2[i] + er12*k3[i];
-	sqr = erri / sk;
-	err += sqr*sqr;
+        sk = atoler[i] + rtoler[i] * max_d(fabs(y[i]), fabs(k5[i]));
+        erri = k4[i] - bhh1 * k1[i] - bhh2 * k9[i] - bhh3 * k3[i];
+        sqr = erri / sk;
+        err2 += sqr * sqr;
+        erri = er1 * k1[i] + er6 * k6[i] + er7 * k7[i] + er8 * k8[i] + er9 * k9[i] +
+               er10 * k10[i] + er11 * k2[i] + er12 * k3[i];
+        sqr = erri / sk;
+        err += sqr * sqr;
       }
     deno = err + 0.01 * err2;
     if (deno <= 0.0)
       deno = 1.0;
-    err = fabs(h) * err * sqrt (1.0 / (deno*(double)n));
+    err = fabs(h) * err * sqrt(1.0 / (deno * (double)n));
 
     /* computation of hnew */
-    fac11 = pow (err, expo1);
+    fac11 = pow(err, expo1);
     /* Lund-stabilization */
-    fac = fac11 / pow(facold,beta);
+    fac = fac11 / pow(facold, beta);
     /* we require fac1 <= hnew/h <= fac2 */
-    fac = max_d (facc2, min_d (facc1, fac/safe));
+    fac = max_d(facc2, min_d(facc1, fac / safe));
     hnew = h / fac;
 
     if (err <= 1.0)
     {
       /* step accepted */
 
-      facold = max_d (err, 1.0E-4);
+      facold = max_d(err, 1.0E-4);
       naccpt++;
-      fcn (n, xph, k5, k4, p, fr, norbits, nbody, args);
+      fcn(n, xph, k5, k4, p, fr, norbits, nbody, args);
       nfcn++;
 
       /* stiffness detection */
       if (!(naccpt % nstiff) || (iasti > 0))
       {
-	stnum = 0.0;
-	stden = 0.0;
-	for (i = 0; i < n; i++)
-	{
-	  sqr = k4[i] - k3[i];
-	  stnum += sqr*sqr;
-	  sqr = k5[i] - yy1[i];
-	  stden += sqr*sqr;
-	}
-	if (stden > 0.0)
-	  hlamb = h * sqrt (stnum / stden);
-	if (hlamb > 6.1)
-	{
-	  nonsti = 0;
-	  iasti++;
-	  if (iasti == 15)
-	    if (fileout)
-	      fprintf (fileout, "The problem seems to become stiff at x = %.16e\r\n", x);
-	    else
-	    {
-	      xout = x;
-	      hout = h;
-	      return -4;
-	    }
-	}
-	else
-	{
-	  nonsti++;
-	  if (nonsti == 6)
-	    iasti = 0;
-	}
+        stnum = 0.0;
+        stden = 0.0;
+        for (i = 0; i < n; i++)
+        {
+          sqr = k4[i] - k3[i];
+          stnum += sqr * sqr;
+          sqr = k5[i] - yy1[i];
+          stden += sqr * sqr;
+        }
+        if (stden > 0.0)
+          hlamb = h * sqrt(stnum / stden);
+        if (hlamb > 6.1)
+        {
+          nonsti = 0;
+          iasti++;
+          if (iasti == 15)
+            if (fileout)
+              fprintf(fileout, "The problem seems to become stiff at x = %.16e\r\n", x);
+            else
+            {
+              if (dense_state)
+                dense_state->xold = x;
+              if (dense_state)
+                dense_state->hout = h;
+              return -4;
+            }
+        }
+        else
+        {
+          nonsti++;
+          if (nonsti == 6)
+            iasti = 0;
+        }
       }
 
       /* final preparation for dense output */
-      if (iout == 2)
+      // if (iout == 2)
+      // APW: modified because I don't think this logic is correct. We should enter
+      // below if we are doing dense output, which is not the same as iout == 2
+      if (dense_state)
       {
-	/* save the first function evaluations */
-	if (nrds == n)
-	  for (i = 0; i < n; i++)
-	  {
-	    rcont1[i] = y[i];
-	    ydiff = k5[i] - y[i];
-	    rcont2[i] = ydiff;
-	    bspl = h * k1[i] - ydiff;
-	    rcont3[i] = bspl;
-	    rcont4[i] = ydiff - h*k4[i] - bspl;
-	    rcont5[i] = d41*k1[i] + d46*k6[i] + d47*k7[i] + d48*k8[i] +
-			d49*k9[i] + d410*k10[i] + d411*k2[i] + d412*k3[i];
-	    rcont6[i] = d51*k1[i] + d56*k6[i] + d57*k7[i] + d58*k8[i] +
-			d59*k9[i] + d510*k10[i] + d511*k2[i] + d512*k3[i];
-	    rcont7[i] = d61*k1[i] + d66*k6[i] + d67*k7[i] + d68*k8[i] +
-			d69*k9[i] + d610*k10[i] + d611*k2[i] + d612*k3[i];
-	    rcont8[i] = d71*k1[i] + d76*k6[i] + d77*k7[i] + d78*k8[i] +
-			d79*k9[i] + d710*k10[i] + d711*k2[i] + d712*k3[i];
-	  }
-	else
-	  for (j = 0; j < nrds; j++)
-	  {
-	    i = icont[j];
-	    rcont1[j] = y[i];
-	    ydiff = k5[i] - y[i];
-	    rcont2[j] = ydiff;
-	    bspl = h * k1[i] - ydiff;
-	    rcont3[j] = bspl;
-	    rcont4[j] = ydiff - h*k4[i] - bspl;
-	    rcont5[j] = d41*k1[i] + d46*k6[i] + d47*k7[i] + d48*k8[i] +
-			d49*k9[i] + d410*k10[i] + d411*k2[i] + d412*k3[i];
-	    rcont6[j] = d51*k1[i] + d56*k6[i] + d57*k7[i] + d58*k8[i] +
-			d59*k9[i] + d510*k10[i] + d511*k2[i] + d512*k3[i];
-	    rcont7[j] = d61*k1[i] + d66*k6[i] + d67*k7[i] + d68*k8[i] +
-			d69*k9[i] + d610*k10[i] + d611*k2[i] + d612*k3[i];
-	    rcont8[j] = d71*k1[i] + d76*k6[i] + d77*k7[i] + d78*k8[i] +
-			d79*k9[i] + d710*k10[i] + d711*k2[i] + d712*k3[i];
-	  }
-
-	/* the next three function evaluations */
-	for (i = 0; i < n; i++)
-	  yy1[i] = y[i] + h * (a141*k1[i] + a147*k7[i] + a148*k8[i] +
-			      a149*k9[i] + a1410*k10[i] + a1411*k2[i] +
-			      a1412*k3[i] + a1413*k4[i]);
-	fcn (n, x+c14*h, yy1, k10, p, fr, norbits, nbody, args);
-	for (i = 0; i < n; i++)
-	  yy1[i] = y[i] + h * (a151*k1[i] + a156*k6[i] + a157*k7[i] + a158*k8[i] +
-			      a1511*k2[i] + a1512*k3[i] + a1513*k4[i] +
-			      a1514*k10[i]);
-	fcn (n, x+c15*h, yy1, k2, p, fr, norbits, nbody, args);
-	for (i = 0; i < n; i++)
-	  yy1[i] = y[i] + h * (a161*k1[i] + a166*k6[i] + a167*k7[i] + a168*k8[i] +
-			      a169*k9[i] + a1613*k4[i] + a1614*k10[i] +
-			      a1615*k2[i]);
-	fcn (n, x+c16*h, yy1, k3, p, fr, norbits, nbody, args);
-	nfcn += 3;
-
-	/* final preparation */
-	if (nrds == n)
-	  for (i = 0; i < n; i++)
-	  {
-	    rcont5[i] = h * (rcont5[i] + d413*k4[i] + d414*k10[i] +
-			     d415*k2[i] + d416*k3[i]);
-	    rcont6[i] = h * (rcont6[i] + d513*k4[i] + d514*k10[i] +
-			     d515*k2[i] + d516*k3[i]);
-	    rcont7[i] = h * (rcont7[i] + d613*k4[i] + d614*k10[i] +
-			     d615*k2[i] + d616*k3[i]);
-	    rcont8[i] = h * (rcont8[i] + d713*k4[i] + d714*k10[i] +
-			     d715*k2[i] + d716*k3[i]);
-	  }
+        /* save the first function evaluations */
+        if (dense_state->nrds == n)
+          for (i = 0; i < n; i++)
+          {
+            dense_state->rcont1[i] = y[i];
+            ydiff = k5[i] - y[i];
+            dense_state->rcont2[i] = ydiff;
+            bspl = h * k1[i] - ydiff;
+            dense_state->rcont3[i] = bspl;
+            dense_state->rcont4[i] = ydiff - h * k4[i] - bspl;
+            dense_state->rcont5[i] = d41 * k1[i] + d46 * k6[i] + d47 * k7[i] + d48 * k8[i] +
+                                     d49 * k9[i] + d410 * k10[i] + d411 * k2[i] + d412 * k3[i];
+            dense_state->rcont6[i] = d51 * k1[i] + d56 * k6[i] + d57 * k7[i] + d58 * k8[i] +
+                                     d59 * k9[i] + d510 * k10[i] + d511 * k2[i] + d512 * k3[i];
+            dense_state->rcont7[i] = d61 * k1[i] + d66 * k6[i] + d67 * k7[i] + d68 * k8[i] +
+                                     d69 * k9[i] + d610 * k10[i] + d611 * k2[i] + d612 * k3[i];
+            dense_state->rcont8[i] = d71 * k1[i] + d76 * k6[i] + d77 * k7[i] + d78 * k8[i] +
+                                     d79 * k9[i] + d710 * k10[i] + d711 * k2[i] + d712 * k3[i];
+          }
         else
-	  for (j = 0; j < nrds; j++)
-	  {
-	    i = icont[j];
-	    rcont5[j] = h * (rcont5[j] + d413*k4[i] + d414*k10[i] +
-			     d415*k2[i] + d416*k3[i]);
-	    rcont6[j] = h * (rcont6[j] + d513*k4[i] + d514*k10[i] +
-			     d515*k2[i] + d516*k3[i]);
-	    rcont7[j] = h * (rcont7[j] + d613*k4[i] + d614*k10[i] +
-			     d615*k2[i] + d616*k3[i]);
-	    rcont8[j] = h * (rcont8[j] + d713*k4[i] + d714*k10[i] +
-			     d715*k2[i] + d716*k3[i]);
-	  }
+          for (j = 0; j < dense_state->nrds; j++)
+          {
+            i = icont[j];
+            dense_state->rcont1[j] = y[i];
+            ydiff = k5[i] - y[i];
+            dense_state->rcont2[j] = ydiff;
+            bspl = h * k1[i] - ydiff;
+            dense_state->rcont3[j] = bspl;
+            dense_state->rcont4[j] = ydiff - h * k4[i] - bspl;
+            dense_state->rcont5[j] = d41 * k1[i] + d46 * k6[i] + d47 * k7[i] + d48 * k8[i] +
+                                     d49 * k9[i] + d410 * k10[i] + d411 * k2[i] + d412 * k3[i];
+            dense_state->rcont6[j] = d51 * k1[i] + d56 * k6[i] + d57 * k7[i] + d58 * k8[i] +
+                                     d59 * k9[i] + d510 * k10[i] + d511 * k2[i] + d512 * k3[i];
+            dense_state->rcont7[j] = d61 * k1[i] + d66 * k6[i] + d67 * k7[i] + d68 * k8[i] +
+                                     d69 * k9[i] + d610 * k10[i] + d611 * k2[i] + d612 * k3[i];
+            dense_state->rcont8[j] = d71 * k1[i] + d76 * k6[i] + d77 * k7[i] + d78 * k8[i] +
+                                     d79 * k9[i] + d710 * k10[i] + d711 * k2[i] + d712 * k3[i];
+          }
+
+        /* the next three function evaluations */
+        for (i = 0; i < n; i++)
+          yy1[i] = y[i] + h * (a141 * k1[i] + a147 * k7[i] + a148 * k8[i] +
+                               a149 * k9[i] + a1410 * k10[i] + a1411 * k2[i] +
+                               a1412 * k3[i] + a1413 * k4[i]);
+        fcn(n, x + c14 * h, yy1, k10, p, fr, norbits, nbody, args);
+        for (i = 0; i < n; i++)
+          yy1[i] = y[i] + h * (a151 * k1[i] + a156 * k6[i] + a157 * k7[i] + a158 * k8[i] +
+                               a1511 * k2[i] + a1512 * k3[i] + a1513 * k4[i] +
+                               a1514 * k10[i]);
+        fcn(n, x + c15 * h, yy1, k2, p, fr, norbits, nbody, args);
+        for (i = 0; i < n; i++)
+          yy1[i] = y[i] + h * (a161 * k1[i] + a166 * k6[i] + a167 * k7[i] + a168 * k8[i] +
+                               a169 * k9[i] + a1613 * k4[i] + a1614 * k10[i] +
+                               a1615 * k2[i]);
+        fcn(n, x + c16 * h, yy1, k3, p, fr, norbits, nbody, args);
+        nfcn += 3;
+
+        /* final preparation */
+        if (dense_state->nrds == n)
+          for (i = 0; i < n; i++)
+          {
+            dense_state->rcont5[i] = h * (dense_state->rcont5[i] + d413 * k4[i] + d414 * k10[i] +
+                                          d415 * k2[i] + d416 * k3[i]);
+            dense_state->rcont6[i] = h * (dense_state->rcont6[i] + d513 * k4[i] + d514 * k10[i] +
+                                          d515 * k2[i] + d516 * k3[i]);
+            dense_state->rcont7[i] = h * (dense_state->rcont7[i] + d613 * k4[i] + d614 * k10[i] +
+                                          d615 * k2[i] + d616 * k3[i]);
+            dense_state->rcont8[i] = h * (dense_state->rcont8[i] + d713 * k4[i] + d714 * k10[i] +
+                                          d715 * k2[i] + d716 * k3[i]);
+          }
+        else
+          for (j = 0; j < dense_state->nrds; j++)
+          {
+            i = icont[j];
+            dense_state->rcont5[j] = h * (dense_state->rcont5[j] + d413 * k4[i] + d414 * k10[i] +
+                                          d415 * k2[i] + d416 * k3[i]);
+            dense_state->rcont6[j] = h * (dense_state->rcont6[j] + d513 * k4[i] + d514 * k10[i] +
+                                          d515 * k2[i] + d516 * k3[i]);
+            dense_state->rcont7[j] = h * (dense_state->rcont7[j] + d613 * k4[i] + d614 * k10[i] +
+                                          d615 * k2[i] + d616 * k3[i]);
+            dense_state->rcont8[j] = h * (dense_state->rcont8[j] + d713 * k4[i] + d714 * k10[i] +
+                                          d715 * k2[i] + d716 * k3[i]);
+          }
       }
 
-      memcpy (k1, k4, n * sizeof(double));
-      memcpy (y, k5, n * sizeof(double));
-      xold = x;
+      memcpy(k1, k4, n * sizeof(double));
+      memcpy(y, k5, n * sizeof(double));
+      if (dense_state) {
+        dense_state->hout = h;
+        dense_state->xold = x;
+      }
       x = xph;
 
       if (iout)
       {
-	hout = h;
-	xout = x;
-	solout (naccpt+1, xold, x, y, n, &irtrn);
-	if (irtrn < 0)
-	{
-	  if (fileout)
-	    fprintf (fileout, "Exit of dop853 at x = %.16e\r\n", x);
-	  return 2;
-	}
+        solout(naccpt + 1, x, x, y, n, &irtrn);
+        if (irtrn < 0)
+        {
+          if (fileout)
+            fprintf(fileout, "Exit of dop853 at x = %.16e\r\n", x);
+          return 2;
+        }
       }
 
       /* normal exit */
       if (last)
       {
-	hout=hnew;
-	xout = x;
-	return 1;
+        return 1;
       }
 
       if (fabs(hnew) > hmax)
-	hnew = posneg * hmax;
+        hnew = posneg * hmax;
       if (reject)
-	hnew = posneg * min_d (fabs(hnew), fabs(h));
+        hnew = posneg * min_d(fabs(hnew), fabs(h));
 
       reject = 0;
     }
     else
     {
       /* step rejected */
-      hnew = h / min_d (facc1, fac11/safe);
+      hnew = h / min_d(facc1, fac11 / safe);
       reject = 1;
       if (naccpt >= 1)
-	nrejct=nrejct + 1;
+        nrejct = nrejct + 1;
       last = 0;
     }
 
@@ -692,28 +678,25 @@ static int dopcor (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, uns
 
 } /* dopcor */
 
-
 /* front-end */
-int dop853
- (unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
-  double x, double* y, double xend, double* rtoler,
-  double* atoler, int itoler, SolTrait solout, int iout, FILE* fileout, double uround,
-  double safe, double fac1, double fac2, double beta, double hmax, double h,
-  long nmax, int meth, long nstiff, unsigned nrdens, unsigned* icont, unsigned licont)
+int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody, void *args,
+           double x, double *y, double xend, double *rtoler,
+           double *atoler, int itoler, SolTrait solout, int iout, FILE *fileout, double uround,
+           double safe, double fac1, double fac2, double beta, double hmax, double h,
+           long nmax, int meth, long nstiff, unsigned nrdens, unsigned *icont, unsigned licont,
+           Dop853DenseState *dense_state)
 {
-  int       arret, idid;
-  unsigned  i;
+  int arret, idid;
+  unsigned i;
 
   /* initialisations */
   nfcn = nstep = naccpt = nrejct = arret = 0;
-  rcont1 = rcont2 = rcont3 = rcont4 = rcont5 = rcont6 = rcont7 = rcont8 = NULL;
-  indir = NULL;
 
   /* n, the dimension of the system */
   if (n == UINT_MAX)
   {
     if (fileout)
-      fprintf (fileout, "System too big, max. n = %u\r\n", UINT_MAX-1);
+      fprintf(fileout, "System too big, max. n = %u\r\n", UINT_MAX - 1);
     arret = 1;
   }
 
@@ -723,7 +706,7 @@ int dop853
   else if (nmax <= 0)
   {
     if (fileout)
-      fprintf (fileout, "Wrong input, nmax = %li\r\n", nmax);
+      fprintf(fileout, "Wrong input, nmax = %li\r\n", nmax);
     arret = 1;
   }
 
@@ -733,7 +716,7 @@ int dop853
   else if ((meth <= 0) || (meth >= 2))
   {
     if (fileout)
-      fprintf (fileout, "Curious input, meth = %i\r\n", meth);
+      fprintf(fileout, "Curious input, meth = %i\r\n", meth);
     arret = 1;
   }
 
@@ -747,7 +730,7 @@ int dop853
   if ((iout < 0) || (iout > 2))
   {
     if (fileout)
-      fprintf (fileout, "Wrong input, iout = %i\r\n", iout);
+      fprintf(fileout, "Wrong input, iout = %i\r\n", iout);
     arret = 1;
   }
 
@@ -755,54 +738,44 @@ int dop853
   if (nrdens > n)
   {
     if (fileout)
-      fprintf (fileout, "Curious input, nrdens = %u\r\n", nrdens);
+      fprintf(fileout, "Curious input, nrdens = %u\r\n", nrdens);
     arret = 1;
   }
   else if (nrdens)
   {
-    /* is there enough memory to allocate rcont12345678&indir ? */
-    rcont1 = (double*) malloc (nrdens*sizeof(double));
-    rcont2 = (double*) malloc (nrdens*sizeof(double));
-    rcont3 = (double*) malloc (nrdens*sizeof(double));
-    rcont4 = (double*) malloc (nrdens*sizeof(double));
-    rcont5 = (double*) malloc (nrdens*sizeof(double));
-    rcont6 = (double*) malloc (nrdens*sizeof(double));
-    rcont7 = (double*) malloc (nrdens*sizeof(double));
-    rcont8 = (double*) malloc (nrdens*sizeof(double));
-    if (nrdens < n)
-      indir = (unsigned*) malloc (n*sizeof(unsigned));
-
-    if (!rcont1 || !rcont2 || !rcont3 || !rcont4 || !rcont5 ||
-	!rcont6 || !rcont7 || !rcont8 || (!indir && (nrdens < n)))
+    if (!dense_state)
     {
       if (fileout)
-	fprintf (fileout, "Not enough free memory for rcont12345678&indir\r\n");
+        fprintf(fileout, "Dense state must be pre-allocated\r\n");
       arret = 1;
     }
-
     /* control of length of icont */
     if (nrdens == n)
     {
       if (icont && fileout)
-	fprintf (fileout, "Warning : when nrdens = n there is no need allocating memory for icont\r\n");
-      nrds = n;
+        fprintf(fileout, "Warning : when nrdens = n there is no need allocating memory for icont\r\n");
+      dense_state->nrds = n;
     }
     else if (licont < nrdens)
     {
       if (fileout)
-	fprintf (fileout, "Insufficient storage for icont, min. licont = %u\r\n", nrdens);
+        fprintf(fileout, "Insufficient storage for icont, min. licont = %u\r\n", nrdens);
       arret = 1;
     }
     else
     {
       if ((iout < 2) && fileout)
-	fprintf (fileout, "Warning : put iout = 2 for dense output\r\n");
-      nrds = nrdens;
+        fprintf(fileout, "Warning : put iout = 2 for dense output\r\n");
+      dense_state->nrds = nrdens;
       for (i = 0; i < n; i++)
-	indir[i] = UINT_MAX;
+        dense_state->indir[i] = UINT_MAX;
       for (i = 0; i < nrdens; i++)
-	indir[icont[i]] = i;
+        dense_state->indir[icont[i]] = i;
     }
+  }
+  else
+  {
+    dense_state = NULL; // Defensive: ensure not used
   }
 
   /* uround, smallest number satisfying 1.0+uround > 1.0 */
@@ -811,7 +784,7 @@ int dop853
   else if ((uround <= 1.0E-35) || (uround >= 1.0))
   {
     if (fileout)
-      fprintf (fileout, "Which machine do you have ? Your uround was : %.16e\r\n", uround);
+      fprintf(fileout, "Which machine do you have ? Your uround was : %.16e\r\n", uround);
     arret = 1;
   }
 
@@ -821,7 +794,7 @@ int dop853
   else if ((safe >= 1.0) || (safe <= 1.0E-4))
   {
     if (fileout)
-      fprintf (fileout, "Curious input for safety factor, safe = %.16e\r\n", safe);
+      fprintf(fileout, "Curious input for safety factor, safe = %.16e\r\n", safe);
     arret = 1;
   }
 
@@ -839,7 +812,7 @@ int dop853
   else if (beta > 0.2)
   {
     if (fileout)
-      fprintf (fileout, "Curious input for beta : beta = %.16e\r\n", beta);
+      fprintf(fileout, "Curious input for beta : beta = %.16e\r\n", beta);
     arret = 1;
   }
 
@@ -848,22 +821,22 @@ int dop853
     hmax = xend - x;
 
   /* is there enough free memory for the method ? */
-  yy1 = (double*) malloc (n*sizeof(double));
-  k1 = (double*) malloc (n*sizeof(double));
-  k2 = (double*) malloc (n*sizeof(double));
-  k3 = (double*) malloc (n*sizeof(double));
-  k4 = (double*) malloc (n*sizeof(double));
-  k5 = (double*) malloc (n*sizeof(double));
-  k6 = (double*) malloc (n*sizeof(double));
-  k7 = (double*) malloc (n*sizeof(double));
-  k8 = (double*) malloc (n*sizeof(double));
-  k9 = (double*) malloc (n*sizeof(double));
-  k10 = (double*) malloc (n*sizeof(double));
+  yy1 = (double *)malloc(n * sizeof(double));
+  k1 = (double *)malloc(n * sizeof(double));
+  k2 = (double *)malloc(n * sizeof(double));
+  k3 = (double *)malloc(n * sizeof(double));
+  k4 = (double *)malloc(n * sizeof(double));
+  k5 = (double *)malloc(n * sizeof(double));
+  k6 = (double *)malloc(n * sizeof(double));
+  k7 = (double *)malloc(n * sizeof(double));
+  k8 = (double *)malloc(n * sizeof(double));
+  k9 = (double *)malloc(n * sizeof(double));
+  k10 = (double *)malloc(n * sizeof(double));
 
   if (!yy1 || !k1 || !k2 || !k3 || !k4 || !k5 || !k6 || !k7 || !k8 || !k9 || !k10)
   {
     if (fileout)
-      fprintf (fileout, "Not enough free memory for the method\r\n");
+      fprintf(fileout, "Not enough free memory for the method\r\n");
     arret = 1;
   }
 
@@ -871,149 +844,194 @@ int dop853
   if (arret)
   {
     if (k10)
-      free (k10);
+      free(k10);
     if (k9)
-      free (k9);
+      free(k9);
     if (k8)
-      free (k8);
+      free(k8);
     if (k7)
-      free (k7);
+      free(k7);
     if (k6)
-      free (k6);
+      free(k6);
     if (k5)
-      free (k5);
+      free(k5);
     if (k4)
-      free (k4);
+      free(k4);
     if (k3)
-      free (k3);
+      free(k3);
     if (k2)
-      free (k2);
+      free(k2);
     if (k1)
-      free (k1);
+      free(k1);
     if (yy1)
-      free (yy1);
-    if (indir)
-      free (indir);
-    if (rcont8)
-      free (rcont8);
-    if (rcont7)
-      free (rcont7);
-    if (rcont6)
-      free (rcont6);
-    if (rcont5)
-      free (rcont5);
-    if (rcont4)
-      free (rcont4);
-    if (rcont3)
-      free (rcont3);
-    if (rcont2)
-      free (rcont2);
-    if (rcont1)
-      free (rcont1);
+      free(yy1);
 
     return -1;
   }
   else
   {
-    idid = dopcor (n, fcn, p, fr, norbits, nbody, args, x, y, xend, hmax, h, rtoler, atoler, itoler, fileout,
-		   solout, iout, nmax, uround, meth, nstiff, safe, beta, fac1, fac2, icont);
-    free (k10);
-    free (k9);
-    free (k8);
-    free (k7);
-    free (k6);
-    free (k5);    /* reverse order freeing too increase chances */
-    free (k4);    /* of efficient dynamic memory managing       */
-    free (k3);
-    free (k2);
-    free (k1);
-    free (yy1);
-    if (indir)
-      free (indir);
-    if (rcont8)
-    {
-      free (rcont8);
-      free (rcont7);
-      free (rcont6);
-      free (rcont5);
-      free (rcont4);
-      free (rcont3);
-      free (rcont2);
-      free (rcont1);
-    }
+    idid = dopcor(n, fcn, p, fr, norbits, nbody, args, x, y, xend, hmax, h, rtoler, atoler, itoler, fileout,
+                  solout, iout, nmax, uround, meth, nstiff, safe, beta, fac1, fac2, icont, nrdens > 0 ? dense_state : NULL);
+    free(k10);
+    free(k9);
+    free(k8);
+    free(k7);
+    free(k6);
+    free(k5); /* reverse order freeing too increase chances */
+    free(k4); /* of efficient dynamic memory managing       */
+    free(k3);
+    free(k2);
+    free(k1);
+    free(yy1);
 
     return idid;
   }
 
 } /* dop853 */
 
-
-/* dense output function */
-double contd8 (unsigned ii, double x)
+// Thread-safe dense output function
+double contd8_threadsafe(Dop853DenseState *state, unsigned ii, double x)
 {
-  unsigned i, j;
-  double   s, s1;
-
-  i = UINT_MAX;
-
-  if (!indir)
-    i = ii;
-  else
-    i = indir[ii];
-
-  if (i == UINT_MAX)
+  if (!state)
   {
-    printf ("No dense output available for %uth component", ii);
+    fprintf(stderr, "contd8_threadsafe: state is NULL\n");
     return 0.0;
   }
-
-  s = (x - xold) / hout;
-  s1 = 1.0 - s;
-
-  return rcont1[i]+s*(rcont2[i]+s1*(rcont3[i]+s*(rcont4[i]+s1*(rcont5[i]+
-	 s*(rcont6[i]+s1*(rcont7[i]+s*rcont8[i]))))));
-
-} /* contd8 */
-
-/* ADDED BY APW */
-void Fwrapper (unsigned full_ndim, double t, double *w, double *f,
-               CPotential *p, CFrameType *fr, unsigned norbits, unsigned na,
-               void *args) {
-    /* na can be ignored here - used in nbody wrapper below */
-
-    int i;
-    unsigned ndim = full_ndim / norbits; // phase-space dimensionality
-
-    for (i=0; i < norbits; i++) {
-        // call gradient function
-        hamiltonian_gradient(p, fr, t, &w[i*ndim], &f[i*ndim]);
-    }
+  if (!state->rcont1 || !state->rcont2 || !state->rcont3 || !state->rcont4 ||
+      !state->rcont5 || !state->rcont6 || !state->rcont7 || !state->rcont8)
+  {
+    fprintf(stderr, "contd8_threadsafe: one or more rcont arrays are NULL\n");
+    return 0.0;
+  }
+  if (ii >= state->nrds)
+  {
+    fprintf(stderr, "contd8_threadsafe: ii=%u out of bounds (nrds=%u)\n", ii, state->nrds);
+    return 0.0;
+  }
+  unsigned i;
+  if (!state->indir)
+  {
+    i = ii;
+  }
+  else
+  {
+    i = state->indir[ii];
+  }
+  if (i == UINT_MAX)
+  {
+    fprintf(stderr, "contd8_threadsafe: No dense output available for %uth component\n", ii);
+    return 0.0;
+  }
+  double s = (x - state->xold) / state->hout;
+  double s1 = 1.0 - s;
+  return state->rcont1[i] + s * (state->rcont2[i] + s1 * (state->rcont3[i] + s * (state->rcont4[i] + s1 * (state->rcont5[i] + s * (state->rcont6[i] + s1 * (state->rcont7[i] + s * state->rcont8[i]))))));
 }
 
-void Fwrapper_direct_nbody (unsigned full_ndim, double t, double *w, double *f,
-                            CPotential *p, CFrameType *fr,
-                            unsigned norbits, unsigned nbody,
-                            void *args) {
-    /* Here, the extra args are actually the array of CPotential objects that
-       represent the potentials of the individual particles.
-    */
-    CPotential **pots = (CPotential **)args;
+// Allocate a Dop853DenseState and its arrays
+Dop853DenseState *dop853_dense_state_alloc(unsigned nrdens, unsigned n)
+{
+  Dop853DenseState *state = (Dop853DenseState *)malloc(sizeof(Dop853DenseState));
+  if (!state)
+    return NULL;
+  state->rcont1 = (double *)malloc(nrdens * sizeof(double));
+  state->rcont2 = (double *)malloc(nrdens * sizeof(double));
+  state->rcont3 = (double *)malloc(nrdens * sizeof(double));
+  state->rcont4 = (double *)malloc(nrdens * sizeof(double));
+  state->rcont5 = (double *)malloc(nrdens * sizeof(double));
+  state->rcont6 = (double *)malloc(nrdens * sizeof(double));
+  state->rcont7 = (double *)malloc(nrdens * sizeof(double));
+  state->rcont8 = (double *)malloc(nrdens * sizeof(double));
+  state->nrds = nrdens;
+  state->xold = 0.0;
+  state->hout = 0.0;
+  if (nrdens < n)
+  {
+    state->indir = (unsigned *)malloc(n * sizeof(unsigned));
+  }
+  else
+  {
+    state->indir = NULL;
+  }
+  if (!state->rcont1 || !state->rcont2 || !state->rcont3 || !state->rcont4 ||
+      !state->rcont5 || !state->rcont6 || !state->rcont7 || !state->rcont8 ||
+      (nrdens < n && !state->indir))
+  {
+    dop853_dense_state_free(state, n);
+    return NULL;
+  }
+  return state;
+}
 
-    // Note: only really works with a static frame! This should be enforced
-    unsigned ps_ndim = 2 * p->n_dim;  // phase-space dimensionality
+// Free a Dop853DenseState and its arrays
+void dop853_dense_state_free(Dop853DenseState *state, unsigned n)
+{
+  if (!state)
+    return;
+  if (state->rcont1)
+    free(state->rcont1);
+  if (state->rcont2)
+    free(state->rcont2);
+  if (state->rcont3)
+    free(state->rcont3);
+  if (state->rcont4)
+    free(state->rcont4);
+  if (state->rcont5)
+    free(state->rcont5);
+  if (state->rcont6)
+    free(state->rcont6);
+  if (state->rcont7)
+    free(state->rcont7);
+  if (state->rcont8)
+    free(state->rcont8);
+  if (state->indir)
+    free(state->indir);
+  free(state);
+}
 
-    for (int i=0; i < norbits; i++)
-        hamiltonian_gradient(p, fr, t, &w[i * ps_ndim], &f[i * ps_ndim]);
+/* ADDED BY APW */
+void Fwrapper(unsigned full_ndim, double t, double *w, double *f,
+              CPotential *p, CFrameType *fr, unsigned norbits, unsigned na,
+              void *args)
+{
+  /* na can be ignored here - used in nbody wrapper below */
 
-    if (nbody > 0)
-        c_nbody_acceleration(pots, t, w, norbits, nbody, p->n_dim, f);
+  int i;
+  unsigned ndim = full_ndim / norbits; // phase-space dimensionality
+
+  for (i = 0; i < norbits; i++)
+  {
+    // call gradient function
+    hamiltonian_gradient(p, fr, t, &w[i * ndim], &f[i * ndim]);
+  }
+}
+
+void Fwrapper_direct_nbody(unsigned full_ndim, double t, double *w, double *f,
+                           CPotential *p, CFrameType *fr,
+                           unsigned norbits, unsigned nbody,
+                           void *args)
+{
+  /* Here, the extra args are actually the array of CPotential objects that
+     represent the potentials of the individual particles.
+  */
+  CPotential **pots = (CPotential **)args;
+
+  // Note: only really works with a static frame! This should be enforced
+  unsigned ps_ndim = 2 * p->n_dim; // phase-space dimensionality
+
+  for (int i = 0; i < norbits; i++)
+    hamiltonian_gradient(p, fr, t, &w[i * ps_ndim], &f[i * ps_ndim]);
+
+  if (nbody > 0)
+    c_nbody_acceleration(pots, t, w, norbits, nbody, p->n_dim, f);
 }
 
 /* Needed for Lyapunov */
-double six_norm (double *x) {
-    double norm = 0;
-    for (int i=0; i<6; i++) {
-        norm = norm + x[i]*x[i];
-    }
-    return sqrt(norm);
+double six_norm(double *x)
+{
+  double norm = 0;
+  for (int i = 0; i < 6; i++)
+  {
+    norm = norm + x[i] * x[i];
+  }
+  return sqrt(norm);
 }

--- a/gala/integrate/cyintegrators/dopri/dop853.c
+++ b/gala/integrate/cyintegrators/dopri/dop853.c
@@ -477,9 +477,7 @@ static int dopcor(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr,
           if (iasti == 15)
             if (fileout)
               fprintf(fileout, "The problem seems to become stiff at x = %.16e\r\n", x);
-            else {
-              return -4;
-            }
+            return -4;
         } else {
           nonsti++;
           if (nonsti == 6)
@@ -711,8 +709,11 @@ int dop853(unsigned n, FcnEqDiff fcn, CPotential *p, CFrameType *fr, unsigned no
     // ADDED BY APW:
     if (nrdens != n) {
       if (fileout) {
-        fprintf(fileout, "Warning: nrdens = %u, but not all components are dense\n",
-                nrdens);
+        fprintf(
+          fileout,
+          "Warning: nrdens = %u, but not all components are dense (n = %u)\n",
+          nrdens, n
+        );
         arret = 1;
       }
     }

--- a/gala/integrate/cyintegrators/dopri/dop853.h
+++ b/gala/integrate/cyintegrators/dopri/dop853.h
@@ -187,6 +187,21 @@ nfcnRead    Number of function calls.
 #include "frame/src/cframe.h"
 #include "hamiltonian/src/chamiltonian.h"
 
+// Thread-safe struct for dense output state
+typedef struct {
+    double *rcont1, *rcont2, *rcont3, *rcont4;
+    double *rcont5, *rcont6, *rcont7, *rcont8;
+    double xold, hout;
+    unsigned nrds;
+    unsigned *indir;
+} Dop853DenseState;
+
+// Thread-safe dense output function
+double contd8_threadsafe(Dop853DenseState *state, unsigned ii, double x);
+
+Dop853DenseState* dop853_dense_state_alloc(unsigned nrdens, unsigned n);
+void dop853_dense_state_free(Dop853DenseState* state, unsigned n);
+
 typedef void (*FcnEqDiff)(unsigned n, double x, double *y, double *f,
                           CPotential *p, CFrameType *fr, unsigned norbits,
                           unsigned nbody, void *args);
@@ -222,20 +237,19 @@ extern int dop853
   long nstiff,     /* test for stiffness */
   unsigned nrdens, /* number of components for which dense outpout is required */
   unsigned* icont, /* indexes of components for which dense output is required, >= nrdens */
-  unsigned licont  /* declared length of icon */
+  unsigned licont, /* declared length of icon */
+  Dop853DenseState* dense_state
  );
 
-extern double contd8
- (unsigned ii,     /* index of desired component */
-  double x         /* approximation at x */
- );
+// extern double contd8
+//  (unsigned ii,     /* index of desired component */
+//   double x         /* approximation at x */
+//  );
 
 extern long nfcnRead (void);   /* encapsulation of statistical data */
 extern long nstepRead (void);
 extern long naccptRead (void);
 extern long nrejctRead (void);
-extern double hRead (void);
-extern double xRead (void);
 
 /* ADDED BY APW */
 extern void Fwrapper (unsigned ndim, double t, double *w, double *f,

--- a/gala/integrate/cyintegrators/dopri/dop853.h
+++ b/gala/integrate/cyintegrators/dopri/dop853.h
@@ -238,7 +238,10 @@ extern int dop853
   unsigned nrdens, /* number of components for which dense outpout is required */
   unsigned* icont, /* indexes of components for which dense output is required, >= nrdens */
   unsigned licont, /* declared length of icon */
-  Dop853DenseState* dense_state
+  Dop853DenseState* dense_state,
+  double* output_times, /* array of times to sample */
+  int n_output_times,   /* number of output times */
+  double* output_y  /* output array to fill (size: n_output_times * n) */
  );
 
 // extern double contd8

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -62,7 +62,7 @@ cdef void c_leapfrog_step(CPotential *p, int half_ndim, double t, double dt,
         v_jm1_2[k] = v_jm1_2[k] - grad[k] * dt
 
 cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1] t,
-                                     int store_all=1):
+                                     int save_all=1):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -99,7 +99,7 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
         # whoa, so many dots
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
-    if store_all:
+    if save_all:
         all_w = np.zeros((ntimes, n, ndim))
 
         # save initial conditions
@@ -125,11 +125,11 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
                                 &v_jm1_2[i, 0],
                                 &grad[0])
 
-                if store_all:
+                if save_all:
                     for k in range(ndim):
                         all_w[j, i, k] = tmp_w[i, k]
 
-    if store_all:
+    if save_all:
         return np.asarray(t), np.asarray(all_w)
     else:
         return np.asarray(t[-1:]), np.asarray(tmp_w)
@@ -173,7 +173,7 @@ cdef void c_leapfrog_step_nbody(
 
 
 cpdef leapfrog_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
-                               list particle_potentials, int store_all=1):
+                               list particle_potentials, int save_all=1):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -212,7 +212,7 @@ cpdef leapfrog_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
         CPotential **c_particle_potentials = NULL
         unsigned nbody = 0
 
-    if store_all:
+    if save_all:
         all_w = np.zeros((ntimes, n, ndim))
 
         # save initial conditions
@@ -254,11 +254,11 @@ cpdef leapfrog_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
                                         &v_jm1_2[i, 0],
                                         &grad[0])
 
-                    if store_all:
+                    if save_all:
                         for k in range(ndim):
                             all_w[j, i, k] = tmp_w[i, k]
 
-        if store_all:
+        if save_all:
             return_val = (np.asarray(t), np.asarray(all_w))
         else:
             return_val = (np.asarray(t[-1:]), np.asarray(tmp_w))

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -53,7 +53,7 @@ cdef void c_ruth4_step(CPotential *p, int half_ndim, double t, double dt,
 cpdef ruth4_integrate_hamiltonian(hamiltonian,
                                   double[:, ::1] w0,
                                   double[::1] t,
-                                  int store_all=1):
+                                  int save_all=1):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -104,7 +104,7 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
         # whoa, so many dots
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
-    if store_all:
+    if save_all:
         all_w = np.zeros((ntimes, n, ndim))
 
         # save initial conditions
@@ -120,11 +120,11 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
                              &cs[0], &ds[0],
                              &tmp_w[i, 0], &grad[0])
 
-                if store_all:
+                if save_all:
                     for k in range(ndim):
                         all_w[j, i, k] = tmp_w[i, k]
 
-    if store_all:
+    if save_all:
         return np.asarray(t), np.asarray(all_w)
     else:
         return np.asarray(t[-1:]), np.asarray(tmp_w)
@@ -154,7 +154,7 @@ cdef void c_ruth4_step_nbody(
             w[k] = w[k] + cs[j] * w[half_ndim + k] * dt
 
 cpdef ruth4_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
-                            list particle_potentials, int store_all=1):
+                            list particle_potentials, int save_all=1):
     """
     CAUTION: Interpretation of axes is different here! We need the
     arrays to be C ordered and easy to iterate over, so here the
@@ -209,7 +209,7 @@ cpdef ruth4_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
         CPotential **c_particle_potentials = NULL
         unsigned nbody = 0
 
-    if store_all:
+    if save_all:
         all_w = np.zeros((ntimes, n, ndim))
 
         # save initial conditions
@@ -241,11 +241,11 @@ cpdef ruth4_integrate_nbody(hamiltonian, double [:, ::1] w0, double[::1] t,
                         &tmp_w[i, 0], &grad[0]
                     )
 
-                    if store_all:
+                    if save_all:
                         for k in range(ndim):
                             all_w[j, i, k] = tmp_w[i, k]
 
-        if store_all:
+        if save_all:
             return_val = (np.asarray(t), np.asarray(all_w))
         else:
             return_val = (np.asarray(t[-1:]), np.asarray(tmp_w))

--- a/gala/integrate/pyintegrators/dopri853.py
+++ b/gala/integrate/pyintegrators/dopri853.py
@@ -1,4 +1,4 @@
-""" Wrapper around SciPy DOPRI853 integrator. """
+"""Wrapper around SciPy DOPRI853 integrator."""
 
 # Third-party
 from scipy.integrate import ode
@@ -42,11 +42,11 @@ class DOPRI853Integrator(Integrator):
         func_args=(),
         func_units=None,
         progress=False,
-        store_all=True,
-        **kwargs
+        save_all=True,
+        **kwargs,
     ):
         super(DOPRI853Integrator, self).__init__(
-            func, func_args, func_units, progress=progress, store_all=store_all
+            func, func_args, func_units, progress=progress, save_all=save_all
         )
         self._ode_kwargs = kwargs
 
@@ -69,7 +69,7 @@ class DOPRI853Integrator(Integrator):
         self._ode = self._ode.set_integrator("dop853", **self._ode_kwargs)
 
         # create the return arrays
-        if self.store_all:
+        if self.save_all:
             ws[:, 0] = arr_w0
 
         # make 1D
@@ -84,13 +84,13 @@ class DOPRI853Integrator(Integrator):
             self._ode.integrate(times[k])
             outy = self._ode.y
 
-            if self.store_all:
+            if self.save_all:
                 ws[:, k] = outy.reshape(2 * self.ndim, self.norbits)
 
             if not self._ode.successful():
                 raise RuntimeError("ODE integration failed!")
 
-        if not self.store_all:
+        if not self.save_all:
             ws = outy.reshape(2 * self.ndim, 1, self.norbits)
             times = times[-1:]
 

--- a/gala/integrate/pyintegrators/dopri853.py
+++ b/gala/integrate/pyintegrators/dopri853.py
@@ -11,9 +11,38 @@ __all__ = ["DOPRI853Integrator"]
 
 
 class DOPRI853Integrator(Integrator):
-    r"""
-    This provides a wrapper around ``Scipy``'s implementation of the
-    Dormand-Prince 85(3) integration scheme.
+    r"""The Dormand-Prince 85(3) integration scheme.
+
+    For Python integration, this class serves as a wrapper around Scipy's
+    implementation of the integrator. See the Scipy documentation (`scipy.integrate.
+    DOP853`) for more details and parameters. Note that the default tolerances for the
+    Scipy integrator are quite poor for most applications, so you may want to set them
+    to something like ``atol=1e-10`` and ``rtol=1e-10`` for better accuracy. Pass these
+    to the class constructor as additional keyword arguments, e.g.::
+
+        >>> integrator = DOPRI853Integrator(func, atol=1e-10, rtol=1e-10)
+
+    For Cython integration, this class serves as a wrapper around a modified version of
+    a C implementation of the integrator. The C implementation is based on the original
+    Hairer and Wanner implementation, which is a C translation of the original Fortran
+    code by Dormand and Prince. The available arguments for the Cython integrator are:
+
+        - ``atol`` (float) - the minimum absolute error allowed in each integration
+          variable (i.e. position and velocity components) per step
+        - ``rtol`` (float) - the minimum relative error allowed in each integration
+          variable (i.e. position and velocity components) per step
+        - ``nmax`` (int) - the maximum number of integration steps
+        - ``dt_max`` (float) - the maximum internal timestep used for integration
+        - ``nstiff`` (int) - the number of steps to take before checking for stiffness
+        - ``err_if_fail`` (bool) - raise an error if the integration fails
+        - ``log_output`` (bool) - log any debug or additional error messages from the C
+          integrator (useful for debugging failed integrations)
+
+    New in version 1.10: The Cython implementation of the DOPRI853 integrator now uses
+    the dense output functionality of the integrator, which allows for more efficient
+    evaluation of the orbit on a dense grid of times. This is done by using internal
+    interpolation to compute the orbit at the requested times, rather than using the
+    original integration steps.
 
     .. seealso::
 
@@ -33,6 +62,10 @@ class DOPRI853Integrator(Integrator):
         integrand function.
     progress : bool (optional)
         Display a progress bar during integration.
+    **kwargs
+        Additional keyword arguments to pass to the integrator.
+        See the Scipy documentation for more details about Python integration options.
+        For Cython integration, see the class docstring above for details.
 
     """
 

--- a/gala/integrate/pyintegrators/leapfrog.py
+++ b/gala/integrate/pyintegrators/leapfrog.py
@@ -1,4 +1,4 @@
-""" Leapfrog integration. """
+"""Leapfrog integration."""
 
 # Third-party
 import numpy as np
@@ -104,7 +104,7 @@ class LeapfrogIntegrator(Integrator):
 
         x_i = x_im1 + v_im1_2 * dt
         F_i = self.F(t, np.vstack((x_i, v_im1_2)), *self._func_args)
-        a_i = F_i[self.ndim:]
+        a_i = F_i[self.ndim :]
 
         v_i = v_im1_2 + a_i * dt / 2
         v_ip1_2 = v_i + a_i * dt / 2
@@ -127,8 +127,8 @@ class LeapfrogIntegrator(Integrator):
 
         # here is where we scoot the velocity at t=t1 to v(t+1/2)
         F0 = self.F(t.copy(), w0.copy(), *self._func_args)
-        a0 = F0[self.ndim:]
-        v_1_2 = w0[self.ndim:] + a0*dt/2.
+        a0 = F0[self.ndim :]
+        v_1_2 = w0[self.ndim :] + a0 * dt / 2.0
 
         return v_1_2
 
@@ -139,29 +139,29 @@ class LeapfrogIntegrator(Integrator):
         dt = times[1] - times[0]
 
         w0_obj, w0, ws = self._prepare_ws(w0, mmap, n_steps)
-        x0 = w0[:self.ndim]
+        x0 = w0[: self.ndim]
 
         # prime the integrator so velocity is offset from coordinate by a
         #   half timestep
         v_im1_2 = self._init_v(times[0], w0, dt)
         x_im1 = x0
 
-        if self.store_all:
+        if self.save_all:
             ws[:, 0] = w0
 
         range_ = self._get_range_func()
-        for ii in range_(1, n_steps+1):
+        for ii in range_(1, n_steps + 1):
             x_i, v_i, v_ip1_2 = self.step(times[ii], x_im1, v_im1_2, dt)
 
-            if self.store_all:
+            if self.save_all:
                 slc = (ii, slice(None))
             else:
-                slc = (slice(None), )
-            ws[(slice(None, self.ndim), ) + slc] = x_i
-            ws[(slice(self.ndim, None), ) + slc] = v_i
+                slc = (slice(None),)
+            ws[(slice(None, self.ndim),) + slc] = x_i
+            ws[(slice(self.ndim, None),) + slc] = v_i
             x_im1, v_im1_2 = x_i, v_ip1_2
 
-        if not self.store_all:
+        if not self.save_all:
             times = times[-1:]
 
         return self._handle_output(w0_obj, times, ws)

--- a/gala/integrate/pyintegrators/rk5.py
+++ b/gala/integrate/pyintegrators/rk5.py
@@ -1,4 +1,4 @@
-""" 5th order Runge-Kutta integration. """
+"""5th order Runge-Kutta integration."""
 
 # Third-party
 import numpy as np
@@ -11,16 +11,33 @@ __all__ = ["RK5Integrator"]
 
 # These are the Dormand-Prince parameters for embedded Runge-Kutta methods
 A = np.array([0.0, 0.2, 0.3, 0.6, 1.0, 0.875])
-B = np.array([[0.0, 0.0, 0.0, 0.0, 0.0],
-              [1./5., 0.0, 0.0, 0.0, 0.0],
-              [3./40., 9./40., 0.0, 0.0, 0.0],
-              [3./10., -9./10., 6./5., 0.0, 0.0],
-              [-11./54., 5./2., -70./27., 35./27., 0.0],
-              [1631./55296., 175./512., 575./13824., 44275./110592., 253./4096.]
-              ])
-C = np.array([37./378., 0., 250./621., 125./594., 0., 512./1771.])
-D = np.array([2825./27648., 0., 18575./48384., 13525./55296.,
-              277./14336., 1./4.])
+B = np.array(
+    [
+        [0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0 / 5.0, 0.0, 0.0, 0.0, 0.0],
+        [3.0 / 40.0, 9.0 / 40.0, 0.0, 0.0, 0.0],
+        [3.0 / 10.0, -9.0 / 10.0, 6.0 / 5.0, 0.0, 0.0],
+        [-11.0 / 54.0, 5.0 / 2.0, -70.0 / 27.0, 35.0 / 27.0, 0.0],
+        [
+            1631.0 / 55296.0,
+            175.0 / 512.0,
+            575.0 / 13824.0,
+            44275.0 / 110592.0,
+            253.0 / 4096.0,
+        ],
+    ]
+)
+C = np.array([37.0 / 378.0, 0.0, 250.0 / 621.0, 125.0 / 594.0, 0.0, 512.0 / 1771.0])
+D = np.array(
+    [
+        2825.0 / 27648.0,
+        0.0,
+        18575.0 / 48384.0,
+        13525.0 / 55296.0,
+        277.0 / 14336.0,
+        1.0 / 4.0,
+    ]
+)
 
 
 class RK5Integrator(Integrator):
@@ -53,53 +70,65 @@ class RK5Integrator(Integrator):
     """
 
     def step(self, t, w, dt):
-        """ Step forward the vector w by the given timestep.
+        """Step forward the vector w by the given timestep.
 
-            Parameters
-            ----------
-            dt : numeric
-                The timestep to move forward.
+        Parameters
+        ----------
+        dt : numeric
+            The timestep to move forward.
         """
 
         # Runge-Kutta Fehlberg formulas (see: Numerical Recipes)
         F = lambda t, w: self.F(t, w, *self._func_args)  # noqa
 
-        K = np.zeros((6,)+w.shape)
+        K = np.zeros((6,) + w.shape)
         K[0] = dt * F(t, w)
-        K[1] = dt * F(t + A[1]*dt, w + B[1][0]*K[0])
-        K[2] = dt * F(t + A[2]*dt, w + B[2][0]*K[0] + B[2][1]*K[1])
-        K[3] = dt * F(t + A[3]*dt, w + B[3][0]*K[0] + B[3][1]*K[1] + B[3][2]*K[2])
-        K[4] = dt * F(t + A[4]*dt, w + B[4][0]*K[0] + B[4][1]*K[1] + B[4][2]*K[2] + B[4][3]*K[3])
-        K[5] = dt * F(t + A[5]*dt,
-                      w + B[5][0]*K[0] + B[5][1]*K[1] + B[5][2]*K[2] + B[5][3]*K[3] + B[5][4]*K[4])
+        K[1] = dt * F(t + A[1] * dt, w + B[1][0] * K[0])
+        K[2] = dt * F(t + A[2] * dt, w + B[2][0] * K[0] + B[2][1] * K[1])
+        K[3] = dt * F(
+            t + A[3] * dt, w + B[3][0] * K[0] + B[3][1] * K[1] + B[3][2] * K[2]
+        )
+        K[4] = dt * F(
+            t + A[4] * dt,
+            w + B[4][0] * K[0] + B[4][1] * K[1] + B[4][2] * K[2] + B[4][3] * K[3],
+        )
+        K[5] = dt * F(
+            t + A[5] * dt,
+            w
+            + B[5][0] * K[0]
+            + B[5][1] * K[1]
+            + B[5][2] * K[2]
+            + B[5][3] * K[3]
+            + B[5][4] * K[4],
+        )
 
         # shift
         dw = np.zeros_like(w)
         for i in range(6):
-            dw = dw + C[i]*K[i]
+            dw = dw + C[i] * K[i]
 
         return w + dw
 
     def __call__(self, w0, mmap=None, **time_spec):
         # generate the array of times
         times = parse_time_specification(self._func_units, **time_spec)
-        n_steps = len(times)-1
-        dt = times[1]-times[0]
+        n_steps = len(times) - 1
+        dt = times[1] - times[0]
 
         w0_obj, w0, ws = self._prepare_ws(w0, mmap, n_steps=n_steps)
 
-        if self.store_all:
+        if self.save_all:
             # Set first step to the initial conditions
             ws[:, 0] = w0
         w = w0.copy()
         range_ = self._get_range_func()
-        for ii in range_(1, n_steps+1):
+        for ii in range_(1, n_steps + 1):
             w = self.step(times[ii], w, dt)
 
-            if self.store_all:
+            if self.save_all:
                 ws[:, ii] = w
 
-        if not self.store_all:
+        if not self.save_all:
             ws = w
             times = times[-1:]
 

--- a/gala/integrate/pyintegrators/ruth4.py
+++ b/gala/integrate/pyintegrators/ruth4.py
@@ -1,4 +1,4 @@
-""" Leapfrog integration. """
+"""Leapfrog integration."""
 
 # Project
 from ..core import Integrator
@@ -115,10 +115,10 @@ class Ruth4Integrator(Integrator):
         w_i = w.copy()
         for cj, dj in zip(self._cs, self._ds):
             F_i = self.F(t, w_i, *self._func_args)
-            a_i = F_i[self.ndim:]
+            a_i = F_i[self.ndim :]
 
-            w_i[self.ndim:] += dj * a_i * dt
-            w_i[: self.ndim] += cj * w_i[self.ndim:] * dt
+            w_i[self.ndim :] += dj * a_i * dt
+            w_i[: self.ndim] += cj * w_i[self.ndim :] * dt
 
         return w_i
 
@@ -131,17 +131,17 @@ class Ruth4Integrator(Integrator):
         w0_obj, w0, ws = self._prepare_ws(w0, mmap, n_steps=n_steps)
 
         # Set first step to the initial conditions
-        if self.store_all:
+        if self.save_all:
             ws[:, 0] = w0
         w = w0.copy()
         range_ = self._get_range_func()
         for ii in range_(1, n_steps + 1):
             w = self.step(times[ii], w, dt)
 
-            if self.store_all:
+            if self.save_all:
                 ws[:, ii] = w
 
-        if not self.store_all:
+        if not self.save_all:
             ws = w
             times = times[-1:]
 

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -1,24 +1,25 @@
 """
-    Test the Cython integrators.
+Test the Cython integrators.
 """
 
 # Standard library
-from itertools import product
 import time
+from itertools import product
 
 # Third-party
 import numpy as np
 import pytest
 
-# Project
-from ..pyintegrators.leapfrog import LeapfrogIntegrator
-from ..cyintegrators.leapfrog import leapfrog_integrate_hamiltonian
-from ..pyintegrators.dopri853 import DOPRI853Integrator
-from ..cyintegrators.dop853 import dop853_integrate_hamiltonian
-from ..pyintegrators.ruth4 import Ruth4Integrator
-from ..cyintegrators.ruth4 import ruth4_integrate_hamiltonian
 from ...potential import Hamiltonian, HernquistPotential
 from ...units import galactic
+from ..cyintegrators.dop853 import dop853_integrate_hamiltonian
+from ..cyintegrators.leapfrog import leapfrog_integrate_hamiltonian
+from ..cyintegrators.ruth4 import ruth4_integrate_hamiltonian
+from ..pyintegrators.dopri853 import DOPRI853Integrator
+
+# Project
+from ..pyintegrators.leapfrog import LeapfrogIntegrator
+from ..pyintegrators.ruth4 import Ruth4Integrator
 
 integrator_list = [LeapfrogIntegrator, DOPRI853Integrator, Ruth4Integrator]
 func_list = [
@@ -32,10 +33,7 @@ for dt in [2, -2]:
     _list.extend([(x, y, dt) for x, y in zip(integrator_list, func_list)])
 
 
-@pytest.mark.parametrize(
-    ["Integrator", "integrate_func", "dt"],
-    _list
-)
+@pytest.mark.parametrize(["Integrator", "integrate_func", "dt"], _list)
 def test_compare_to_py(Integrator, integrate_func, dt):
     p = HernquistPotential(m=1e11, c=0.5, units=galactic)
     H = Hamiltonian(potential=p)
@@ -70,10 +68,7 @@ def test_compare_to_py(Integrator, integrate_func, dt):
     assert np.allclose(cy_t, py_t)
 
 
-@pytest.mark.parametrize(
-    ["integrate_func", "dt"],
-    product(func_list, [-2., 2])
-)
+@pytest.mark.parametrize(["integrate_func", "dt"], product(func_list, [-2.0, 2]))
 def test_store_all(integrate_func, dt):
     p = HernquistPotential(m=1e11, c=0.5, units=galactic)
     H = Hamiltonian(potential=p)
@@ -100,8 +95,7 @@ def test_store_all(integrate_func, dt):
 # --speed-scaling or something?
 @pytest.mark.skipif(True, reason="Slow test - mainly for plotting locally")
 @pytest.mark.parametrize(
-    ["Integrator", "integrate_func"],
-    zip(integrator_list, func_list)
+    ["Integrator", "integrate_func"], zip(integrator_list, func_list)
 )
 def test_scaling(tmpdir, Integrator, integrate_func):
     p = HernquistPotential(m=1e11, c=0.5, units=galactic)

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -69,7 +69,7 @@ def test_compare_to_py(Integrator, integrate_func, dt):
 
 
 @pytest.mark.parametrize(["integrate_func", "dt"], product(func_list, [-2.0, 2]))
-def test_store_all(integrate_func, dt):
+def test_save_all(integrate_func, dt):
     p = HernquistPotential(m=1e11, c=0.5, units=galactic)
     H = Hamiltonian(potential=p)
 
@@ -85,7 +85,7 @@ def test_store_all(integrate_func, dt):
     t = np.linspace(0, dt * 1024, 1024 + 1)
 
     t_all, w_all = integrate_func(H, w0, t)
-    t_f, w_f = integrate_func(H, w0, t, store_all=False)
+    t_f, w_f = integrate_func(H, w0, t, save_all=False)
 
     assert t_all[-1] == t_f[0]
     assert np.allclose(w_all[-1], w_f)

--- a/gala/integrate/tests/test_pyintegrators.py
+++ b/gala/integrate/tests/test_pyintegrators.py
@@ -1,21 +1,24 @@
 """
-    Test the integrators.
+Test the integrators.
 """
+
 import os
+
+import numpy as np
 
 # Third-party
 import pytest
-import numpy as np
 from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from gala.tests.optional_deps import HAS_TQDM
 
 # Project
 from .. import (
+    DOPRI853Integrator,
     LeapfrogIntegrator,
     RK5Integrator,
-    DOPRI853Integrator,
     Ruth4Integrator,
 )
-from gala.tests.optional_deps import HAS_TQDM
 
 # Integrators to test
 integrator_list = [
@@ -24,6 +27,7 @@ integrator_list = [
     LeapfrogIntegrator,
     Ruth4Integrator,
 ]
+
 
 # Gradient functions:
 def sho_F(t, w, T):  # noqa
@@ -116,9 +120,7 @@ def test_progress(Integrator):
 
 @pytest.mark.parametrize("Integrator", integrator_list)
 def test_point_mass_multiple(Integrator):
-    w0 = np.array(
-        [[1.0, 0.0, 0.0, 1.0], [0.8, 0.0, 0.0, 1.1], [2.0, 1.0, -1.0, 1.1]]
-    ).T
+    w0 = np.array([[1.0, 0.0, 0.0, 1.0], [0.8, 0.0, 0.0, 1.1], [2.0, 1.0, -1.0, 1.1]]).T
 
     integrator = Integrator(ptmass_F)
     _ = integrator(w0, dt=1e-3, n_steps=1e4)
@@ -155,9 +157,9 @@ def test_memmap(tmpdir, Integrator):
 
 
 @pytest.mark.parametrize("Integrator", integrator_list)
-def test_py_store_all(Integrator):
-    integrator_all = Integrator(sho_F, func_args=(1.3,), store_all=True)
-    integrator_final = Integrator(sho_F, func_args=(1.3,), store_all=False)
+def test_py_save_all(Integrator):
+    integrator_all = Integrator(sho_F, func_args=(1.3,), save_all=True)
+    integrator_final = Integrator(sho_F, func_args=(1.3,), save_all=False)
 
     dt = 1e-4
     n_steps = 10_000

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -335,7 +335,7 @@ class Hamiltonian(CommonBase):
                 from ...integrate.cyintegrators import dop853_integrate_hamiltonian
                 t, w = dop853_integrate_hamiltonian(
                     self, arr_w0, t,
-                    Integrator_kwargs.get('atol', 0),
+                    Integrator_kwargs.get('atol', 1e-10),
                     Integrator_kwargs.get('rtol', 1E-10),
                     Integrator_kwargs.get('nmax', 0),
                     save_all=save_all,

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -334,7 +334,6 @@ class Hamiltonian(CommonBase):
                     Integrator_kwargs.get('atol', 1E-10),
                     Integrator_kwargs.get('rtol', 1E-10),
                     Integrator_kwargs.get('nmax', 0),
-                    Integrator_kwargs.get('progress', False),
                     store_all=store_all
                 )
             else:

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -263,8 +263,10 @@ class Hamiltonian(CommonBase):
             `~gala.integrate.LeapfrogIntegrator` if the frame is static and
             `~gala.integrate.DOPRI853Integrator` else.
         Integrator_kwargs : dict (optional)
-            Any extra keyword argumets to pass to the integrator class
-            when initializing. Only works in non-Cython mode.
+            Any extra keyword arguments to pass to the integrator class
+            when initializing. For example, you can pass in the
+            ``atol`` and ``rtol`` keyword arguments to set the absolute and
+            relative tolerances for the DOPRI853 integrator.
         cython_if_possible : bool (optional)
             If there is a Cython version of the integrator implemented,
             and the potential object has a C instance, using Cython
@@ -334,7 +336,9 @@ class Hamiltonian(CommonBase):
                     Integrator_kwargs.get('atol', 1E-10),
                     Integrator_kwargs.get('rtol', 1E-10),
                     Integrator_kwargs.get('nmax', 0),
-                    store_all=store_all
+                    store_all=store_all,
+                    err_if_fail=int(Integrator_kwargs.get('err_if_fail', 1)),
+                    log_output=int(Integrator_kwargs.get('log_output', 0)),
                 )
             else:
                 raise ValueError(f"Cython integration not supported for '{Integrator!r}'")

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -5,6 +5,7 @@ import warnings
 
 # Third-party
 import numpy as np
+from astropy.utils.decorators import deprecated_renamed_argument
 import astropy.units as u
 
 # Project
@@ -241,12 +242,13 @@ class Hamiltonian(CommonBase):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    @deprecated_renamed_argument("store_all", "save_all", since="1.10")
     def integrate_orbit(self,
         w0,
         Integrator=None,
         Integrator_kwargs=dict(),
         cython_if_possible=True,
-        store_all=True,
+        save_all=True,
         **time_spec
     ):
         """
@@ -271,7 +273,7 @@ class Hamiltonian(CommonBase):
             If there is a Cython version of the integrator implemented,
             and the potential object has a C instance, using Cython
             will be *much* faster.
-        store_all : bool (optional)
+        save_all : bool (optional)
             Controls whether to store the phase-space position at all intermediate
             timesteps. Set to False to store only the final values (i.e. the
             phase-space position(s) at the final timestep). Default is True.
@@ -323,11 +325,11 @@ class Hamiltonian(CommonBase):
             # TODO: these replacements should be defined in gala.integrate...
             if Integrator == LeapfrogIntegrator:
                 from ...integrate.cyintegrators import leapfrog_integrate_hamiltonian
-                t, w = leapfrog_integrate_hamiltonian(self, arr_w0, t, store_all=store_all)
+                t, w = leapfrog_integrate_hamiltonian(self, arr_w0, t, save_all=save_all)
 
             elif Integrator == Ruth4Integrator:
                 from ...integrate.cyintegrators import ruth4_integrate_hamiltonian
-                t, w = ruth4_integrate_hamiltonian(self, arr_w0, t, store_all=store_all)
+                t, w = ruth4_integrate_hamiltonian(self, arr_w0, t, save_all=save_all)
 
             elif Integrator == DOPRI853Integrator:
                 from ...integrate.cyintegrators import dop853_integrate_hamiltonian
@@ -336,7 +338,7 @@ class Hamiltonian(CommonBase):
                     Integrator_kwargs.get('atol', 1E-10),
                     Integrator_kwargs.get('rtol', 1E-10),
                     Integrator_kwargs.get('nmax', 0),
-                    store_all=store_all,
+                    save_all=save_all,
                     err_if_fail=int(Integrator_kwargs.get('err_if_fail', 1)),
                     log_output=int(Integrator_kwargs.get('log_output', 0)),
                 )
@@ -359,7 +361,7 @@ class Hamiltonian(CommonBase):
             orbit.frame = self.frame
             return orbit
 
-        if not store_all:
+        if not save_all:
             w = w[:, None]
 
         try:

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -335,7 +335,7 @@ class Hamiltonian(CommonBase):
                 from ...integrate.cyintegrators import dop853_integrate_hamiltonian
                 t, w = dop853_integrate_hamiltonian(
                     self, arr_w0, t,
-                    Integrator_kwargs.get('atol', 1E-10),
+                    Integrator_kwargs.get('atol', 0),
                     Integrator_kwargs.get('rtol', 1E-10),
                     Integrator_kwargs.get('nmax', 0),
                     save_all=save_all,

--- a/gala/potential/hamiltonian/tests/test_with_frame_potential.py
+++ b/gala/potential/hamiltonian/tests/test_with_frame_potential.py
@@ -186,8 +186,8 @@ class TestKepler2RotatingFrame(_TestBase):
 @pytest.mark.parametrize(
     "name, Omega, tol",
     [
-        ("z-aligned co-rotating", [0, 0, 1.0] * u.one, 1e-12),
-        ("z-aligned", [0, 0, 1.5834] * u.one, 1e-12),
+        ("z-aligned co-rotating", [0, 0, 1.0] * u.one, 1e-10),
+        ("z-aligned", [0, 0, 1.5834] * u.one, 1e-10),
         ("random", [0.95792653, 0.82760659, 0.66443135] * u.one, 1e-10),
     ],
 )
@@ -206,9 +206,19 @@ def test_velocity_rot_frame(name, Omega, tol):
     )
     H = Hamiltonian(potential, StaticFrame(units=dimensionless))
 
-    orbit_i = H.integrate_orbit(w0, dt=0.1, n_steps=1000, Integrator=DOPRI853Integrator)
+    orbit_i = H.integrate_orbit(
+        w0,
+        dt=0.1,
+        n_steps=1000,
+        Integrator=DOPRI853Integrator,
+        Integrator_kwargs={"atol": 1e-12, "rtol": 1e-12},
+    )
     orbit_r = H_r.integrate_orbit(
-        w0, dt=0.1, n_steps=1000, Integrator=DOPRI853Integrator
+        w0,
+        dt=0.1,
+        n_steps=1000,
+        Integrator=DOPRI853Integrator,
+        Integrator_kwargs={"atol": 1e-12, "rtol": 1e-12},
     )
 
     orbit_i2r = orbit_i.to_frame(

--- a/gala/potential/hamiltonian/tests/test_with_frame_potential.py
+++ b/gala/potential/hamiltonian/tests/test_with_frame_potential.py
@@ -1,16 +1,17 @@
 # Third-party
 import astropy.units as u
-import pytest
 import numpy as np
+import pytest
+
+from ....dynamics import Orbit, PhaseSpacePosition
+from ....integrate import DOPRI853Integrator
+from ....units import dimensionless, galactic
+from ...frame.builtin import ConstantRotatingFrame, StaticFrame
+from ...potential.builtin import HernquistPotential, KeplerPotential, NFWPotential
+from .. import Hamiltonian
 
 # Project
 from .helpers import _TestBase
-from .. import Hamiltonian
-from ...potential.builtin import NFWPotential, KeplerPotential, HernquistPotential
-from ...frame.builtin import StaticFrame, ConstantRotatingFrame
-from ....units import galactic, dimensionless
-from ....dynamics import PhaseSpacePosition, Orbit
-from ....integrate import DOPRI853Integrator
 
 # ----------------------------------------------------------------------------
 
@@ -21,23 +22,26 @@ def to_rotating_frame(omega, w, t=None):
     TODO: move this to be a ConstantRotatingFrame method
     """
 
-    if not hasattr(omega, 'unit'):
+    if not hasattr(omega, "unit"):
         raise TypeError("Input frequency vector must be a Quantity object.")
 
     try:
-        omega = omega.to(u.rad/u.Myr, equivalencies=u.dimensionless_angles()).value
+        omega = omega.to(u.rad / u.Myr, equivalencies=u.dimensionless_angles()).value
     except:  # noqa
         omega = omega.value
 
     if isinstance(w, Orbit) and t is not None:
-        raise TypeError("If passing in an Orbit object, do not also specify "
-                        "a time array, t.")
+        raise TypeError(
+            "If passing in an Orbit object, do not also specify " "a time array, t."
+        )
 
     elif not isinstance(w, Orbit) and t is None:
-        raise TypeError("If not passing in an Orbit object, you must also specify "
-                        "a time array, t.")
+        raise TypeError(
+            "If not passing in an Orbit object, you must also specify "
+            "a time array, t."
+        )
 
-    elif t is not None and not hasattr(t, 'unit'):
+    elif t is not None and not hasattr(t, "unit"):
         raise TypeError("Input time must be a Quantity object.")
 
     if t is not None:
@@ -62,13 +66,14 @@ def to_rotating_frame(omega, w, t=None):
     else:
         Cls = None
         ndim = w.shape[0]
-        x_shape = (ndim//2,) + w.shape[1:]
-        x = w[:ndim//2]
-        v = w[ndim//2:]
+        x_shape = (ndim // 2,) + w.shape[1:]
+        x = w[: ndim // 2]
+        v = w[ndim // 2 :]
 
-        if hasattr(x, 'unit'):
-            raise TypeError("If w is not an Orbit or PhaseSpacePosition, w "
-                            "cannot have units!")
+        if hasattr(x, "unit"):
+            raise TypeError(
+                "If w is not an Orbit or PhaseSpacePosition, w " "cannot have units!"
+            )
 
         x_unit = u.one
         v_unit = u.one
@@ -78,8 +83,11 @@ def to_rotating_frame(omega, w, t=None):
     theta = (np.linalg.norm(omega) * t)[None]
 
     # we use Rodrigues' rotation formula to rotate the position
-    x_rot = np.cos(theta)*x + np.sin(theta)*np.cross(ee, x, axisa=0, axisb=0, axisc=0) \
+    x_rot = (
+        np.cos(theta) * x
+        + np.sin(theta) * np.cross(ee, x, axisa=0, axisb=0, axisc=0)
         + (1 - np.cos(theta)) * np.einsum("i, ij->j", ee, x) * ee[:, None]
+    )
 
     v_cor = np.cross(omega, x, axisa=0, axisb=0, axisc=0) * x_unit
     v_rot = v - v_cor.to(v_unit, u.dimensionless_angles()).value
@@ -96,13 +104,15 @@ def to_rotating_frame(omega, w, t=None):
         else:
             return Cls(pos=x_rot, vel=v_rot)
 
+
 # ----------------------------------------------------------------------------
 
 
 class TestWithPotentialStaticFrame(_TestBase):
-    obj = Hamiltonian(NFWPotential.from_circular_velocity(v_c=0.2, r_s=20.,
-                                                          units=galactic),
-                      StaticFrame(units=galactic))
+    obj = Hamiltonian(
+        NFWPotential.from_circular_velocity(v_c=0.2, r_s=20.0, units=galactic),
+        StaticFrame(units=galactic),
+    )
 
     @pytest.mark.skip("Not implemented")
     def test_hessian(self):
@@ -110,10 +120,12 @@ class TestWithPotentialStaticFrame(_TestBase):
 
 
 class TestKeplerRotatingFrame(_TestBase):
-    Omega = [0., 0, 1.]*u.one
+    Omega = [0.0, 0, 1.0] * u.one
     E_unit = u.one
-    obj = Hamiltonian(KeplerPotential(m=1., units=dimensionless),
-                      ConstantRotatingFrame(Omega=Omega, units=dimensionless))
+    obj = Hamiltonian(
+        KeplerPotential(m=1.0, units=dimensionless),
+        ConstantRotatingFrame(Omega=Omega, units=dimensionless),
+    )
 
     @pytest.mark.skip("Not implemented")
     def test_hessian(self):
@@ -121,22 +133,28 @@ class TestKeplerRotatingFrame(_TestBase):
 
     def test_integrate(self):
 
-        w0 = PhaseSpacePosition(pos=[1., 0, 0.], vel=[0, 1., 0.])
+        w0 = PhaseSpacePosition(pos=[1.0, 0, 0.0], vel=[0, 1.0, 0.0])
 
         for bl in [True, False]:
-            orbit = self.obj.integrate_orbit(w0, dt=1., n_steps=1000,
-                                             cython_if_possible=bl,
-                                             Integrator=DOPRI853Integrator)
+            orbit = self.obj.integrate_orbit(
+                w0,
+                dt=1.0,
+                n_steps=1000,
+                cython_if_possible=bl,
+                Integrator=DOPRI853Integrator,
+            )
 
-            assert np.allclose(orbit.x.value, 1., atol=1E-7)
-            assert np.allclose(orbit.xyz.value[1:], 0., atol=1E-7)
+            assert np.allclose(orbit.x.value, 1.0, atol=1e-7)
+            assert np.allclose(orbit.xyz.value[1:], 0.0, atol=1e-7)
 
 
 class TestKepler2RotatingFrame(_TestBase):
-    Omega = [1., 1., 1.]*u.one
+    Omega = [1.0, 1.0, 1.0] * u.one
     E_unit = u.one
-    obj = Hamiltonian(KeplerPotential(m=1., units=dimensionless),
-                      ConstantRotatingFrame(Omega=Omega, units=dimensionless))
+    obj = Hamiltonian(
+        KeplerPotential(m=1.0, units=dimensionless),
+        ConstantRotatingFrame(Omega=Omega, units=dimensionless),
+    )
 
     @pytest.mark.skip("Not implemented")
     def test_hessian(self):
@@ -147,42 +165,54 @@ class TestKepler2RotatingFrame(_TestBase):
         # --------------------------------------------------------------
         # when Omega is off from orbital frequency
         #
-        w0 = PhaseSpacePosition(pos=[1., 0, 0.], vel=[0, 1.1, 0.])
+        w0 = PhaseSpacePosition(pos=[1.0, 0, 0.0], vel=[0, 1.1, 0.0])
 
         for bl in [True, False]:
-            orbit = self.obj.integrate_orbit(w0, dt=0.1, n_steps=10000,
-                                             cython_if_possible=bl,
-                                             Integrator=DOPRI853Integrator)
+            orbit = self.obj.integrate_orbit(
+                w0,
+                dt=0.1,
+                n_steps=10000,
+                cython_if_possible=bl,
+                Integrator=DOPRI853Integrator,
+            )
 
             L = orbit.angular_momentum()
             C = orbit.energy() - np.sum(self.Omega[:, None] * L, axis=0)
-            dC = np.abs((C[1:]-C[0])/C[0])
-            assert np.all(dC < 1E-9)  # conserve Jacobi constant
+            dC = np.abs((C[1:] - C[0]) / C[0])
+            assert np.all(dC < 1e-9)  # conserve Jacobi constant
 
 
-@pytest.mark.parametrize("name, Omega, tol", [
-    ("z-aligned co-rotating", [0, 0, 1.]*u.one, 1E-12),
-    ("z-aligned", [0, 0, 1.5834]*u.one, 1E-12),
-    ("random", [0.95792653, 0.82760659, 0.66443135]*u.one, 1E-10),
-])
+@pytest.mark.parametrize(
+    "name, Omega, tol",
+    [
+        ("z-aligned co-rotating", [0, 0, 1.0] * u.one, 1e-12),
+        ("z-aligned", [0, 0, 1.5834] * u.one, 1e-12),
+        ("random", [0.95792653, 0.82760659, 0.66443135] * u.one, 1e-10),
+    ],
+)
 def test_velocity_rot_frame(name, Omega, tol):
     # _i = inertial
     # _r = rotating
 
     r0 = 1.245246
-    potential = HernquistPotential(m=1., c=0.2, units=dimensionless)
+    potential = HernquistPotential(m=1.0, c=0.2, units=dimensionless)
     vc = potential.circular_velocity([r0, 0, 0]).value[0]
-    w0 = PhaseSpacePosition(pos=[r0, 0, 0.],
-                            vel=[0, vc, 0.])
-    Omega = Omega * [1., 1., vc/r0]
+    w0 = PhaseSpacePosition(pos=[r0, 0, 0.0], vel=[0, vc, 0.0])
+    Omega = Omega * [1.0, 1.0, vc / r0]
 
-    H_r = Hamiltonian(potential, ConstantRotatingFrame(Omega=Omega, units=dimensionless))
+    H_r = Hamiltonian(
+        potential, ConstantRotatingFrame(Omega=Omega, units=dimensionless)
+    )
     H = Hamiltonian(potential, StaticFrame(units=dimensionless))
 
     orbit_i = H.integrate_orbit(w0, dt=0.1, n_steps=1000, Integrator=DOPRI853Integrator)
-    orbit_r = H_r.integrate_orbit(w0, dt=0.1, n_steps=1000, Integrator=DOPRI853Integrator)
+    orbit_r = H_r.integrate_orbit(
+        w0, dt=0.1, n_steps=1000, Integrator=DOPRI853Integrator
+    )
 
-    orbit_i2r = orbit_i.to_frame(ConstantRotatingFrame(Omega=Omega, units=dimensionless))
+    orbit_i2r = orbit_i.to_frame(
+        ConstantRotatingFrame(Omega=Omega, units=dimensionless)
+    )
     orbit_r2i = orbit_r.to_frame(StaticFrame(units=dimensionless))
 
     assert u.allclose(orbit_i.xyz, orbit_r2i.xyz, atol=tol)

--- a/gala/potential/hamiltonian/tests/test_with_frame_potential.py
+++ b/gala/potential/hamiltonian/tests/test_with_frame_potential.py
@@ -174,6 +174,7 @@ class TestKepler2RotatingFrame(_TestBase):
                 n_steps=10000,
                 cython_if_possible=bl,
                 Integrator=DOPRI853Integrator,
+                Integrator_kwargs={"atol": 1e-12, "rtol": 1e-12},
             )
 
             L = orbit.angular_momentum()

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -795,7 +795,7 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
             If there is a Cython version of the integrator implemented,
             and the potential object has a C instance, using Cython
             will be *much* faster.
-        store_all : bool (optional)
+        save_all : bool (optional)
             Controls whether to store the phase-space position at all intermediate
             timesteps. Set to False to store only the final values (i.e. the
             phase-space position(s) at the final timestep). Default is True.

--- a/gala/potential/potential/tests/test_composite.py
+++ b/gala/potential/potential/tests/test_composite.py
@@ -62,6 +62,10 @@ class CompositeHelper:
         potential["two"] = self.p2
 
         for Integrator in [DOPRI853Integrator, LeapfrogIntegrator]:
+            kw = {}
+            if Integrator == DOPRI853Integrator:
+                kw = {"atol": 1e-14, "rtol": 1e-14}
+
             H = gp.Hamiltonian(potential)
             w_cy = H.integrate_orbit(
                 [1.0, 0, 0, 0, 2 * np.pi, 0],
@@ -69,6 +73,7 @@ class CompositeHelper:
                 n_steps=1000,
                 Integrator=Integrator,
                 cython_if_possible=True,
+                Integrator_kwargs=kw,
             )
             w_py = H.integrate_orbit(
                 [1.0, 0, 0, 0, 2 * np.pi, 0],
@@ -78,6 +83,7 @@ class CompositeHelper:
                 cython_if_possible=False,
             )
 
+            dx = w_cy.xyz.value - w_py.xyz.value
             assert np.allclose(w_cy.xyz.value, w_py.xyz.value)
             assert np.allclose(w_cy.v_xyz.value, w_py.v_xyz.value)
 


### PR DESCRIPTION
### Describe your changes
Out of laziness, the longstanding way integration was done with the dop853 integrator was to use the integrator to evolve each step in the requested output time array sequentially. This led to very good energy conservation properties, but was very slow and full of overheads. 

This is a major refactor of the C implementation of dop853 to expose the dense integration (in a thread-safe way) to Cython/Python. This should lead to some significant speed increases for integration with this integrator.

### TODO:
- [x] Track down lingering thread-unsafeness?? I was running some integration tests in a loop and one integration failed with a return code -2. That is unexpected and suspicious...
- [x] Add tests against hard-coded values from integration with the implementation in `main`, to ensure backwards-stability and consistency
- [x] Expose tolerances as configurable arguments
- [x] Add option to not raise a Python error if the integrator fails
- [x] Pass a file pointer to collect log output?
- Allow integrators to be specified by string name (make a new issue and PR for this)

### Checklist

* [x] Did you add tests?
* [x] Did you add documentation for your changes?
* [x] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?

Closes #215