### PR TITLE
 exp: improve file path handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Bug fixes
 ---------
 
 - Support for ``gala.potential.EXPPotential`` in composite potentials is fixed.
+- File path handling in ``gala.potential.EXPPotential`` is improved.
 
 
 1.10.0 (2025-07-31)

--- a/gala/potential/potential/builtin/cyexp.pyx
+++ b/gala/potential/potential/builtin/cyexp.pyx
@@ -66,8 +66,8 @@ cdef class EXPWrapper(CPotentialWrapper):
 
         if USE_EXP == 1:
             self.exp_state = exp_init(
-                config_file,
-                coef_file,
+                str(config_file),
+                str(coef_file),
                 stride,
                 tmin,
                 tmax,

--- a/gala/potential/potential/builtin/exp_fields.cc
+++ b/gala/potential/potential/builtin/exp_fields.cc
@@ -28,6 +28,7 @@ State exp_init(
   {
     // change the cwd to the directory of the config file
     // so that relative paths in the config file work
+    // TODO: this is not thread-safe, threads share a cwd
     ScopedChdir cd(fs::path(config_fn).parent_path());
     basis = BasisClasses::Basis::factory(yaml);
   }

--- a/gala/potential/potential/builtin/exp_fields.h
+++ b/gala/potential/potential/builtin/exp_fields.h
@@ -45,14 +45,20 @@ extern double exp_density(double t, double *pars, double *q, int n_dim, void* st
 class ScopedChdir {
 private:
     std::filesystem::path original_path;
+    bool empty;
 
 public:
     inline explicit ScopedChdir(const std::filesystem::path& new_path) {
-        original_path = std::filesystem::current_path();
-        std::filesystem::current_path(new_path);
+        empty = new_path.empty();
+
+        if(!empty){
+            original_path = std::filesystem::current_path();
+            std::filesystem::current_path(new_path);
+        }
     }
 
     inline ~ScopedChdir() {
+        if (empty) return;
         try {
             std::filesystem::current_path(original_path);
         } catch (...) {

--- a/gala/potential/potential/tests/test_exp.py
+++ b/gala/potential/potential/tests/test_exp.py
@@ -3,6 +3,7 @@ Test the EXP potential
 """
 
 import os
+from pathlib import Path
 
 import astropy.units as u
 import numpy as np
@@ -331,3 +332,22 @@ def test_composite():
     assert np.all(np.isfinite(orbit.pos.xyz.value))
     assert np.all(np.isfinite(orbit.vel.d_xyz.value))
     assert np.all(np.isfinite(orbit.t.value))
+
+
+def test_paths():
+    """
+    Test relative and absolute file paths
+    """
+
+    gp.EXPPotential(
+        config_file=Path(EXP_CONFIG_FILE).absolute(),
+        coef_file=Path(EXP_SINGLE_COEF_FILE).absolute(),
+        units=SimulationUnitSystem(mass=1e11 * u.Msun, length=2.5 * u.kpc, G=1),
+    )
+
+    with chdir(Path(EXP_CONFIG_FILE).parent):
+        gp.EXPPotential(
+            config_file=Path(EXP_CONFIG_FILE).name,
+            coef_file=Path(EXP_SINGLE_COEF_FILE).name,
+            units=SimulationUnitSystem(mass=1e11 * u.Msun, length=2.5 * u.kpc, G=1),
+        )

--- a/gala/potential/potential/tests/test_exp.py
+++ b/gala/potential/potential/tests/test_exp.py
@@ -33,13 +33,15 @@ EXP_MULTI_COEF_FILE = get_pkg_data_filename("EXP-Hernquist-multi-coefs.hdf5")
 FORCE_EXP_TEST = os.environ.get("GALA_FORCE_EXP_TEST", "0") == "1"
 FORCE_PYEXP_TEST = os.environ.get("GALA_FORCE_PYEXP_TEST", "0") == "1"
 
-# See: generate_exp.py, which generates the basis and coefficients for these tests
-
-
-@pytest.mark.skipif(
+# global pytest marker to skip tests if EXP is not enabled
+pytestmark = pytest.mark.skipif(
     not EXP_ENABLED and not FORCE_EXP_TEST,
     reason="requires Gala compiled with EXP support",
 )
+
+# See: generate_exp.py, which generates the basis and coefficients for these tests
+
+
 class EXPTestBase(PotentialTestBase):
     tol = 1e-2  # increase tolerance for gradient test
 
@@ -110,8 +112,8 @@ class EXPTestBase(PotentialTestBase):
         )
 
     @pytest.mark.skipif(
-        (not EXP_ENABLED or not HAVE_PYEXP) and not FORCE_PYEXP_TEST,
-        reason="requires Gala compiled with EXP support and pyEXP",
+        not FORCE_PYEXP_TEST,
+        reason="requires pyEXP",
     )
     def test_pyexp(self):
         """Test EXPPotential against pyEXP"""
@@ -146,28 +148,16 @@ class EXPTestBase(PotentialTestBase):
         assert u.allclose(exp_grad, gala_grad)
 
 
-@pytest.mark.skipif(
-    not EXP_ENABLED and not FORCE_EXP_TEST,
-    reason="requires Gala compiled with EXP support",
-)
 class TestEXPSingle(EXPTestBase):
     EXP_CONFIG_FILE = EXP_CONFIG_FILE
     EXP_COEF_FILE = EXP_SINGLE_COEF_FILE
 
 
-@pytest.mark.skipif(
-    not EXP_ENABLED and not FORCE_EXP_TEST,
-    reason="requires Gala compiled with EXP support",
-)
 class TestEXPMulti(EXPTestBase):
     EXP_CONFIG_FILE = EXP_CONFIG_FILE
     EXP_COEF_FILE = EXP_MULTI_COEF_FILE
 
 
-@pytest.mark.skipif(
-    not EXP_ENABLED and not FORCE_EXP_TEST,
-    reason="requires Gala compiled with EXP support",
-)
 def test_exp_unit_tests():
     pot_single = EXPPotential(
         config_file=EXP_CONFIG_FILE,
@@ -238,10 +228,6 @@ def test_exp_unit_tests():
     assert u.allclose(pot_multi.tmax_exp, 2.0 * u.Gyr)
 
 
-@pytest.mark.skipif(
-    not EXP_ENABLED and not FORCE_EXP_TEST,
-    reason="requires Gala compiled with EXP support",
-)
 def test_cython_exceptions():
     """Test various exceptions propagated from C++"""
     units = SimulationUnitSystem(mass=1e11 * u.Msun, length=2.5 * u.kpc, G=1)
@@ -287,10 +273,6 @@ def test_cython_exceptions():
         )
 
 
-@pytest.mark.skipif(
-    not EXP_ENABLED and not FORCE_EXP_TEST,
-    reason="requires Gala compiled with EXP support",
-)
 def test_composite():
     """Test that EXPPotential can be used in a CompositePotential"""
     units = SimulationUnitSystem(mass=1.25234e11 * u.Msun, length=3.845 * u.kpc, G=1)


### PR DESCRIPTION
### Describe your changes
Handle the case where the user passes `config.yml` instead of `./config.yml` to `EXPPotential`. `std::filesystem` gives a blank parent path for the former, meaning we can't chdir to it.

Also now accepts pathlib `Path`s.

Thanks to Sóley Hyman for the report!

### Checklist

- [x] Did you add tests?
- [x] Did you add documentation for your changes?
- [x] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`)
- [ ] Are the CI tests passing?
- [x] Is the milestone set?
