### PR TITLE
exp: return nan instead of crashing the interpreter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ New Features
 - Added the ability to specify integer or string (i.e. non-Quantity) potential
   parameters.
 
+- Added ``gala.potential.EXPPotential`` for using EXP as a source of potentials
+
 Bug fixes
 ---------
 
@@ -48,7 +50,7 @@ API changes
 
 - Gala has ``save_all`` and ``store_all`` flags for saving all orbits at every
   timestep. The ``store_all`` flag is now deprecated and will be removed in a future
-  release. The``save_all`` flag should be used instead.
+  release. The ``save_all`` flag should be used instead.
 
 Other
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - Added the ability to specify integer or string (i.e. non-Quantity) potential
   parameters.
 
-- Added ``gala.potential.EXPPotential`` for using basis function expansion potentials from EXP. 
+- Added ``gala.potential.EXPPotential`` for using basis function expansion potentials from EXP.
 
 Bug fixes
 ---------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - Added the ability to specify integer or string (i.e. non-Quantity) potential
   parameters.
 
-- Added ``gala.potential.EXPPotential`` for using EXP as a source of potentials
+- Added ``gala.potential.EXPPotential`` for using basis function expansion potentials from EXP. 
 
 Bug fixes
 ---------

--- a/docs/tutorials/exp.rst
+++ b/docs/tutorials/exp.rst
@@ -185,11 +185,8 @@ a single snapshot with the ``snapshot_index`` parameter:
 
     For time-evolving potentials, if one tries to evaluate the potential outside of the
     time range stored in the coefficients file (even indirectly, such as during an
-    orbit integration), currently the interpreter will crash (after printing an error
+    orbit integration), currently a NAN will be returned (after printing an error
     message to stderr). Proper exception propagation is a planned feature.
-
-.. TODO: an exception isn't raised, the interpreter just crashes. We can probably have
-.. it return NaN instead, but actually raising a Python exception is hard...
 
 If the coefficients file stores a very large time range but the user is only interested
 in a smaller range, one can specify ``tmin`` and/or ``tmax`` to load a smaller subset of
@@ -206,7 +203,7 @@ the coefficient data (for memory efficiency):
     )
 
 Note that, as mentioned above, subsequently using a time outside this range will result
-in an interpreter crash (with an associated error printed to stderr). Or more precisely:
+in a NAN being returned (with an associated error printed to stderr). Or more precisely:
 using a time outside the range of snapshots that this ``tmin``/``tmax`` caused to be
 loaded will cause such an error. One can check the loaded range of snapshots with:
 
@@ -237,6 +234,12 @@ The `~gala.potential.EXPPotential` currently has the following limitations:
 * Pickling, saving, and loading is not supported.
 * Performance may currently not be as high as native Gala potentials
 * Evaluating the potential at a time outside the loaded time range will result
-  in the interpreter crashing
+  in NANs
 
 .. TODO (adrn): any other notable limitations?
+
+---
+API
+---
+
+See :class:`~gala.potential.EXPPotential` for the complete API documentation.

--- a/gala/coordinates/helpers.py
+++ b/gala/coordinates/helpers.py
@@ -22,10 +22,10 @@ class StringValidatedAttribute(Attribute):
         self.valid_values = list(valid_values)
         try:
             default = self.convert_input(default)[0]
-        except ValueError:
+        except ValueError as e:
             raise ValueError(
                 "The specified default value is not in the list of valid values."
-            )
+            ) from e
         super().__init__(default, secondary_attribute)
 
     def convert_input(self, value):

--- a/gala/potential/potential/builtin/core.py
+++ b/gala/potential/potential/builtin/core.py
@@ -1353,9 +1353,11 @@ class CylSplinePotential(CPotentialBase):
 @format_doc(common_doc=_potential_docstring)
 class EXPPotential(CPotentialBase, EXP_only=True):
     r"""
-    EXPPotential(units=None, origin=None, R=None)
-
     Calls the EXP code for the potential.
+
+    This potential will usually be constructed with
+    :class:`~gala.units.SimulationUnitSystem` units. See the tutorial for more
+    information.
 
     .. note::
 
@@ -1365,8 +1367,30 @@ class EXPPotential(CPotentialBase, EXP_only=True):
 
     Parameters
     ----------
-    TODO
+    config_file : path-like
+        The path to the EXP configuration file (usually a YAML file).
+    coef_file : path-like
+        The path to the EXP coefficients file (usually a HDF5 file).
+    tmin, tmax : :class:`~astropy.units.Quantity`, numeric [time], optional
+        The minimum and maximum snapshot times from the EXP potential to load.
+        The default is to load all snapshots (but see ``snapshot_index``).
+    snapshot_index : int, optional
+        The index of the snapshot to load from the EXP potential.
+        This is mutually exclusive with ``tmin`` and ``tmax``.
+        Using this option will make the potential static, i.e. fixed-time.
+        The default is -1, which means to ignore this parameter.
+    stride : int, optional
+        The stride to use when loading snapshots from the EXP potential.
+        This is useful for loading every N-th snapshot, where N is the stride.
+        The default is 1, which means to load every snapshot.
     {common_doc}
+
+    Attributes
+    ----------
+    static : bool
+        Whether the potential is in static, i.e. fixed-time, mode.
+    tmin_exp, tmax_exp : `~astropy.units.Quantity`
+        The actual, loaded minimum and maximum time for which the potential is defined.
     """
 
     config_file = PotentialParameter("config_file", physical_type=None)

