### PR TITLE
nfw potential vectorization proof-of-concept

### DIFF
--- a/gala/integrate/cyintegrators/__init__.py
+++ b/gala/integrate/cyintegrators/__init__.py
@@ -1,3 +1,3 @@
 from .dop853 import dop853_integrate_hamiltonian
-from .leapfrog import leapfrog_integrate_hamiltonian
+from .leapfrog import leapfrog_integrate_hamiltonian, leapfrog_integrate_hamiltonian_v
 from .ruth4 import ruth4_integrate_hamiltonian

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -250,6 +250,7 @@ class Hamiltonian(CommonBase):
         Integrator_kwargs=dict(),
         cython_if_possible=True,
         save_all=True,
+        vectorized=True,
         **time_spec
     ):
         """
@@ -325,8 +326,13 @@ class Hamiltonian(CommonBase):
 
             # TODO: these replacements should be defined in gala.integrate...
             if Integrator == LeapfrogIntegrator:
-                from ...integrate.cyintegrators import leapfrog_integrate_hamiltonian
-                t, w = leapfrog_integrate_hamiltonian(self, arr_w0, t, save_all=save_all)
+                from ...integrate.cyintegrators import leapfrog_integrate_hamiltonian, leapfrog_integrate_hamiltonian_v
+                # temporary toggle during development
+                if vectorized:
+                    t, w = leapfrog_integrate_hamiltonian_v(self, arr_w0, t, save_all=save_all)
+                else:
+                    t, w = leapfrog_integrate_hamiltonian(self, arr_w0, t, save_all=save_all)
+
 
             elif Integrator == Ruth4Integrator:
                 from ...integrate.cyintegrators import ruth4_integrate_hamiltonian

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -250,7 +250,7 @@ class Hamiltonian(CommonBase):
         Integrator_kwargs=dict(),
         cython_if_possible=True,
         save_all=True,
-        vectorized=True,
+        vectorized=False,
         **time_spec
     ):
         """

