### PR TITLE
Fix powerlaw cutoff potential normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Bug fixes
 - Fixed a bug in ``MockStreamGenerator.run()`` where passing an array of length 1 for
   the progenitor mass would lead to a silent failure of the stream generation.
 
+- Fixed the normalization of the ``PowerLawCutoffPotential`` potential energy so that it
+  goes to zero at infinity.
 
 API changes
 -----------

--- a/gala/potential/potential/builtin/builtin_potentials.c
+++ b/gala/potential/potential/builtin/builtin_potentials.c
@@ -522,14 +522,24 @@ double powerlawcutoff_value(double t, double *pars, double *q, int n_dim) {
     if (r == 0.) {
         return -INFINITY;
     } else {
-        double tmp_0 = (1.0/2.0)*alpha;
+        double tmp_0 = alpha / 2.0;
         double tmp_1 = -tmp_0;
         double tmp_2 = tmp_1 + 1.5;
         double tmp_3 = pow(x, 2) + pow(y, 2) + pow(z, 2);
         double tmp_4 = tmp_3/pow(r_c, 2);
         double tmp_5 = G*m;
         double tmp_6 = tmp_5*safe_gamma_inc(tmp_2, tmp_4)/(sqrt(tmp_3)*tgamma(tmp_1 + 2.5));
-        return tmp_0*tmp_6 - 3.0/2.0*tmp_6 + tmp_5*safe_gamma_inc(tmp_1 + 1, tmp_4)/(r_c*tgamma(tmp_2));
+
+        // Original potential
+        double phi_r = tmp_0*tmp_6 - 3.0/2.0*tmp_6 + tmp_5*safe_gamma_inc(tmp_1 + 1, tmp_4)/(r_c*tgamma(tmp_2));
+
+        // Subtract asymptotic value to enforce Φ(∞) = 0
+        double phi_infinity = 0.0;
+        if (tmp_2 > 0) {  // alpha < 3
+            phi_infinity = tmp_5 * tgamma(tmp_1 + 1) / (r_c * tgamma(tmp_2));
+        }
+
+        return phi_r - phi_infinity;
     }
 }
 
@@ -1995,7 +2005,7 @@ double burkert_value(double t, double *pars, double *q, int n_dim) {
     double R, x;
     R = sqrt(q[0]*q[0] + q[1]*q[1] + q[2]*q[2]);
     x = R / pars[2];
-    
+
     // pi G rho r0^2 (pi - 2(1 - r0/r)arctan(r/r0) + 2(1 - r0/r)log(1 + r/r0) - (1 - r0/r)log(1 + (r/r0)^2))
     return -M_PI * pars[0] * pars[1] * pars[2] * pars[2] * (M_PI - 2 * (1 + 1 / x) * atan(x) + 2 * (1 + 1/x) * log(1 + x) - (1 - 1/x) * log(1 + x * x) );
 }

--- a/gala/potential/potential/tests/helpers.py
+++ b/gala/potential/potential/tests/helpers.py
@@ -64,6 +64,7 @@ class PotentialTestBase:
     sympy_hessian = True
     sympy_density = True
     check_finite_at_origin = True
+    check_zero_at_infinity = True
     rotation = False
 
     def setup_method(self):
@@ -140,6 +141,10 @@ class PotentialTestBase:
         if self.check_finite_at_origin:
             val = self.potential.energy([0.0, 0, 0])
             assert np.isfinite(val)
+
+        if self.check_zero_at_infinity:
+            val = self.potential.energy([1e12, 1e12, 1e12])
+            assert np.isclose(val, 0.0, atol=1e-6)
 
     def test_gradient(self):
         for arr, shp in zip(self.w0s, self._grad_return_shapes):

--- a/gala/potential/potential/tests/test_all_builtin.py
+++ b/gala/potential/potential/tests/test_all_builtin.py
@@ -32,6 +32,7 @@ class TestHarmonicOscillator1D(PotentialTestBase):
     w0 = [1.0, 0.1]
     sympy_density = False
     check_finite_at_origin = False
+    check_zero_at_infinity = False
 
     def test_plot(self):
         # Skip for now because contour plotting assumes 3D
@@ -43,6 +44,7 @@ class TestHarmonicOscillator2D(PotentialTestBase):
     w0 = [1.0, 0.5, 0.0, 0.1]
     sympy_density = False
     check_finite_at_origin = False
+    check_zero_at_infinity = False
 
     def test_plot(self):
         # Skip for now because contour plotting assumes 3D
