### PR TITLE
Allow specifying plot units as a UnitSystem instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ New Features
   ``gala.integrate.DOP853Integrator`` for more information about all of the available
   options for the integrator.
 
+- You may now specify a ``gala.units.UnitSystem`` instance to control the units of
+  plotted components when using ``gala.dynamics.Orbit.plot()`` or
+  ``gala.dynamics.PhaseSpacePosition.plot()``.
+
 Bug fixes
 ---------
 

--- a/gala/dynamics/core.py
+++ b/gala/dynamics/core.py
@@ -742,6 +742,13 @@ class PhaseSpacePosition:
             if isinstance(units, u.UnitBase):
                 units = [units] * n_comps  # global unit
 
+            elif isinstance(units, UnitSystem):
+                list_units = []
+                for i, name in enumerate(components):
+                    val = getattr(self, name)
+                    list_units.append(units[val.unit.physical_type])
+                units = list_units
+
             elif len(units) != n_comps:
                 raise ValueError(
                     "You must specify a unit for each axis, or a "

--- a/gala/dynamics/core.py
+++ b/gala/dynamics/core.py
@@ -804,7 +804,7 @@ class PhaseSpacePosition:
             Cartesian positions ``['x', 'y', 'z']``. To plot Cartesian
             velocities, pass in the velocity component names
             ``['d_x', 'd_y', 'd_z']``.
-        units : `~astropy.units.UnitBase`, iterable (optional)
+        units : `~astropy.units.UnitBase`, iterable, `gala.units.UnitSystem` (optional)
             A single unit or list of units to display the components in.
         auto_aspect : bool (optional)
             Automatically enforce an equal aspect ratio.

--- a/gala/dynamics/orbit.py
+++ b/gala/dynamics/orbit.py
@@ -897,7 +897,7 @@ class Orbit(PhaseSpacePosition):
             component names will be different. For example, for a Cylindrical
             representation, the components are ``['rho', 'phi', 'z']`` and
             ``['v_rho', 'pm_phi', 'v_z']``.
-        units : `~astropy.units.UnitBase`, iterable (optional)
+        units : `~astropy.units.UnitBase`, iterable, `gala.units.UnitSystem` (optional)
             A single unit or list of units to display the components in.
         auto_aspect : bool (optional)
             Automatically enforce an equal aspect ratio.
@@ -982,7 +982,7 @@ class Orbit(PhaseSpacePosition):
             component names will be different. For example, for a Cylindrical
             representation, the components are ``['rho', 'phi', 'z']`` and
             ``['v_rho', 'pm_phi', 'v_z']``.
-        units : `~astropy.units.UnitBase`, iterable (optional)
+        units : `~astropy.units.UnitBase`, iterable, `gala.units.UnitSystem` (optional)
             A single unit or list of units to display the components in.
         auto_aspect : bool (optional)
             Automatically enforce an equal aspect ratio.
@@ -1085,7 +1085,7 @@ class Orbit(PhaseSpacePosition):
             component names will be different. For example, for a Cylindrical
             representation, the components are ``['rho', 'phi', 'z']`` and
             ``['v_rho', 'pm_phi', 'v_z']``.
-        units : `~astropy.units.UnitBase`, iterable (optional)
+        units : `~astropy.units.UnitBase`, iterable, `gala.units.UnitSystem` (optional)
             A single unit or list of units to display the components in.
         stride : int (optional)
             How often to draw a new frame, in terms of orbit timesteps.


### PR DESCRIPTION
### Describe your changes

This allows passing in `units=galactic` or some other unit system instance when calling `orbit.plot()` or `psp.plot()`.

### Checklist

* [x] Did you add tests?
* [x] Did you add documentation for your changes?
* [ ] Did you reference any relevant issues?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [ ] Are the CI tests passing?
* [x] Is the milestone set?