--- a/gala/potential/potential/builtin/builtin_potentials.h
+++ b/gala/potential/potential/builtin/builtin_potentials.h
@@ -3,6 +3,8 @@ extern double nan_value(double t, double *pars, double *q, int n_dim, void *stat
 extern void nan_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void nan_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
+extern void nan_gradientv(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
+
 extern double null_density(double t, double *pars, double *q, int n_dim, void *state);
 extern double null_value(double t, double *pars, double *q, int n_dim, void *state);
 extern void null_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
@@ -51,6 +53,8 @@ extern double sphericalnfw_value(double t, double *pars, double *q, int n_dim, v
 extern void sphericalnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double sphericalnfw_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void sphericalnfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
+
+extern void sphericalnfw_gradientv(size_t N, double t, double *__restrict__ pars, double *__restrict__ q, int n_dim, double *__restrict__ grad, void * __restrict__ state);
 
 extern double flattenednfw_value(double t, double *pars, double *q, int n_dim, void *state);
 extern void flattenednfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);

--- a/gala/potential/potential/builtin/cybuiltin.pxd
+++ b/gala/potential/potential/builtin/cybuiltin.pxd
@@ -7,6 +7,8 @@ cdef extern from "potential/potential/builtin/builtin_potentials.h":
     void nan_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void nan_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
+    void nan_gradientv(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+
     double null_value(double t, double *pars, double *q, int n_dim, void *state) nogil
     void null_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double null_density(double t, double *pars, double *q, int n_dim, void *state) nogil
@@ -55,6 +57,8 @@ cdef extern from "potential/potential/builtin/builtin_potentials.h":
     void sphericalnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double sphericalnfw_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void sphericalnfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
+
+    void sphericalnfw_gradientv(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
 
     double flattenednfw_value(double t, double *pars, double *q, int n_dim, void *state) nogil
     void flattenednfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil

--- a/gala/potential/potential/builtin/cybuiltin.pyx
+++ b/gala/potential/potential/builtin/cybuiltin.pyx
@@ -23,7 +23,7 @@ from ..core import CompositePotential, _potential_docstring, PotentialBase
 from ..util import format_doc, sympy_wrap
 from ..cpotential import CPotentialBase
 from ..cpotential cimport CPotential, CPotentialWrapper
-from ..cpotential cimport densityfunc, energyfunc, gradientfunc, hessianfunc
+from ..cpotential cimport densityfunc, energyfunc, gradientfunc, gradientfuncv, hessianfunc
 from ...common import PotentialParameter
 from ...frame.cframe cimport CFrameWrapper
 from ....units import dimensionless, DimensionlessUnitSystem
@@ -266,6 +266,8 @@ cdef class SphericalNFWWrapper(CPotentialWrapper):
         self.cpotential.density[0] = <densityfunc>(sphericalnfw_density)
         self.cpotential.gradient[0] = <gradientfunc>(sphericalnfw_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(sphericalnfw_hessian)
+
+        self.cpotential.gradientv[0] = <gradientfuncv>(sphericalnfw_gradientv)
 
 cdef class FlattenedNFWWrapper(CPotentialWrapper):
 

--- a/gala/potential/potential/cpotential.pxd
+++ b/gala/potential/potential/cpotential.pxd
@@ -2,10 +2,12 @@
 # cython: language=c++
 
 cdef extern from "src/funcdefs.h":
-    ctypedef double (*densityfunc)(double t, double *pars, double *q, void *state) except + nogil
-    ctypedef double (*energyfunc)(double t, double *pars, double *q, void *state) except + nogil
-    ctypedef void (*gradientfunc)(double t, double *pars, double *q, double *grad, void *state) except + nogil
-    ctypedef void (*hessianfunc)(double t, double *pars, double *q, double *hess, void *state) except + nogil
+    ctypedef double (*densityfunc)(double t, double *pars, double *q, int n_dim, void *state) except + nogil
+    ctypedef double (*energyfunc)(double t, double *pars, double *q, int n_dim, void *state) except + nogil
+    ctypedef void (*gradientfunc)(double t, double *pars, double *q, int n_dim, double *grad, void *state) except + nogil
+    ctypedef void (*hessianfunc)(double t, double *pars, double *q, int n_dim, double *hess, void *state) except + nogil
+
+    ctypedef void (*gradientfuncv)(size_t N, double t, double *pars, double *q, double *grad, int n_dim, void *state) except + nogil
 
 cdef extern from "potential/src/cpotential.h":
     ctypedef struct CPotential:
@@ -17,6 +19,9 @@ cdef extern from "potential/src/cpotential.h":
         energyfunc* value
         gradientfunc* gradient
         hessianfunc* hessian
+
+        gradientfuncv* gradientv
+
         int* n_params         # parameter counts per component
         double** parameters   # pointers to parameter arrays per component
         double** q0           # pointers to origin per component
@@ -31,6 +36,8 @@ cdef extern from "potential/src/cpotential.h":
     double c_density(CPotential *p, double t, double *q) except + nogil
     void c_gradient(CPotential *p, double t, double *q, double *grad) except + nogil
     void c_hessian(CPotential *p, double t, double *q, double *hess) except + nogil
+
+    void c_gradientv(CPotential *p, size_t N, double t, double *q, double *grad) except + nogil
 
     double c_d_dr(CPotential *p, double t, double *q, double *epsilon) except + nogil
     double c_d2_dr2(CPotential *p, double t, double *q, double *epsilon) except + nogil

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -22,7 +22,7 @@ cimport cython
 from libc.stdio cimport printf
 
 
-from .builtin.cybuiltin cimport nan_density, nan_value, nan_gradient, nan_hessian
+from .builtin.cybuiltin cimport nan_density, nan_value, nan_gradient, nan_gradientv, nan_hessian
 from .core import PotentialBase, CompositePotential
 from ...util import atleast_2d
 from ...units import DimensionlessUnitSystem
@@ -78,6 +78,8 @@ cdef class CPotentialWrapper:
         self.cpotential.density[0] = <densityfunc>(nan_density)
         self.cpotential.gradient[0] = <gradientfunc>(nan_gradient)
         self.cpotential.hessian[0] = <hessianfunc>(nan_hessian)
+
+        self.cpotential.gradientv[0] = <gradientfuncv>(nan_gradientv)
 
         # set the origin of the potentials
         _q0 = np.array(q0)

--- a/gala/potential/potential/src/cpotential.h
+++ b/gala/potential/potential/src/cpotential.h
@@ -16,6 +16,8 @@
         gradientfunc* gradient;
         hessianfunc* hessian;
 
+        gradientfuncv* gradientv;
+
         // array containing the number of parameters in each component
         int* n_params;
 
@@ -41,6 +43,8 @@ extern double c_potential(CPotential *p, double t, double *q);
 extern double c_density(CPotential *p, double t, double *q);
 extern void c_gradient(CPotential *p, double t, double *q, double *grad);
 extern void c_hessian(CPotential *p, double t, double *q, double *hess);
+
+extern void c_gradientv(CPotential *p, size_t N, double t, double *q, double *grad);
 
 // TODO: err, what about reference frames...
 extern double c_d_dr(CPotential *p, double t, double *q, double *epsilon);

--- a/gala/potential/src/funcdefs.h
+++ b/gala/potential/src/funcdefs.h
@@ -4,4 +4,6 @@
     typedef double (*energyfunc)(double t, double *pars, double *q, int n_dim, void *state);
     typedef void (*gradientfunc)(double t, double *pars, double *q, int n_dim, double *grad, void *state);
     typedef void (*hessianfunc)(double t, double *pars, double *q, int n_dim, double *hess, void *state);
+
+    typedef void (*gradientfuncv)(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 #endif

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ else:
 all_extensions = get_extensions()
 extensions = []
 for ext in all_extensions:
+    ext.extra_compile_args.extend(["-Ofast"])
     if ("potential.potential" in ext.name or "scf" in ext.name) and (
         gsl_version is not None
     ):


### PR DESCRIPTION
## Overview

This is an experiment in rewriting `sphericalnfw_gradient()` in a vectorization-friendly way for performance. The basic idea is to pass the entire coordinate array into the potential function, rather than calling it in a loop for every coordinate. This (1) allows the compiler to vectorize the loops, (2) allows the CPU to execute the instructions in a pipelined manner, and (3) reduces the number of function pointer calls.

The results are promising: leapfrog integrations with 1000 particles or more and `save_all=False` are 10x faster. Here's a bit more detail:

```
❯ python scripts/bench.py --scalar
Running orbit integration benchmarks
Options:
  Number of steps: 1000
  Vectorized: False
  Save all time steps: False
--------------------------------------------------
N particles  Time (s)   M particle-steps/sec
--------------------------------------------------
1            0.001      1.547               
10           0.001      8.308               
100          0.007      14.797              
1000         0.065      15.340              
10000        0.690      14.500              
100000       6.951      14.386              
```

```
❯ python scripts/bench.py         
Running orbit integration benchmarks
Options:
  Number of steps: 1000
  Vectorized: True
  Save all time steps: False
--------------------------------------------------
N particles  Time (s)   M particle-steps/sec
--------------------------------------------------
1            0.001      1.531               
10           0.001      13.933              
100          0.001      77.434              
1000         0.007      145.349             
10000        0.063      159.587             
100000       0.619      161.633             
```

The benchmark script checks that the scalar and vector versions get the same result.

## Benchmark variations

The above benchmarks were run on a Genoa node with `-march=native -Ofast`. `-Ofast` is important for vectorization; the advantage degrades to about 3x without it. I spot-checked that `-O3` vs `-Ofast` passed `np.allclose()` in a 1 million step integration.

`-march=native` is less important; the advantage degrades to about 7x when targeting `-march=x86-64`. This is good news for distributing generic wheels on PyPI.

`save_all` is pretty expensive, so enabling that reduces the vectorization benefit to about 3.5x. There may be additional optimization opportunities there.

## Code Changes
The code changes to get this to work weren't very big. This PR has a lot of commits, though, because it includes the changes of #433. Once that's merged, this PR will get a lot smaller. All of the changes relevant to this PR are actually in one commit: https://github.com/adrn/gala/commit/bf475741327e7a8513973aeeaf82257b5b0534dd

I implemented this as a vectorized alternative to the existing leapfrog, but if we decide to go forward with this, I don't think there would be any need to keep the scalar version. It would be a decent amount of work to convert all the potentials to vectorized form, but an LLM could help with that.

## Benchmark script
Here is the benchmark script I'm using:

<details><summary><code>bench.py</code></summary>
<p>

```python
"""
Benchmark script for gala orbit integration with N particles in an NFW potential.
"""

# ruff: noqa: T201

import timeit

import click
import matplotlib.pyplot as plt
import numpy as np
from astropy import units as u

import gala.dynamics as gd
import gala.potential as gp
from gala.units import galactic


def benchmark_orbit_integration(
    n_particles, n_steps=1_000, vectorized=False, save_all=False
):
    """
    Benchmark orbit integration for N particles in NFW potential.

    Parameters
    ----------
    n_particles : int
        Number of particles to integrate
    dt : astropy.units.Quantity
        Time step

    Returns
    -------
    float
        Integration time in seconds
    """
    # Create NFW potential
    potential = gp.NFWPotential(m=1e12 * u.Msun, r_s=20 * u.kpc, units=galactic)

    # Generate random initial conditions
    rng = np.random.default_rng(42)  # For reproducibility

    # Random positions (spherical coordinates)
    r = rng.uniform(10, 100, n_particles)
    theta = rng.uniform(0, np.pi, n_particles)
    phi = rng.uniform(0, 2 * np.pi, n_particles)

    # Convert to cartesian
    x = r * np.sin(theta) * np.cos(phi)
    y = r * np.sin(theta) * np.sin(phi)
    z = r * np.cos(theta)

    pos = np.asarray([x, y, z]) * u.kpc

    # Random velocities
    vel = rng.normal(0, 50, size=(3, n_particles)) * u.km / u.s

    # Create initial conditions
    w0 = gd.PhaseSpacePosition(pos=pos, vel=vel)

    dt = 1.0 * u.Myr

    def bench_func():
        return potential.integrate_orbit(
            w0,
            dt=dt,
            t1=0,
            n_steps=n_steps,
            vectorized=vectorized,
            save_all=save_all,
        )

    bench_result = timeit.Timer(bench_func).autorange()
    avg_time = bench_result[1] / bench_result[0]

    # Get the orbits result for return
    orbits = bench_func()

    # print(orbits)

    return avg_time, orbits


def run_benchmark_suite(
    particle_counts, output_file, n_steps=1000, vectorized=True, save_all=False
):
    """Run benchmark for various numbers of particles."""

    times = []

    print("Running orbit integration benchmarks")
    print("Options:")
    print(f"  Number of steps: {n_steps}")
    print(f"  Vectorized: {vectorized}")
    print(f"  Save all time steps: {save_all}")
    print("-" * 50)
    print(f"{'N particles':<12} {'Time (s)':<10} {'M particle-steps/sec':<20}")
    print("-" * 50)

    for n in particle_counts:
        integration_time, _ = benchmark_orbit_integration(
            n, n_steps=n_steps, vectorized=vectorized, save_all=save_all
        )
        times.append(integration_time)

        particle_steps_per_sec = n * n_steps / integration_time
        print(
            f"{n:<12} {integration_time:<10.3f} {particle_steps_per_sec / 1e6:<20.3f}"
        )

    # Plot results using object-oriented API
    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 6), layout="constrained")

    ax1.plot(particle_counts, times, "o-")
    ax1.set_xlabel("Number of particles")
    ax1.set_ylabel("Integration time (s)")
    ax1.set_title("Total Integration Time")
    ax1.grid(True, alpha=0.3)

    particles_per_sec = np.array(particle_counts) / np.array(times)
    ax2.plot(particle_counts, particles_per_sec, "o-")
    ax2.set_xlabel("Number of particles")
    ax2.set_ylabel("Particles per second")
    ax2.set_title("Particles per Second")
    ax2.grid(True, alpha=0.3)

    fig.savefig(output_file, dpi=150)

    return particle_counts, times, fig


@click.command()
@click.option(
    "--min-particles", "-m", default=0, help="Minimum number of particles (10^min)"
)
@click.option(
    "--max-particles", "-M", default=5, help="Maximum number of particles (10^max)"
)
@click.option(
    "--num-points", "-n", default=6, help="Number of points between min and max"
)
@click.option(
    "--output",
    "-o",
    default="gala_orbit_benchmark.png",
    help="Output filename for the plot",
)
@click.option("--show/--no-show", default=False, help="Show the plot interactively")
@click.option("--nsteps", "-s", default=1000, help="Number of integration steps")
@click.option(
    "--vectorized/--scalar", default=True, help="Use vectorized integration if True"
)
@click.option(
    "--save-all/--no-save-all",
    default=False,
    help="Save all orbits if True, only final positions if False",
)
def main(
    min_particles, max_particles, num_points, output, show, nsteps, vectorized, save_all
):
    """Benchmark gala orbit integration for N particles in an NFW potential."""

    # Generate particle counts on log scale
    log_counts = np.linspace(min_particles, max_particles, num_points)
    particle_counts = np.round(10**log_counts).astype(int)

    # Check correctness of vectorized integration
    _, vecorbit = benchmark_orbit_integration(
        n_particles=101, n_steps=nsteps, vectorized=True, save_all=save_all
    )
    _, scalarorbit = benchmark_orbit_integration(
        n_particles=101, n_steps=nsteps, vectorized=False, save_all=save_all
    )
    assert np.allclose(vecorbit.pos.xyz.value, scalarorbit.pos.xyz.value), (
        "Vectorized and scalar orbits differ!"
    )
    assert np.allclose(vecorbit.vel.d_xyz.value, scalarorbit.vel.d_xyz.value), (
        "Vectorized and scalar velocities differ!"
    )

    # Run benchmark
    particle_counts, times, fig = run_benchmark_suite(
        particle_counts,
        output,
        n_steps=nsteps,
        vectorized=vectorized,
        save_all=save_all,
    )

    print("\nBenchmark completed!")
    print(f"Results saved to '{output}'")

    if show:
        plt.show()
    else:
        plt.close(fig)


if __name__ == "__main__":
    main()
```

</p>
</details> 