@@ -106,6 +108,7 @@ class TestHenonHeiles(PotentialTestBase):
     w0 = [1.0, 0.0, 0.0, 2 * np.pi]
     sympy_density = False
     check_finite_at_origin = False
+    check_zero_at_infinity = False
 
     @pytest.mark.skip(reason="Not relevant")
     def test_plot(self):
@@ -405,6 +408,7 @@ class TestLogarithmic(PotentialTestBase):
         units=galactic, v_c=0.17, r_h=10.0, q1=1.2, q2=1.0, q3=0.8
     )
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
+    check_zero_at_infinity = False
 
 
 class TestLongMuraliBar(PotentialTestBase):
@@ -476,6 +480,7 @@ class TestComposite(CompositePotentialTestBase):
     potential["halo"] = p1
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
     rotation = True
+    check_zero_at_infinity = False
 
 
 class TestCComposite(CompositePotentialTestBase):
@@ -488,6 +493,7 @@ class TestCComposite(CompositePotentialTestBase):
     potential["halo"] = p1
     w0 = [19.0, 2.7, -6.9, 0.0352238, -0.03579493, 0.075]
     rotation = True
+    check_zero_at_infinity = False
 
 
 class TestKepler3Body(CompositePotentialTestBase):
@@ -515,6 +521,7 @@ class TestMultipoleInner(CompositePotentialTestBase):
     )
     vc = potential.circular_velocity([19.0, 0, 0] * u.kpc).decompose(galactic).value[0]
     w0 = [19.0, 0.2, -0.9, 0.0, vc, 0.0]
+    check_zero_at_infinity = False
 
     @pytest.mark.skip(reason="Not implemented for multipole potentials")
     def test_hessian(self):

--- a/gala/potential/potential/tests/test_special.py
+++ b/gala/potential/potential/tests/test_special.py
@@ -1,5 +1,5 @@
 """
-    Test the special potentials...
+Test the special potentials...
 """
 
 # Third-party
@@ -21,11 +21,13 @@ from .helpers import CompositePotentialTestBase
 class TestLM10Potential(CompositePotentialTestBase):
     potential = LM10Potential()
     w0 = [8.0, 0.0, 0.0, 0.0, 0.22, 0.1]
+    check_zero_at_infinity = False
 
 
 class TestLM10Potential2(CompositePotentialTestBase):
     potential = LM10Potential(disk={"m": 5e10 * u.Msun}, bulge={"m": 5e10 * u.Msun})
     w0 = [8.0, 0.0, 0.0, 0.0, 0.22, 0.1]
+    check_zero_at_infinity = False
 
 
 class TestMilkyWayPotential(CompositePotentialTestBase):

--- a/gala/potential/potential/tests/test_util.py
+++ b/gala/potential/potential/tests/test_util.py
@@ -1,9 +1,10 @@
 import pytest
 
+from gala.tests.optional_deps import HAS_SYMPY
+
 # This project
 from ..util import from_equation
 from .helpers import PotentialTestBase
-from gala.tests.optional_deps import HAS_SYMPY
 
 
 class EquationBase(PotentialTestBase):
@@ -21,17 +22,20 @@ class EquationBase(PotentialTestBase):
 
 
 if HAS_SYMPY:
+
     class TestHarmonicOscillatorFromEquation(EquationBase):
         check_finite_at_origin = False
+        check_zero_at_infinity = False
 
-        Potential = from_equation("1/2*k*x**2", vars="x", pars="k",
-                                  name='HarmonicOscillator',
-                                  hessian=True)
-        potential = Potential(k=1.)
-        w0 = [1., 0.]
+        Potential = from_equation(
+            "1/2*k*x**2", vars="x", pars="k", name="HarmonicOscillator", hessian=True
+        )
+        potential = Potential(k=1.0)
+        w0 = [1.0, 0.0]
 
         def test_derp(self):
             import numpy as np
+
             self.potential.gradient(np.random.random(size=(1, 13)))
 
         @pytest.mark.skip(reason="to_sympy() not implemented")


### PR DESCRIPTION
### Describe your changes

The `PowerLawCutoffPotential` was incorrectly normalized so that Phi(r=0) = 0 instead of Phi(r=infinity) = 0.


### Checklist

* [x] Did you add tests?
* [x] Did you add a changelog entry? (see `CHANGES.rst`)
* [x] Are the CI tests passing?
* [x] Is the milestone set?
