### PR TITLE
vectorize gradients for leapfrog integration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ New Features
 ------------
 
 - A C++ compiler is now required to build Gala from source.
+- Orbit integration performance is improved.
 
 Bug fixes
 ---------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -42,6 +42,13 @@ the cloned ``gala`` directory)::
 
     python -m pip install .
 
+For the best performance, you may wish to compile with architecture-specific optimizations::
+
+    export CXXFLAGS=-march=native
+
+This will likely have the biggest effect on orbit integration. Be aware that compiling with this
+flag means that Gala will only run on the same type of CPU that it was compiled on!
+
 
 Installing on Windows
 =====================

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -18,7 +18,7 @@ cimport numpy as np
 np.import_array()
 
 from cpython.exc cimport PyErr_CheckSignals
-from ...potential.potential.cpotential cimport CPotentialWrapper, CPotential, c_gradient
+from ...potential.potential.cpotential cimport CPotentialWrapper, CPotential
 from ...potential.frame.cframe cimport CFrameWrapper, CFrameType
 from .dop853 cimport dop853, Fwrapper, FcnEqDiff, six_norm, SolTrait, dop853_dense_state_alloc, dop853_dense_state_free, Dop853DenseState
 

--- a/gala/integrate/cyintegrators/leapfrog.pxd
+++ b/gala/integrate/cyintegrators/leapfrog.pxd
@@ -3,8 +3,8 @@
 
 from ...potential.potential.cpotential cimport CPotential
 
