### PR TITLE
Fix bug with passing array length 1 as progenitor mass to mock stream generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,10 @@ Bug fixes
   now converts to floats to set the unit scales in agama when converting a potential to
   Agama (using ``potential.as_interop("agama")``).
 
+- Fixed a bug in ``MockStreamGenerator.run()`` where passing an array of length 1 for
+  the progenitor mass would lead to a silent failure of the stream generation.
+
+
 API changes
 -----------
 

--- a/gala/dynamics/mockstream/df.pyx
+++ b/gala/dynamics/mockstream/df.pyx
@@ -188,14 +188,14 @@ cdef class BaseStreamDF:
             prog_orbit_static.v_xyz.decompose(_units).value.T)
         prog_t = prog_orbit_static.t.decompose(_units).value
         try:
-            prog_m = prog_mass.decompose(_units).value
+            prog_m = np.squeeze(prog_mass.decompose(_units).value)
         except:
             raise TypeError("Input progenitor mass must be a Quantity object "
                             "with a decompose() method, e.g, an astropy "
                             "quantity.")
 
-        if not isiterable(prog_m):
-            prog_m = np.ones_like(prog_t) * prog_m
+        if prog_m.shape == ():
+            prog_m = np.full_like(prog_t, prog_m)
 
         if isiterable(n_particles):
             n_particles = np.array(n_particles).astype('i4')


### PR DESCRIPTION
### Describe your changes

This fixes the bug reported by @segasai in #415.

### Checklist

* [x] Did you add tests?
* [x] Did you add documentation for your changes?
* [x] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?
