### PR TITLE
Add convenience properties to compute M200, R200, c200 from NFWPotential instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,12 @@ New Features
 - Added the ability to specify integer or string (i.e. non-Quantity) potential
   parameters.
 
-- Added ``gala.potential.EXPPotential`` for using basis function expansion potentials from EXP.
+- Added ``gala.potential.EXPPotential`` for using basis function expansion potentials
+  from EXP.
+
+- Added methods ``NFWPotential.M200()``, ``NFWPotential.R200()``,
+  ``NFWPotential.c200()`` to compute the characteristic mass, radius, and concentration
+  of an NFW instance.
 
 Bug fixes
 ---------

--- a/gala/potential/potential/tests/test_all_builtin.py
+++ b/gala/potential/potential/tests/test_all_builtin.py
@@ -385,6 +385,26 @@ class TestNFW(PotentialTestBase):
         assert u.allclose(sph.energy(xyz), fla.energy(xyz))
         assert u.allclose(sph.gradient(xyz), fla.gradient(xyz))
 
+    def test_nfw_properties(self):
+        """Test that M200, c200, and R200 properties work correctly."""
+
+        M200_input = 1e12 * u.Msun
+        c_input = 15.0
+        pot_input = p.NFWPotential.from_M200_c(M200_input, c_input, units=galactic)
+
+        # Test the inverse properties
+        c200_computed = pot_input.c200()
+        M200_computed = pot_input.M200()
+
+        assert u.allclose(c200_computed, c_input)
+        assert u.allclose(M200_computed, M200_input)
+
+        # Test that R200 evaluates and is equivalent to r_s * c200
+        R200_computed = pot_input.R200()
+        r_s = pot_input.parameters["r_s"]
+        R200_expected = r_s * c200_computed
+        assert u.allclose(R200_computed, R200_expected)
+
 
 class TestLeeSutoTriaxialNFW(PotentialTestBase):
     potential = p.LeeSutoTriaxialNFWPotential(


### PR DESCRIPTION
### Describe your changes

This PR adds convenience properties to compute M200, R200, c200 from an NFWPotential instance.

### Checklist

- [x] Did you add tests?
- [x] Did you add documentation for your changes?
- [ ] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`)
- [ ] Are the CI tests passing?
- [x] Is the milestone set?