-cdef void c_init_velocity(CPotential *p, int ndim, double t, double dt,
-                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil
+cdef void c_init_velocity(CPotential *p, size_t n, int half_ndim, double t, double dt,
+                      double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil
 
-cdef void c_leapfrog_step(CPotential *p, int ndim, double t, double dt,
-                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil
+cdef void c_leapfrog_step(CPotential *p, size_t n, int half_ndim, double t, double dt,
+                            double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -20,30 +20,36 @@ from ...potential import NullPotential
 
 from libc.stdlib cimport malloc, free
 
-cdef void c_init_velocity(CPotential *p, int half_ndim, double t, double dt,
-                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil:
-    cdef int k
 
-    c_gradient(p, t, x_jm1, grad)
+cdef void c_init_velocity(CPotential *p, size_t n, int half_ndim, double t, double dt,
+                      double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil:
+    cdef int i, k
+
+    c_gradient(p, n, t, x_jm1, grad)
 
     for k in range(half_ndim):
-        v_jm1_2[k] = v_jm1[k] - grad[k] * dt/2.  # acceleration is minus gradient
+        for i in range(n):
+            v_jm1_2[i + k * n] = v_jm1[i + k * n] - grad[i + k * n] * dt/2.  # acceleration is minus gradient
 
-cdef void c_leapfrog_step(CPotential *p, int half_ndim, double t, double dt,
-                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil:
-    cdef int k
+
+cdef void c_leapfrog_step(CPotential *p, size_t n, int half_ndim, double t, double dt,
+                            double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) nogil:
+    cdef int i, k
 
     # full step the positions
     for k in range(half_ndim):
-        x_jm1[k] = x_jm1[k] + v_jm1_2[k] * dt
+        for i in range(n):
+            x_jm1[i + k * n] = x_jm1[i + k * n] + v_jm1_2[i + k * n] * dt
 
-    c_gradient(p, t, x_jm1, grad)  # compute gradient at new position
+    c_gradient(p, n, t, x_jm1, grad)  # compute gradient at new position
 
     # step velocity forward by half step, aligned w/ position, then
     #   finish the full step to leapfrog over position
     for k in range(half_ndim):
-        v_jm1[k] = v_jm1_2[k] - grad[k] * dt/2.
-        v_jm1_2[k] = v_jm1_2[k] - grad[k] * dt
+        for i in range(n):
+            v_jm1[i + k * n] = v_jm1_2[i + k * n] - grad[i + k * n] * dt/2.
+            v_jm1_2[i + k * n] = v_jm1_2[i + k * n] - grad[i + k * n] * dt
+
 
 cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1] t,
                                      int save_all=1):
@@ -73,50 +79,48 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
         double dt = t[1]-t[0]
 
         # temporary array containers
-        double[::1] grad = np.zeros(half_ndim)
-        double[:, ::1] v_jm1_2 = np.zeros((n, half_ndim))
+        # Input is (n, ndim), which we will transpose for vectorization
+        double[:, ::1] grad_v = np.zeros((half_ndim, n))
+        double[:, ::1] v_jm1_2 = np.zeros((half_ndim, n))
 
         # return arrays
         double[:, :, ::1] all_w
-        double[:, ::1] tmp_w = np.zeros((n, ndim))
+        double[:, ::1] tmp_w
 
         # whoa, so many dots
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
     if save_all:
-        all_w = np.zeros((ntimes, n, ndim))
+        all_w = np.zeros((ntimes, ndim, n))
 
         # save initial conditions
-        all_w[0, :, :] = w0.copy()
+        all_w[0, :, :] = w0.T.copy()
 
-    tmp_w = w0.copy()
+    tmp_w = w0.T.copy()
 
     with nogil:
         # first initialize the velocities so they are evolved by a
         #   half step relative to the positions
-        for i in range(n):
-            c_init_velocity(cp, half_ndim, t[0], dt,
-                            &tmp_w[i, 0], &tmp_w[i, half_ndim],
-                            &v_jm1_2[i, 0], &grad[0])
+        c_init_velocity(cp, n, half_ndim, t[0], dt,
+                        &tmp_w[0, 0], &tmp_w[half_ndim, 0],
+                        &v_jm1_2[0, 0], &grad_v[0, 0])
 
         for j in range(1, ntimes, 1):
-            for i in range(n):
-                for k in range(half_ndim):
-                    grad[k] = 0.
+            grad_v[:] = 0.
+            c_leapfrog_step(cp, n, half_ndim, t[j], dt,
+                            &tmp_w[0, 0], &tmp_w[half_ndim, 0],
+                            &v_jm1_2[0, 0],
+                            &grad_v[0, 0])
 
-                c_leapfrog_step(cp, half_ndim, t[j], dt,
-                                &tmp_w[i, 0], &tmp_w[i, half_ndim],
-                                &v_jm1_2[i, 0],
-                                &grad[0])
-
-                if save_all:
-                    for k in range(ndim):
-                        all_w[j, i, k] = tmp_w[i, k]
+            if save_all:
+                for k in range(ndim):
+                    for i in range(n):
+                        all_w[j, k, i] = tmp_w[k, i]
 
     if save_all:
-        return np.asarray(t), np.asarray(all_w)
+        return np.asarray(t), np.asarray(all_w).transpose(0,2,1)
     else:
-        return np.asarray(t[-1:]), np.asarray(tmp_w)
+        return np.asarray(t[-1:]), np.asarray(tmp_w.T, copy=False)
 
 # -------------------------------------------------------------------------------------
 # N-body stuff - TODO: to be moved, because this is a HACK!
@@ -128,7 +132,7 @@ cdef void c_init_velocity_nbody(
 ) nogil:
     cdef int k
 
-    c_gradient(p, t, x_jm1, grad)
+    c_gradient(p, 1, t, x_jm1, grad)
     c_nbody_gradient_symplectic(pots, t, x_jm1, x_nbody_jm1, nbody, nbody_i, half_ndim, grad)
 
     for k in range(half_ndim):
@@ -146,7 +150,7 @@ cdef void c_leapfrog_step_nbody(
     for k in range(half_ndim):
         x_jm1[k] = x_jm1[k] + v_jm1_2[k] * dt
 
-    c_gradient(p, t, x_jm1, grad)  # compute gradient at new position
+    c_gradient(p, 1, t, x_jm1, grad)  # compute gradient at new position
     c_nbody_gradient_symplectic(pots, t, x_jm1, x_nbody_jm1, nbody, nbody_i, half_ndim, grad)
 
     # step velocity forward by half step, aligned w/ position, then

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -30,7 +30,7 @@ cdef void c_ruth4_step(CPotential *p, int half_ndim, double t, double dt,
     for j in range(4):
         for k in range(half_ndim):
              grad[k] = 0.
-        c_gradient(p, t, w, grad)
+        c_gradient(p, 1, t, w, grad)
         for k in range(half_ndim):
             w[half_ndim + k] = w[half_ndim + k] - ds[j] * grad[k] * dt
             w[k] = w[k] + cs[j] * w[half_ndim + k] * dt
@@ -131,7 +131,7 @@ cdef void c_ruth4_step_nbody(
         for k in range(half_ndim):
              grad[k] = 0.
 
-        c_gradient(p, t, w, grad)
+        c_gradient(p, 1, t, w, grad)
         c_nbody_gradient_symplectic(pots, t, w, w_nbody, nbody, nbody_i, half_ndim, grad)
 
         for k in range(half_ndim):

--- a/gala/potential/frame/builtin/builtin_frames.cpp
+++ b/gala/potential/frame/builtin/builtin_frames.cpp
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <string.h>
+#include "src/vectorization.h"
 
 /*
     Static, inertial frame
@@ -14,7 +15,7 @@ double static_frame_hamiltonian(double t, double *pars, double *qp, int n_dim) {
     return 0.5*E; // kinetic term
 }
 
-void static_frame_gradient(double t, double *pars, double *qp, int n_dim, double *dH) {
+void static_frame_gradient_single(double t, double *__restrict__ pars, double6ptr qp, int n_dim, double6ptr dH, void *__restrict__ state) {
     int i;
 
     for (i=0; i < n_dim; i++) {
@@ -29,7 +30,7 @@ void static_frame_hessian(double t, double *pars, double *qp, int n_dim, double 
 /*
     Constantly rotating frame
 */
-double constant_rotating_frame_hamiltonian_2d(double t, double *pars, double *qp, int n_dim) {
+double constant_rotating_frame_2d_hamiltonian(double t, double *pars, double *qp, int n_dim) {
     /*
         Omega = pars
         TODO: this is klugy, n_dim has to equal 2!
@@ -46,7 +47,7 @@ double constant_rotating_frame_hamiltonian_2d(double t, double *pars, double *qp
     return E - 0.5 * pars[0]*pars[0] * R2;
 }
 
-void constant_rotating_frame_gradient_2d(double t, double *pars, double *qp, int n_dim, double *dH) {
+void constant_rotating_frame_2d_gradient_single(double t, double *__restrict__ pars, double6ptr qp, int n_dim, double6ptr dH, void *__restrict__ state) {
     /*
         TODO: this is klugy, n_dim has to equal 2!
     */
@@ -65,11 +66,11 @@ void constant_rotating_frame_gradient_2d(double t, double *pars, double *qp, int
     dH[3] = dH[4] + Cy;
 }
 
-void constant_rotating_frame_hessian_2d(double t, double *pars, double *qp, int n_dim, double *d2H) {
+void constant_rotating_frame_2d_hessian(double t, double *pars, double *qp, int n_dim, double *d2H) {
     /* TODO: */
 }
 
-double constant_rotating_frame_hamiltonian_3d(double t, double *pars, double *qp, int n_dim) {
+double constant_rotating_frame_3d_hamiltonian(double t, double *pars, double *qp, int n_dim) {
     /*
         Omega = pars
     */
@@ -90,7 +91,7 @@ double constant_rotating_frame_hamiltonian_3d(double t, double *pars, double *qp
     return E - (pars[0]*Lx + pars[1]*Ly + pars[2]*Lz);
 }
 
-void constant_rotating_frame_gradient_3d(double t, double *pars, double *qp, int n_dim, double *dH) {
+void constant_rotating_frame_3d_gradient_single(double t, double *__restrict__ pars, double6ptr qp, int n_dim, double6ptr dH, void *__restrict__ state) {
     double Cx, Cy, Cz; // used in cross-products below
 
     // Omega x q
@@ -110,6 +111,10 @@ void constant_rotating_frame_gradient_3d(double t, double *pars, double *qp, int
     dH[5] = dH[5] + Cz;
 }
 
-void constant_rotating_frame_hessian_3d(double t, double *pars, double *qp, int n_dim, double *d2H) {
+void constant_rotating_frame_3d_hessian(double t, double *pars, double *qp, int n_dim, double *d2H) {
     /* TODO: */
 }
+
+DEFINE_VECTORIZED_GRADIENT(static_frame)
+DEFINE_VECTORIZED_GRADIENT(constant_rotating_frame_2d)
+DEFINE_VECTORIZED_GRADIENT(constant_rotating_frame_3d)

--- a/gala/potential/frame/builtin/builtin_frames.h
+++ b/gala/potential/frame/builtin/builtin_frames.h
@@ -1,11 +1,13 @@
+#include <stddef.h>
+
 extern double static_frame_hamiltonian(double t, double *pars, double *qp, int n_dim);
-extern void static_frame_gradient(double t, double *pars, double *qp, int n_dim, double *grad);
+extern void static_frame_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void static_frame_hessian(double t, double *pars, double *qp, int n_dim, double *hess);
 
-extern double constant_rotating_frame_hamiltonian_2d(double t, double *pars, double *qp, int n_dim);
-extern void constant_rotating_frame_gradient_2d(double t, double *pars, double *qp, int n_dim, double *grad);
-extern void constant_rotating_frame_hessian_2d(double t, double *pars, double *qp, int n_dim, double *hess);
+extern double constant_rotating_frame_2d_hamiltonian(double t, double *pars, double *qp, int n_dim);
+extern void constant_rotating_frame_2d_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void constant_rotating_frame_2d_hessian(double t, double *pars, double *qp, int n_dim, double *hess);
 
-extern double constant_rotating_frame_hamiltonian_3d(double t, double *pars, double *qp, int n_dim);
-extern void constant_rotating_frame_gradient_3d(double t, double *pars, double *qp, int n_dim, double *grad);
-extern void constant_rotating_frame_hessian_3d(double t, double *pars, double *qp, int n_dim, double *hess);
+extern double constant_rotating_frame_3d_hamiltonian(double t, double *pars, double *qp, int n_dim);
+extern void constant_rotating_frame_3d_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void constant_rotating_frame_3d_hessian(double t, double *pars, double *qp, int n_dim, double *hess);

--- a/gala/potential/frame/builtin/frames.pyx
+++ b/gala/potential/frame/builtin/frames.pyx
@@ -22,16 +22,16 @@ from ...potential.cpotential cimport energyfunc, gradientfunc, hessianfunc
 
 cdef extern from "frame/builtin/builtin_frames.h":
     double static_frame_hamiltonian(double t, double *pars, double *qp, int n_dim) nogil
-    void static_frame_gradient(double t, double *pars, double *qp, int n_dim, double *grad) nogil
+    void static_frame_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void static_frame_hessian(double t, double *pars, double *qp, int n_dim, double *hess) nogil
 
-    double constant_rotating_frame_hamiltonian_2d(double t, double *pars, double *qp, int n_dim) nogil
-    void constant_rotating_frame_gradient_2d(double t, double *pars, double *qp, int n_dim, double *grad) nogil
-    void constant_rotating_frame_hessian_2d(double t, double *pars, double *qp, int n_dim, double *hess) nogil
+    double constant_rotating_frame_2d_hamiltonian(double t, double *pars, double *qp, int n_dim) nogil
+    void constant_rotating_frame_2d_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void constant_rotating_frame_2d_hessian(double t, double *pars, double *qp, int n_dim, double *hess) nogil
 
-    double constant_rotating_frame_hamiltonian_3d(double t, double *pars, double *qp, int n_dim) nogil
-    void constant_rotating_frame_gradient_3d(double t, double *pars, double *qp, int n_dim, double *grad) nogil
-    void constant_rotating_frame_hessian_3d(double t, double *pars, double *qp, int n_dim, double *hess) nogil
+    double constant_rotating_frame_3d_hamiltonian(double t, double *pars, double *qp, int n_dim) nogil
+    void constant_rotating_frame_3d_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void constant_rotating_frame_3d_hessian(double t, double *pars, double *qp, int n_dim, double *hess) nogil
 
 __all__ = ['StaticFrame', 'ConstantRotatingFrame']
 
@@ -80,9 +80,9 @@ cdef class ConstantRotatingFrameWrapper2D(CFrameWrapper):
         assert len(params) == 1
         self._params = np.array([params[0]], dtype=np.float64)
 
-        cf.energy = <energyfunc>(constant_rotating_frame_hamiltonian_2d)
-        cf.gradient = <gradientfunc>(constant_rotating_frame_gradient_2d)
-        cf.hessian = <hessianfunc>(constant_rotating_frame_hessian_2d)
+        cf.energy = <energyfunc>(constant_rotating_frame_2d_hamiltonian)
+        cf.gradient = <gradientfunc>(constant_rotating_frame_2d_gradient)
+        cf.hessian = <hessianfunc>(constant_rotating_frame_2d_hessian)
         cf.n_params = 1
         cf.parameters = &(self._params[0])
 
@@ -98,9 +98,9 @@ cdef class ConstantRotatingFrameWrapper3D(CFrameWrapper):
         self._params = np.array([params[0], params[1], params[2]],
                                 dtype=np.float64)
 
-        cf.energy = <energyfunc>(constant_rotating_frame_hamiltonian_3d)
-        cf.gradient = <gradientfunc>(constant_rotating_frame_gradient_3d)
-        cf.hessian = <hessianfunc>(constant_rotating_frame_hessian_3d)
+        cf.energy = <energyfunc>(constant_rotating_frame_3d_hamiltonian)
+        cf.gradient = <gradientfunc>(constant_rotating_frame_3d_gradient)
+        cf.hessian = <hessianfunc>(constant_rotating_frame_3d_hessian)
         cf.n_params = 3
         cf.parameters = &(self._params[0])
 

--- a/gala/potential/frame/src/cframe.cpp
+++ b/gala/potential/frame/src/cframe.cpp
@@ -8,7 +8,7 @@ double frame_hamiltonian(CFrameType *fr, double t, double *qp, int n_dim) {
 }
 
 void frame_gradient(CFrameType *fr, double t, double *qp, int n_dim, double *dH) {
-    (fr->gradient)(t, (fr->parameters), qp, n_dim, dH, NULL);
+    (fr->gradient)(1, t, (fr->parameters), qp, n_dim, dH, NULL);
 }
 
 void frame_hessian(CFrameType *fr, double t, double *qp, int n_dim, double *d2H) {

--- a/gala/potential/hamiltonian/src/chamiltonian.cpp
+++ b/gala/potential/hamiltonian/src/chamiltonian.cpp
@@ -25,9 +25,9 @@ void hamiltonian_gradient(CPotential *p, CFrameType *fr, double t, double *qp, d
     }
 
     // potential gradient has to be first
-    c_gradient(p, t, qp, &(dH[p->n_dim]));
+    c_gradient(p, 1, t, qp, &(dH[p->n_dim]));
 
-    (fr->gradient)(t, (fr->parameters), qp, p->n_dim, dH, NULL);
+    (fr->gradient)(1, t, (fr->parameters), qp, p->n_dim, dH, NULL);
 
     for (i=p->n_dim; i < 2*(p->n_dim); i++) {
         dH[i] = -dH[i]; // pdot = -dH/dq

--- a/gala/potential/potential/builtin/builtin_potentials.cpp
+++ b/gala/potential/potential/builtin/builtin_potentials.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "extra_compile_macros.h"
+#include "src/vectorization.h"
 
 #if USE_GSL == 1
 #include <gsl/gsl_sf_gamma.h>
@@ -10,12 +11,12 @@
 
 double nan_density(double t, double *pars, double *q, int n_dim, void *state) { return NAN; }
 double nan_value(double t, double *pars, double *q, int n_dim, void *state) { return NAN; }
-void nan_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {}
+void nan_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {}
 void nan_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) {}
 
 double null_density(double t, double *pars, double *q, int n_dim, void *state) { return 0; }
 double null_value(double t, double *pars, double *q, int n_dim, void *state) { return 0; }
-void null_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state){}
+void null_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state){}
 void null_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) {}
 
 /* Note: many Hessians generated with sympy in
@@ -30,7 +31,7 @@ double henon_heiles_value(double t, double *pars, double *q, int n_dim, void *st
     return 0.5 * (q[0]*q[0] + q[1]*q[1] + 2*q[0]*q[0]*q[1] - 2/3.*q[1]*q[1]*q[1]);
 }
 
-void henon_heiles_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void henon_heiles_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  no parameters... */
     grad[0] = grad[0] + q[0] + 2*q[0]*q[1];
     grad[1] = grad[1] + q[1] + q[0]*q[0] - q[1]*q[1];
@@ -63,7 +64,7 @@ double kepler_value(double t, double *pars, double *q, int n_dim, void *state) {
     return -pars[0] * pars[1] / R;
 }
 
-void kepler_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void kepler_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -140,7 +141,7 @@ double isochrone_value(double t, double *pars, double *q, int n_dim, void *state
     return -pars[0] * pars[1] / (sqrt(R2 + pars[2]*pars[2]) + pars[2]);
 }
 
-void isochrone_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void isochrone_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -227,7 +228,7 @@ double hernquist_value(double t, double *pars, double *q, int n_dim, void *state
     return -pars[0] * pars[1] / (R + pars[2]);
 }
 
-void hernquist_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void hernquist_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -310,7 +311,7 @@ double plummer_value(double t, double *pars, double *q, int n_dim, void *state) 
     return -pars[0]*pars[1] / sqrt(R2 + pars[2]*pars[2]);
 }
 
-void plummer_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void plummer_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -385,7 +386,7 @@ double jaffe_value(double t, double *pars, double *q, int n_dim, void *state) {
     return -pars[0] * pars[1] / pars[2] * log(1 + pars[2]/R);
 }
 
-void jaffe_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state){
+void jaffe_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state){
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -556,7 +557,7 @@ double powerlawcutoff_density(double t, double *pars, double *q, int n_dim, void
     return A * pow(r, -pars[2]) * exp(-r*r / (pars[3]*pars[3]));
 }
 
-void powerlawcutoff_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void powerlawcutoff_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             0 - G (Gravitational constant)
             1 - m (total mass)
@@ -705,7 +706,7 @@ double stone_value(double t, double *pars, double *q, int n_dim, void *state) {
 
 }
 
-void stone_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void stone_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - M (total mass)
@@ -858,7 +859,7 @@ double sphericalnfw_value(double t, double *pars, double *q, int n_dim, void *st
     }
 }
 
-void sphericalnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void sphericalnfw_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -970,7 +971,7 @@ double flattenednfw_value(double t, double *pars, double *q, int n_dim, void *st
     }
 }
 
-void flattenednfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void flattenednfw_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (scale mass)
@@ -1078,7 +1079,7 @@ double triaxialnfw_value(double t, double *pars, double *q, int n_dim, void *sta
     }
 }
 
-void triaxialnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void triaxialnfw_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - v_c (circular velocity at the scale radius)
@@ -1186,7 +1187,7 @@ double satoh_value(double t, double *pars, double *q, int n_dim, void *state) {
     return -pars[0] * pars[1] / sqrt(S2);
 }
 
-void satoh_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void satoh_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -1273,8 +1274,7 @@ double kuzmin_value(double t, double *pars, double *q, int n_dim, void *state) {
     return -pars[0] * pars[1] / sqrt(S2);
 }
 
-void kuzmin_gradient(double t, double *pars, double *q, int n_dim,
-                     double *grad, void *state) {
+void kuzmin_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -1328,7 +1328,7 @@ double miyamotonagai_value(double t, double *pars, double *q, int n_dim, void *s
     return -pars[0] * pars[1] / sqrt(q[0]*q[0] + q[1]*q[1] + zd*zd);
 }
 
-void miyamotonagai_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void miyamotonagai_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - m (mass scale)
@@ -1437,7 +1437,7 @@ double mn3_value(double t, double *pars, double *q, int n_dim, void *state) {
     return val;
 }
 
-void mn3_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void mn3_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     double tmp_pars[4] = {0., 0., 0., 0.};
     tmp_pars[0] = pars[0];
 
@@ -1445,7 +1445,7 @@ void mn3_gradient(double t, double *pars, double *q, int n_dim, double *grad, vo
         tmp_pars[1] = pars[1+3*i];
         tmp_pars[2] = pars[1+3*i+1];
         tmp_pars[3] = pars[1+3*i+2];
-        miyamotonagai_gradient(t, &tmp_pars[0], q, n_dim, grad, state);
+        miyamotonagai_gradient_single(t, &tmp_pars[0], q, n_dim, grad, state);
     }
 }
 
@@ -1516,7 +1516,7 @@ double leesuto_value(double t, double *pars, double *q, int n_dim, void *state) 
     }
 }
 
-void leesuto_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void leesuto_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars: (alpha = 1)
             0 - G
             1 - v_c
@@ -1638,7 +1638,7 @@ double logarithmic_density(double t, double *pars, double *q, int n_dim, void *s
     return pow(pars[1], 2)*(tmp_2*(tmp_10 - tmp_3) + tmp_5*(tmp_11 - tmp_6 + tmp_8) + tmp_7*(tmp_11 + tmp_6 - tmp_8))/pow(tmp_10 + tmp_3, 2) / (4*M_PI*pars[0]);
 }
 
-void logarithmic_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void logarithmic_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - v_c (velocity scale)
@@ -1746,7 +1746,7 @@ double longmuralibar_value(double t, double *pars, double *q, int n_dim, void *s
     return pars[0]*pars[1]/(2*a) * log((x - a + Tm) / (x + a + Tp));
 }
 
-void longmuralibar_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void longmuralibar_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  http://adsabs.harvard.edu/abs/1992ApJ...397...44L
 
         pars:
@@ -2011,7 +2011,7 @@ double burkert_value(double t, double *pars, double *q, int n_dim, void *state) 
 }
 
 
-void burkert_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) {
+void burkert_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
     /*  pars:
             - G (Gravitational constant)
             - rho (mass scale)
@@ -2043,3 +2043,28 @@ double burkert_density(double t, double *pars, double *q, int n_dim, void *state
 
     return rho;
 }
+
+DEFINE_VECTORIZED_GRADIENT(burkert)
+DEFINE_VECTORIZED_GRADIENT(flattenednfw)
+DEFINE_VECTORIZED_GRADIENT(henon_heiles)
+DEFINE_VECTORIZED_GRADIENT(hernquist)
+DEFINE_VECTORIZED_GRADIENT(isochrone)
+DEFINE_VECTORIZED_GRADIENT(jaffe)
+DEFINE_VECTORIZED_GRADIENT(kepler)
+DEFINE_VECTORIZED_GRADIENT(kuzmin)
+DEFINE_VECTORIZED_GRADIENT(leesuto)
+DEFINE_VECTORIZED_GRADIENT(logarithmic)
+DEFINE_VECTORIZED_GRADIENT(longmuralibar)
+DEFINE_VECTORIZED_GRADIENT(miyamotonagai)
+DEFINE_VECTORIZED_GRADIENT(mn3)
+DEFINE_VECTORIZED_GRADIENT(nan)
+DEFINE_VECTORIZED_GRADIENT(null)
+DEFINE_VECTORIZED_GRADIENT(plummer)
+DEFINE_VECTORIZED_GRADIENT(satoh)
+DEFINE_VECTORIZED_GRADIENT(sphericalnfw)
+DEFINE_VECTORIZED_GRADIENT(stone)
+DEFINE_VECTORIZED_GRADIENT(triaxialnfw)
+
+#if USE_GSL == 1
+DEFINE_VECTORIZED_GRADIENT(powerlawcutoff)
+#endif

--- a/gala/potential/potential/builtin/builtin_potentials.h
+++ b/gala/potential/potential/builtin/builtin_potentials.h
@@ -1,98 +1,100 @@
+#include <stddef.h>
+
 extern double nan_density(double t, double *pars, double *q, int n_dim, void *state);
 extern double nan_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void nan_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void nan_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void nan_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double null_density(double t, double *pars, double *q, int n_dim, void *state);
 extern double null_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void null_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void null_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void null_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double henon_heiles_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void henon_heiles_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void henon_heiles_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void henon_heiles_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double kepler_value(double t, double *pars, double *q, int n_dim, void *state);
 extern double kepler_density(double t, double *pars, double *q, int n_dim, void *state);
-extern void kepler_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void kepler_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void kepler_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double isochrone_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void isochrone_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void isochrone_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double isochrone_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void isochrone_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double hernquist_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void hernquist_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void hernquist_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double hernquist_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void hernquist_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double plummer_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void plummer_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void plummer_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double plummer_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void plummer_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double jaffe_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void jaffe_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void jaffe_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double jaffe_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void jaffe_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double powerlawcutoff_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void powerlawcutoff_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void powerlawcutoff_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double powerlawcutoff_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void powerlawcutoff_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double stone_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void stone_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void stone_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void stone_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void stone_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double sphericalnfw_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void sphericalnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void sphericalnfw_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double sphericalnfw_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void sphericalnfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double flattenednfw_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void flattenednfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void flattenednfw_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void flattenednfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double triaxialnfw_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void triaxialnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void triaxialnfw_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void triaxialnfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double satoh_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void satoh_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void satoh_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double satoh_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void satoh_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double kuzmin_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void kuzmin_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void kuzmin_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double kuzmin_density(double t, double *pars, double *q, int n_dim, void *state);
 
 extern double miyamotonagai_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void miyamotonagai_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void miyamotonagai_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void miyamotonagai_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 extern double miyamotonagai_density(double t, double *pars, double *q, int n_dim, void *state);
 
 extern double mn3_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void mn3_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void mn3_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void mn3_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 extern double mn3_density(double t, double *pars, double *q, int n_dim, void *state);
 
 extern double leesuto_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void leesuto_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void leesuto_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double leesuto_density(double t, double *pars, double *q, int n_dim, void *state);
 
 extern double logarithmic_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void logarithmic_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void logarithmic_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern void logarithmic_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 extern double logarithmic_density(double t, double *pars, double *q, int n_dim, void *state);
 
 extern double longmuralibar_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void longmuralibar_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void longmuralibar_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double longmuralibar_density(double t, double *pars, double *q, int n_dim, void *state);
 extern void longmuralibar_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 
 extern double burkert_value(double t, double *pars, double *q, int n_dim, void *state);
-extern void burkert_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+extern void burkert_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double burkert_density(double t, double *pars, double *q, int n_dim, void *state);

--- a/gala/potential/potential/builtin/cybuiltin.pxd
+++ b/gala/potential/potential/builtin/cybuiltin.pxd
@@ -4,99 +4,99 @@
 cdef extern from "potential/potential/builtin/builtin_potentials.h":
     double nan_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     double nan_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void nan_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void nan_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void nan_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double null_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void null_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void null_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double null_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void null_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double henon_heiles_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void henon_heiles_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void henon_heiles_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void henon_heiles_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double kepler_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void kepler_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void kepler_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double kepler_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void kepler_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double isochrone_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void isochrone_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void isochrone_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double isochrone_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void isochrone_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double hernquist_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void hernquist_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void hernquist_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double hernquist_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void hernquist_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double plummer_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void plummer_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void plummer_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double plummer_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void plummer_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double jaffe_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void jaffe_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void jaffe_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double jaffe_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void jaffe_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double powerlawcutoff_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void powerlawcutoff_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void powerlawcutoff_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double powerlawcutoff_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void powerlawcutoff_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double stone_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void stone_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void stone_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double stone_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void stone_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double sphericalnfw_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void sphericalnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void sphericalnfw_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double sphericalnfw_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void sphericalnfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double flattenednfw_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void flattenednfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void flattenednfw_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void flattenednfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double triaxialnfw_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void triaxialnfw_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void triaxialnfw_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void triaxialnfw_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double satoh_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void satoh_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void satoh_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double satoh_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void satoh_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double kuzmin_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void kuzmin_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void kuzmin_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double kuzmin_density(double t, double *pars, double *q, int n_dim, void *state) nogil
 
     double miyamotonagai_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void miyamotonagai_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void miyamotonagai_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void miyamotonagai_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
     double miyamotonagai_density(double t, double *pars, double *q, int n_dim, void *state) nogil
 
     double mn3_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void mn3_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void mn3_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void mn3_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
     double mn3_density(double t, double *pars, double *q, int n_dim, void *state) nogil
 
     double leesuto_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void leesuto_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void leesuto_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double leesuto_density(double t, double *pars, double *q, int n_dim, void *state) nogil
 
     double logarithmic_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void logarithmic_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void logarithmic_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     void logarithmic_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
     double logarithmic_density(double t, double *pars, double *q, int n_dim, void *state) nogil
 
     double longmuralibar_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void longmuralibar_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void longmuralibar_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double longmuralibar_density(double t, double *pars, double *q, int n_dim, void *state) nogil
     void longmuralibar_hessian(double t, double *pars, double *q, int n_dim, double *hess, void *state) nogil
 
     double burkert_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void burkert_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void burkert_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
     double burkert_density(double t, double *pars, double *q, int n_dim, void *state) nogil

--- a/gala/potential/potential/builtin/cybuiltin.pyx
+++ b/gala/potential/potential/builtin/cybuiltin.pyx
@@ -32,11 +32,11 @@ from ...._cconfig cimport USE_GSL
 
 cdef extern from "potential/potential/builtin/multipole.h":
     double mp_potential(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void mp_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void mp_gradient(size_t N, double t, double *pars, double *q, double *grad, void *state) nogil
     double mp_density(double t, double *pars, double *q, int n_dim, void *state) nogil
 
     double axisym_cylspline_value(double t, double *pars, double *q, int n_dim, void *state) nogil
-    void axisym_cylspline_gradient(double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
+    void axisym_cylspline_gradient(size_t N, double t, double *pars, double *q, double *grad, void *state) nogil
     double axisym_cylspline_density(double t, double *pars, double *q, int n_dim, void *state) nogil
 
 

--- a/gala/potential/potential/builtin/exp_fields.cc
+++ b/gala/potential/potential/builtin/exp_fields.cc
@@ -15,6 +15,7 @@ namespace fs = std::filesystem;
 #include <FieldGenerator.H>
 
 #include "exp_fields.h"
+#include "src/vectorization.h"
 
 namespace gala_exp {
 
@@ -170,8 +171,6 @@ CoefClasses::CoefStrPtr interpolator(double t, CoefClasses::CoefsPtr coefs)
     Only available if EXP available at build time.
 */
 
-extern "C" {
-
 double exp_value(double t, double *pars, double *q, int n_dim, void* state) {
   gala_exp::State *exp_state = static_cast<gala_exp::State *>(state);
 
@@ -188,7 +187,7 @@ double exp_value(double t, double *pars, double *q, int n_dim, void* state) {
   return field[5];
 }
 
-void exp_gradient(double t, double *pars, double *q, int n_dim, double *grad, void* state){
+void exp_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state){
   gala_exp::State *exp_state = static_cast<gala_exp::State *>(state);
 
   if (!exp_state->is_static) {
@@ -233,6 +232,6 @@ double exp_density(double t, double *pars, double *q, int n_dim, void* state) {
 //   }
 // }
 
-}
+DEFINE_VECTORIZED_GRADIENT(exp)
 
 #endif  // USE_EXP

--- a/gala/potential/potential/builtin/exp_fields.h
+++ b/gala/potential/potential/builtin/exp_fields.h
@@ -31,16 +31,9 @@ CoefClasses::CoefStrPtr interpolator(double t, CoefClasses::CoefsPtr coefs);
 
 }
 
-extern "C" {
-
-// These must be C function prototypes. Gala will use the C function pointers
-// in the evaulation loop.
-
 extern double exp_value(double t, double *pars, double *q, int n_dim, void* state);
-extern void exp_gradient(double t, double *pars, double *q, int n_dim, double *grad, void* state);
+extern void exp_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double exp_density(double t, double *pars, double *q, int n_dim, void* state);
-
-}
 
 class ScopedChdir {
 private:

--- a/gala/potential/potential/builtin/multipole.h
+++ b/gala/potential/potential/builtin/multipole.h
@@ -1,10 +1,12 @@
+#include <stddef.h>
+
 extern double mp_potential(double t, double *pars, double *q, int n_dim);
 extern double mp_density(double t, double *pars, double *q, int n_dim);
-extern void mp_gradient(double t, double *pars, double *q, int n_dim, double *grad);
+extern void mp_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 
 extern double mpetd_potential(double t, double *pars, double *q, int n_dim);
 extern double mpetd_density(double t, double *pars, double *q, int n_dim);
-extern void mpetd_gradient(double t, double *pars, double *q, int n_dim, double *grad);
+extern void mpetd_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 
 extern void mp_density_helper(double *xyz, int K,
                                double M, double r_s,
@@ -16,16 +18,11 @@ extern void mp_potential_helper(double *xyz, int K,
                                  double *anlm, double *bnlm,
                                  int lmax, int inner, double *val);
 
-extern void mp_gradient_helper(double *xyz, int K,
-                                double G, double M, double r_s,
-                                double *anlm, double *bnlm,
-                                int lmax, int inner, double *grad);
-
 extern double mp_rho_lm(double r, double phi, double X, int l, int m, int inner);
 extern double mp_phi_lm(double r, double phi, double X, int l, int m, int inner);
 extern void mp_sph_grad_phi_lm(double r, double phi, double X, int l, int m, int lmax, int inner, double *sphgrad);
 
 
 extern double axisym_cylspline_value(double t, double *pars, double *q, int n_dim);
-extern void axisym_cylspline_gradient(double t, double *pars, double *q, int n_dim, double *grad);
+extern void axisym_cylspline_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double axisym_cylspline_density(double t, double *pars, double *q, int n_dim);

--- a/gala/potential/potential/cpotential.pxd
+++ b/gala/potential/potential/cpotential.pxd
@@ -2,10 +2,10 @@
 # cython: language=c++
 
 cdef extern from "src/funcdefs.h":
-    ctypedef double (*densityfunc)(double t, double *pars, double *q, void *state) except + nogil
-    ctypedef double (*energyfunc)(double t, double *pars, double *q, void *state) except + nogil
-    ctypedef void (*gradientfunc)(double t, double *pars, double *q, double *grad, void *state) except + nogil
-    ctypedef void (*hessianfunc)(double t, double *pars, double *q, double *hess, void *state) except + nogil
+    ctypedef double (*densityfunc)(double t, double *pars, double *q, int n_dim, void *state) except + nogil
+    ctypedef double (*energyfunc)(double t, double *pars, double *q, int n_dim, void *state) except + nogil
+    ctypedef void (*gradientfunc)(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) except + nogil
+    ctypedef void (*hessianfunc)(double t, double *pars, double *q, int n_dim, double *hess, void *state) except + nogil
 
 cdef extern from "potential/src/cpotential.h":
     ctypedef struct CPotential:
@@ -17,6 +17,7 @@ cdef extern from "potential/src/cpotential.h":
         energyfunc* value
         gradientfunc* gradient
         hessianfunc* hessian
+
         int* n_params         # parameter counts per component
         double** parameters   # pointers to parameter arrays per component
         double** q0           # pointers to origin per component
@@ -29,7 +30,7 @@ cdef extern from "potential/src/cpotential.h":
 
     double c_potential(CPotential *p, double t, double *q) except + nogil
     double c_density(CPotential *p, double t, double *q) except + nogil
-    void c_gradient(CPotential *p, double t, double *q, double *grad) except + nogil
+    void c_gradient(CPotential *p, size_t N, double t, double *q, double *grad) except + nogil
     void c_hessian(CPotential *p, double t, double *q, double *hess) except + nogil
 
     double c_d_dr(CPotential *p, double t, double *q, double *epsilon) except + nogil

--- a/gala/potential/potential/src/cpotential.h
+++ b/gala/potential/potential/src/cpotential.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #include "src/funcdefs.h"
 
 #ifndef _CPotential_H
@@ -39,7 +41,7 @@ extern int resize_cpotential_arrays(CPotential* pot, int new_n_components);
 
 extern double c_potential(CPotential *p, double t, double *q);
 extern double c_density(CPotential *p, double t, double *q);
-extern void c_gradient(CPotential *p, double t, double *q, double *grad);
+extern void c_gradient(CPotential *p, size_t N, double t, double *q, double *grad);
 extern void c_hessian(CPotential *p, double t, double *q, double *hess);
 
 // TODO: err, what about reference frames...

--- a/gala/potential/potential/tests/helpers.py
+++ b/gala/potential/potential/tests/helpers.py
@@ -142,7 +142,7 @@ class PotentialTestBase:
 
         if self.check_zero_at_infinity:
             val = self.potential.energy([1e12, 1e12, 1e12])
-            assert np.isclose(val, 0.0, atol=1e-6)
+            np.testing.assert_allclose(val, 0.0, rtol=1e-05, atol=1e-6)
 
     def test_gradient(self):
         for arr, shp in zip(self.w0s, self._grad_return_shapes):
@@ -197,7 +197,7 @@ class PotentialTestBase:
         for arr, shp in zip(self.w0s, self._valu_return_shapes):
             g = self.potential.circular_velocity(arr[: self.ndim])
             assert g.shape == shp
-            assert np.all(g > 0.0)
+            np.testing.assert_array_less(0.0, g)
 
             g = self.potential.circular_velocity(arr[: self.ndim], t=0.1)
             g = self.potential.circular_velocity(
@@ -318,7 +318,7 @@ class PotentialTestBase:
                 ]
             )
         grad = self.potential._gradient(xyz, t=np.array([0.0]))
-        assert np.allclose(num_grad, grad, rtol=self.tol)
+        np.testing.assert_allclose(grad, num_grad, rtol=self.tol, atol=1e-8)
 
     def test_orbit_integration(self, t1=0.0, t2=1000.0, nsteps=10000):
         """

--- a/gala/potential/scf/bfe.pxd
+++ b/gala/potential/scf/bfe.pxd
@@ -8,14 +8,16 @@ cdef extern from "scf/src/bfe.h":
     void scf_potential_helper(double *xyz, int K, double G, double M, double r_s,
                               double *Snlm, double *Tnlm,
                               int nmax, int lmax, double *potv) nogil
-    void scf_gradient_helper(double *xyz, int K, double G, double M, double r_s,
-                             double *Snlm, double *Tnlm,
-                             int nmax, int lmax, double *grad) nogil
+    void scf_gradient_helper(double *x, double *y, double *z, int K,
+                         double G, double M, double r_s,
+                         double *Snlm, double *Tnlm,
+                         int nmax, int lmax,
+                         double *gradx, double *grady, double *gradz) nogil
 
     double scf_value(double t, double *pars, double *q, int n_dim) nogil
     double scf_density(double t, double *pars, double *q, int n_dim) nogil
-    void scf_gradient(double t, double *pars, double *q, int n_dim, double *grad) nogil
+    void scf_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil
 
     double scf_interp_value(double t, double *pars, double *q, int n_dim) nogil
     double scf_interp_density(double t, double *pars, double *q, int n_dim) nogil
-    void scf_interp_gradient(double t, double *pars, double *q, int n_dim, double *grad) nogil
+    void scf_interp_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state) nogil

--- a/gala/potential/scf/bfe.pyx
+++ b/gala/potential/scf/bfe.pyx
@@ -173,14 +173,17 @@ cpdef gradient(double[:, ::1] xyz,
     """
     cdef:
         int ncoords = xyz.shape[0]
-        double[:, ::1] grad = np.zeros((ncoords, 3))
+        double[:, ::1] xyz_T = np.ascontiguousarray(xyz.T)
+        double[:, ::1] grad = np.zeros((3, ncoords))
 
         int nmax = Snlm.shape[0]-1
         int lmax = Snlm.shape[1]-1
 
     if USE_GSL == 1:
-        scf_gradient_helper(&xyz[0, 0], ncoords, G, M, r_s,
+        scf_gradient_helper(&xyz_T[0, 0], &xyz_T[1, 0], &xyz_T[2, 0],
+                            ncoords, G, M, r_s,
                             &Snlm[0, 0, 0], &Tnlm[0, 0, 0],
-                            nmax, lmax, &grad[0, 0])
+                            nmax, lmax,
+                            &grad[0, 0], &grad[1, 0], &grad[2, 0])
 
-    return np.array(grad)
+    return np.asarray(grad.T, copy=False)

--- a/gala/potential/scf/src/bfe.h
+++ b/gala/potential/scf/src/bfe.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 extern void scf_density_helper(double *xyz, int K, double M, double r_s,
                                double *Snlm, double *Tnlm,
                                int nmax, int lmax, double *dens);
@@ -7,17 +9,16 @@ extern void scf_potential_helper(double *xyz, int K,
                                  double *Snlm, double *Tnlm,
                                  int nmax, int lmax, double *val);
 
-extern void scf_gradient_helper(double *xyz, int K,
-                                double G, double M, double r_s,
-                                double *Snlm, double *Tnlm,
-                                int nmax, int lmax, double *grad);
+void scf_gradient_helper(double *x, double *y, double *z, int K,
+                         double G, double M, double r_s,
+                         double *Snlm, double *Tnlm,
+                         int nmax, int lmax,
+                         double *gradx, double *grady, double *gradz);
 
 extern double scf_value(double t, double *pars, double *q, int n_dim);
-extern void scf_gradient(double t, double *pars, double *q, int n_dim,
-                         double *grad);
+extern void scf_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double scf_density(double t, double *pars, double *q, int n_dim);
 
 extern double scf_interp_value(double t, double *pars, double *q, int n_dim);
-extern void scf_interp_gradient(double t, double *pars, double *q, int n_dim,
-                                double *grad);
+extern void scf_interp_gradient(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
 extern double scf_interp_density(double t, double *pars, double *q, int n_dim);

--- a/gala/potential/src/funcdefs.h
+++ b/gala/potential/src/funcdefs.h
@@ -2,6 +2,6 @@
 #define _FUNCS_
     typedef double (*densityfunc)(double t, double *pars, double *q, int n_dim, void *state);
     typedef double (*energyfunc)(double t, double *pars, double *q, int n_dim, void *state);
-    typedef void (*gradientfunc)(double t, double *pars, double *q, int n_dim, double *grad, void *state);
+    typedef void (*gradientfunc)(size_t N, double t, double *pars, double *q, int n_dim, double *grad, void *state);
     typedef void (*hessianfunc)(double t, double *pars, double *q, int n_dim, double *hess, void *state);
 #endif

--- a/gala/potential/src/vectorization.h
+++ b/gala/potential/src/vectorization.h
@@ -1,0 +1,80 @@
+#ifndef VECTORIZATION_H
+#define VECTORIZATION_H
+
+#include <stddef.h>
+#include <stdexcept>
+
+class double6ptr {
+    // This class is a container for 6 pointers to doubles.
+    // It lets us naturally pass around arrays of shape (6,N).
+    // Note that not all the pointers may be valid; it is the
+    // responsibility of the downstream function to not dereference
+    // an invalid pointer!
+
+public:
+    double *__restrict__ x, *__restrict__ y, *__restrict__ z;
+    double *__restrict__ px, *__restrict__ py, *__restrict__ pz;
+
+    explicit double6ptr(double *__restrict__ q, size_t N) {
+        x = q;
+        y = q + N;
+        z = q + 2 * N;
+        px = q + 3 * N;
+        py = q + 4 * N;
+        pz = q + 5 * N;
+    }
+
+    // Access through the index operator will dereference the pointers
+    double & operator[](int i) {
+        switch (i) {
+            case 0: return *x;
+            case 1: return *y;
+            case 2: return *z;
+            case 3: return *px;
+            case 4: return *py;
+            case 5: return *pz;
+            default: throw std::out_of_range("Index out of range");
+        }
+    }
+
+    const double & operator[](int i) const {
+        switch (i) {
+            case 0: return *x;
+            case 1: return *y;
+            case 2: return *z;
+            case 3: return *px;
+            case 4: return *py;
+            case 5: return *pz;
+            default: throw std::out_of_range("Index out of range");
+        }
+    }
+};
+
+// This is a wrapper to generate vectorized versions of the scalar gradient
+// functions. It looks a little gnarly because we have to play some tricks to ensure
+// that the compiler can vectorize through the call to the scalar function.
+
+#define DEFINE_VECTORIZED_GRADIENT(POTENTIAL_NAME) \
+struct POTENTIAL_NAME##_gradient_functor { \
+    template <typename ...Params> \
+    void operator()(Params&&... params) { \
+        POTENTIAL_NAME##_gradient_single(std::forward<Params>(params)...); \
+    } \
+}; \
+void POTENTIAL_NAME##_gradient(size_t N, double t, double *__restrict__ pars, double *__restrict__ q, int n_dim, double *__restrict__ grad, void *__restrict__ state) { \
+    gradientv<POTENTIAL_NAME##_gradient_functor>(N, t, pars, q, n_dim, grad, state); \
+}
+
+template <typename F>
+void gradientv(size_t N, double t, double *__restrict__ pars, double *__restrict__ q, int n_dim, double *__restrict__ grad, void *__restrict__ state) {
+    F f;
+    for (size_t i = 0; i < N; i++) {
+        f(t, pars,
+            double6ptr{q + i, N},
+            n_dim,
+            double6ptr{grad + i, N},
+        state);
+    }
+}
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,10 @@ else:
 all_extensions = get_extensions()
 extensions = []
 for ext in all_extensions:
-    ext.extra_compile_args.extend(["-Ofast"])
+    # TODO: -Ofast deprecated with clang
+    # -march=native may be useful, depending on the architecture
+    ext.extra_compile_args.extend(["-Ofast", "-flto=auto"])
+    ext.extra_link_args.extend(["-Ofast", "-flto=auto"])
     if ("potential.potential" in ext.name or "scf" in ext.name) and (
         gsl_version is not None
     ):

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ else:
 all_extensions = get_extensions()
 extensions = []
 for ext in all_extensions:
+    ext.extra_compile_args.extend(["-Ofast"])
     if ("potential.potential" in ext.name or "scf" in ext.name) and (
         gsl_version is not None
     ):


### PR DESCRIPTION
### Describe your changes
This is a follow-up to #435, generalizing the vectorization to all potentials. The idea is the same as before: by passing the particle arrays down to the gradient functions, the compiler can efficiently vectorize the evaluation.  To avoid having to write a particle loop in every gradient function, we define a particle loop template function, templated on the single-particle function. We register the single-particle versions with a macro.

To help with vectorization, we transpose the input arrays from `(N, ndim)` to `(ndim, N)`.  This isn't a user-facing change, but it does mean that each integration routine needs to transpose the input and transpose back the output. In this PR, I've only applied this to leapfrog. The others (ruth4 and dop853) are done but will be a separate PR to make this easier to review.

This transpose does make dealing with the highly flexible gradients trickier. Some expect 3 dimensions, some 6, and some loop over `ndim`. Since the dimensions are no longer contiguous in memory, the functions need to know where to find the coordinate arrays. I implemented a `double6ptr` type that acts as a container of (up to) 6 pointers, giving a way to access transposed arrays. Not all 6 pointers may be valid; it's up to the potentials to not dereference invalid pointers. But this was true before, too, since all accesses were through a raw pointer.

With enough particles, the performance gain is over a factor of 10x on a Genoa node:

![](https://github.com/user-attachments/assets/b13d91ef-2617-4382-9b7d-dfc4c9b92e84)

Not every code path is equally optimized/vectorized here. For example, the N-body accelerations are still doing single-particle gradients (as seen by the `c_gradient(p, 1, ...)` calls). N-body is a bit tricky in this model because we don't have an easy way for the inner evaluation loop to skip the self interaction. We could revisit this if N-body performance is important. Likewise, I've only vectorized the gradients (assuming that orbit integration is a common, expensive operation), but the potential, density, and hessian could also be vectorized. `save_all` still hurts performance a lot.

The build isn't using any particular `-march` flags right now, but we might want to consider `x86-64-v2` or even `x86-64-v3` for wheels. The latter requires Haswell or newer (12 years old). We should consider similar flags for aarch64. I did enable `-Ofast` (i.e. non-strict floating point compliance), which is generally fine for numerical integration with controlled tolerance, but it's worth thinking about whether there are other areas of the code that we need to check.

I'm pretty happy with where this PR landed, but I think it does have an above-average chance of bugs. There's a decent amount of memory layout changes, pointer manipulation, and both Cython and C++ changes. The tests caught plenty of bugs during development, as did the address sanitizer. The tests run clean under the sanitizer now.

### Checklist

- [ ] Did you add tests? (No, unless we wanted to add performance tests)
- [x] Did you add documentation for your changes?
- [x] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`)
- [ ] Are the CI tests passing?
- [ ] Is the milestone set?
