### PR TITLE
Implement an SVD-truncated or regularized version of O2GF action solver

### DIFF
--- a/gala/dynamics/actionangle/actionangle_regularized_o2gf.py
+++ b/gala/dynamics/actionangle/actionangle_regularized_o2gf.py
@@ -11,9 +11,7 @@ def solve_low_rank(A, b, rank=None, tol=1e-10):
     Parameters
     ----------
     A : array_like
-        Square system matrix.
     b : array_like
-        Right-hand side.
     rank : int, optional
         Number of singular values to keep. If None, use all above `tol`.
     tol : float

--- a/gala/dynamics/actionangle/actionangle_regularized_o2gf.py
+++ b/gala/dynamics/actionangle/actionangle_regularized_o2gf.py
@@ -1,0 +1,155 @@
+import numpy as np
+from scipy.linalg import svd
+
+from .actionangle_o2gf import _action_prepare, _angle_prepare, fit_toy_potential
+
+
+def solve_low_rank(A, b, rank=None, tol=1e-10):
+    """
+    Solve Ax = b using a low-rank approximation to A via truncated SVD.
+
+    Parameters
+    ----------
+    A : array_like
+        Square system matrix.
+    b : array_like
+        Right-hand side.
+    rank : int, optional
+        Number of singular values to keep. If None, use all above `tol`.
+    tol : float
+        Threshold below which singular values are discarded.
+
+    Returns
+    -------
+    x : array_like
+        Solution vector.
+    """
+    U, s, Vh = svd(A)
+    if rank is None:
+        rank = np.sum(s > tol)
+    S_inv = np.zeros_like(s)
+    S_inv[:rank] = 1.0 / s[:rank]
+    A_pinv = (Vh.T @ np.diag(S_inv)) @ U.T
+    return A_pinv @ b
+
+
+def _single_orbit_find_actions_regularized(
+    orbit,
+    N_max,
+    rank=None,
+    tol=1e-10,
+    toy_potential=None,
+    force_harmonic_oscillator=False,
+    fit_kwargs=None,
+):
+    import warnings
+
+    from gala.logging import logger
+    from gala.potential import HarmonicOscillatorPotential, IsochronePotential
+
+    if orbit.norbits > 1:
+        raise ValueError("must be a single orbit")
+
+    if fit_kwargs is None:
+        fit_kwargs = {}
+
+    if toy_potential is None:
+        toy_potential = fit_toy_potential(
+            orbit, force_harmonic_oscillator=force_harmonic_oscillator, **fit_kwargs
+        )
+    else:
+        logger.debug(f"Using *fixed* toy potential: {toy_potential.parameters}")
+
+    if isinstance(toy_potential, IsochronePotential):
+        orbit_align = orbit.align_circulation_with_z()
+        w = orbit_align.w()
+
+        dxyz = (1, 2, 2)
+        circ = np.sign(w[0, 0] * w[4, 0] - w[1, 0] * w[3, 0])
+        sign = np.array([1.0, circ, 1.0])
+        orbit = orbit_align
+    elif isinstance(toy_potential, HarmonicOscillatorPotential):
+        dxyz = (2, 2, 2)
+        sign = 1.0
+        w = orbit.w()
+    else:
+        raise ValueError("Invalid toy potential.")
+
+    t = orbit.t.value
+    aaf = toy_potential.action_angle(orbit)
+    if aaf[0].ndim > 2:
+        aa = np.vstack((aaf[0].value[..., 0], aaf[1].value[..., 0]))
+    else:
+        aa = np.vstack((aaf[0].value, aaf[1].value))
+
+    if np.any(np.isnan(aa)):
+        ix = ~np.any(np.isnan(aa), axis=0)
+        aa = aa[:, ix]
+        t = t[ix]
+        warnings.warn("NaN value in toy actions or angles!")
+        if sum(ix) > 1:
+            raise ValueError("Too many NaN value in toy actions or angles!")
+
+    J_toy = aa[:3]  # shape (3, N)
+    J_mean = np.mean(J_toy, axis=1, keepdims=True)
+    aa[:3] -= J_mean
+
+    A, b, nvecs = _action_prepare(aa, N_max, dx=dxyz[0], dy=dxyz[1], dz=dxyz[2])
+    actions = solve_low_rank(A, b, rank=rank, tol=tol)
+
+    A, b, nvecs = _angle_prepare(
+        aa, t, N_max, dx=dxyz[0], dy=dxyz[1], dz=dxyz[2], sign=sign
+    )
+    angles = solve_low_rank(A, b, rank=rank, tol=tol)
+
+    J = actions[:3] + J_mean
+    theta = angles[:3]
+    freqs = angles[3:6]
+
+    return dict(
+        actions=J * aaf[0].unit,
+        angles=theta * aaf[1].unit,
+        freqs=freqs * aaf[2].unit,
+        Sn=actions[3:],
+        dSn_dJ=angles[6:],
+        nvecs=nvecs,
+    )
+
+
+def find_actions_o2gf_regularized(
+    orbit,
+    N_max,
+    rank=None,
+    tol=1e-10,
+    force_harmonic_oscillator=False,
+    toy_potential=None,
+    fit_kwargs=None,
+):
+    from astropy.table import QTable
+
+    if orbit.norbits == 1:
+        result = _single_orbit_find_actions_regularized(
+            orbit,
+            N_max,
+            rank=rank,
+            tol=tol,
+            force_harmonic_oscillator=force_harmonic_oscillator,
+            toy_potential=toy_potential,
+            fit_kwargs=fit_kwargs,
+        )
+        rows = [result]
+    else:
+        rows = []
+        for n in range(orbit.norbits):
+            aaf = _single_orbit_find_actions_regularized(
+                orbit[:, n],
+                N_max,
+                rank=rank,
+                tol=tol,
+                force_harmonic_oscillator=force_harmonic_oscillator,
+                toy_potential=toy_potential,
+                fit_kwargs=fit_kwargs,
+            )
+            rows.append(aaf)
+
+    return QTable(rows=rows)


### PR DESCRIPTION
### Describe your changes

This has been a curiosity of mine for too long, but finally decided to try implementing a test of the idea. 

The main idea here starts with the [O2GF action estimation method](https://arxiv.org/abs/1401.3600) by @jlsanders. This method solves for the generating function and its derivatives that transforms from "toy" actions and angles to the "correct" action/angle values for an integrated orbit. This works by approximating the generating function as a Fourier series in the toy angles, and solves for the coefficients using a matrix solve. This is unstable when the integrated orbit is short or sparsely sampled because the design matrix can be ill-conditioned or the system underdetermined.

The demo implementation here replaces the standard linalg solve with a version that uses a low-rank approximation of A (via SVD), where the rank is set by the magnitude of the singular values. This effectively applies a low-pass filter to the Fourier modes of the generating function, which may reduce over-fitting and make the solve better conditioned.

I tried it on one orbit and it seems to work, but the performance gain over integrating an orbit for longer and using the standard method isn't huge. Specifically: orbit 1 integrated for 10 radial orbital periods with 128 steps per period, orbit 2 integrated for 4 radial orbital periods with 32 steps per period. The low-rank solve on orbit 2 was ~30% faster than the standard O2GF on orbit 1.

cc @nstarman and @jnibauer because I was mainly scoping this out as a potential addition to Galax, but now I think that standard O2GF is a first priority.

🤷 

### Checklist

* [ ] Did you add tests?
* [ ] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [ ] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [ ] Is the milestone set?