--- a/gala/potential/potential/builtin/exp_fields.cc
+++ b/gala/potential/potential/builtin/exp_fields.cc
@@ -175,8 +175,14 @@ double exp_value(double t, double *pars, double *q, int n_dim, void* state) {
   gala_exp::State *exp_state = static_cast<gala_exp::State *>(state);
 
   if (!exp_state->is_static) {
-    // TODO: how expensive is this, actually?
-    exp_state->basis->set_coefs(gala_exp::interpolator(t, exp_state->coefs));
+    try {
+      // TODO: how expensive is this, actually?
+      exp_state->basis->set_coefs(gala_exp::interpolator(t, exp_state->coefs));
+    } catch (const std::exception &e) {
+      // TODO: propagate this exception to Python
+      std::cerr << "[GALA EXP] Error setting coefficients: " << e.what() << std::endl;
+      return std::numeric_limits<double>::quiet_NaN();
+    }
   }
 
   // Get the field quantities
@@ -191,7 +197,14 @@ void exp_gradient(double t, double *pars, double *q, int n_dim, double *grad, vo
   gala_exp::State *exp_state = static_cast<gala_exp::State *>(state);
 
   if (!exp_state->is_static) {
-    exp_state->basis->set_coefs(gala_exp::interpolator(t, exp_state->coefs));
+    try {
+      exp_state->basis->set_coefs(gala_exp::interpolator(t, exp_state->coefs));
+    } catch (const std::exception &e) {
+      // TODO
+      std::cerr << "[GALA EXP] Error setting coefficients: " << e.what() << std::endl;
+      grad[0] = grad[1] = grad[2] = std::numeric_limits<double>::quiet_NaN();
+      return;
+    }
   }
 
   // TODO: ask Martin/Mike for a way to compute only the force/acceleration - we're wasting
@@ -207,7 +220,13 @@ double exp_density(double t, double *pars, double *q, int n_dim, void* state) {
   gala_exp::State *exp_state = static_cast<gala_exp::State *>(state);
 
   if (!exp_state->is_static) {
-    exp_state->basis->set_coefs(gala_exp::interpolator(t, exp_state->coefs));
+    try {
+      exp_state->basis->set_coefs(gala_exp::interpolator(t, exp_state->coefs));
+    } catch (const std::exception &e) {
+      // TODO
+      std::cerr << "[GALA EXP] Error setting coefficients: " << e.what() << std::endl;
+      return std::numeric_limits<double>::quiet_NaN();
+    }
   }
 
   // TODO: ask Martin/Mike for a way to compute only the density - we're wasting

--- a/gala/potential/potential/tests/test_exp.py
+++ b/gala/potential/potential/tests/test_exp.py
@@ -266,3 +266,11 @@ def test_cython_exceptions():
             tmin=0xBAD,
             units=units,
         )
+
+    pot = EXPPotential(
+        config_file=EXP_CONFIG_FILE,
+        coef_file=EXP_MULTI_COEF_FILE,
+        units=units,
+    )
+    # TODO: this will eventually be an exception
+    assert np.isnan(pot.energy([0, 0, 0], t=float(0xBAD)))


### PR DESCRIPTION
### Describe your changes

Catch EXP interpolator exceptions (usually caused by an out-of-bounds time) and return NAN. This at least avoids crashing the interpreter. Hopefully we'll be able to propagate the exception to Python instead soon.

Also update the `EXPPotential` docs a bit.

x-ref #423 

### Checklist

- [x] Did you add tests?
- [x] Did you add documentation for your changes?
- [x] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`)
- [x] Are the CI tests passing?
- [x] Is the milestone set?