### PR TITLE
vectorization follow-ups

### DIFF
--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -129,6 +129,7 @@ cpdef mockstream_dop853(
             atol, rtol, nmax, dt_max,
             nstiff=-1,  # disable stiffness check
             err_if_fail=err_if_fail, log_output=log_output, save_all=1,
+            transposed=0
         )
 
         n = 0

--- a/gala/dynamics/nbody/nbody.pyx
+++ b/gala/dynamics/nbody/nbody.pyx
@@ -105,7 +105,8 @@ cpdef direct_nbody_dop853(
             atol, rtol, nmax, dt_max,
             nstiff=-1,  # disable stiffness check - TODO: note somewhere
             err_if_fail=err_if_fail, log_output=log_output,
-            save_all=save_all
+            save_all=save_all,
+            transposed=0
         )
         if save_all:
             return np.array(w)

--- a/gala/integrate/cyintegrators/dop853.pxd
+++ b/gala/integrate/cyintegrators/dop853.pxd
@@ -28,6 +28,8 @@ cdef extern from "dopri/dop853.h":
 
     void Fwrapper (unsigned ndim, double t, double *w, double *f,
                    CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody) except +
+    void Fwrapper_T (unsigned ndim, double t, double *w, double *f,
+                   CPotential *p, CFrameType *fr, unsigned norbits, unsigned nbody) except +
     void Fwrapper_direct_nbody(unsigned ndim, double t, double *w, double *f,
                                CPotential *p, CFrameType *fr,
                                unsigned norbits, unsigned nbody, void *args) except + nogil
@@ -67,6 +69,7 @@ cdef dop853_helper(
     int nstiff,
     unsigned err_if_fail,
     unsigned log_output,
+    int transposed,
     unsigned save_all=?
 )
 

--- a/gala/integrate/cyintegrators/dopri/dop853.cpp
+++ b/gala/integrate/cyintegrators/dopri/dop853.cpp
@@ -976,6 +976,17 @@ void Fwrapper(unsigned full_ndim, double t, double *w, double *f, CPotential *p,
   }
 }
 
+void Fwrapper_T(unsigned full_ndim, double t, double *w, double *f, CPotential *p,
+              CFrameType *fr, unsigned norbits, unsigned na, void *args) {
+  /* na can be ignored here - used in nbody wrapper below */
+
+  int i;
+  unsigned ndim = full_ndim / norbits; // phase-space dimensionality
+
+  // call gradient function
+  hamiltonian_gradient_T(p, fr, norbits, t, w, f);
+}
+
 void Fwrapper_direct_nbody(unsigned full_ndim, double t, double *w, double *f,
                            CPotential *p, CFrameType *fr, unsigned norbits,
                            unsigned nbody, void *args) {

--- a/gala/integrate/cyintegrators/dopri/dop853.h
+++ b/gala/integrate/cyintegrators/dopri/dop853.h
@@ -258,6 +258,9 @@ extern long nrejctRead (void);
 extern void Fwrapper (unsigned ndim, double t, double *w, double *f,
                       CPotential *p, CFrameType *fr,
                       unsigned norbits, unsigned nbody, void *args);
+extern void Fwrapper_T (unsigned ndim, double t, double *w, double *f,
+                      CPotential *p, CFrameType *fr,
+                      unsigned norbits, unsigned nbody, void *args);
 extern void Fwrapper_direct_nbody(unsigned ndim, double t, double *w, double *f,
                                   CPotential *p, CFrameType *fr,
                                   unsigned norbits, unsigned nbody,

--- a/gala/integrate/cyintegrators/ruth4.pxd
+++ b/gala/integrate/cyintegrators/ruth4.pxd
@@ -3,6 +3,6 @@
 
 from ...potential.potential.cpotential cimport CPotential
 
-cdef void c_ruth4_step(CPotential *p, int ndim, double t, double dt,
+cdef void c_ruth4_step(CPotential *p, size_t n, int ndim, double t, double dt,
                        double *cs, double *ds,
                        double *w, double *grad) nogil

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -21,19 +21,18 @@ from ...potential import NullPotential
 from libc.stdlib cimport malloc, free
 
 
-cdef void c_ruth4_step(CPotential *p, int half_ndim, double t, double dt,
+cdef void c_ruth4_step(CPotential *p, size_t n, int half_ndim, double t, double dt,
                        double *cs, double *ds,
                        double *w, double *grad) nogil:
     cdef:
-        int j, k
+        int j, k, i
 
     for j in range(4):
+        c_gradient(p, n, t, w, grad)
         for k in range(half_ndim):
-             grad[k] = 0.
-        c_gradient(p, 1, t, w, grad)
-        for k in range(half_ndim):
-            w[half_ndim + k] = w[half_ndim + k] - ds[j] * grad[k] * dt
-            w[k] = w[k] + cs[j] * w[half_ndim + k] * dt
+            for i in range(n):
+                w[(half_ndim + k) * n + i] = w[(half_ndim + k) * n + i] - ds[j] * grad[k * n + i] * dt
+                w[k * n + i] = w[k * n + i] + cs[j] * w[(half_ndim + k) * n + i] * dt
 
 cpdef ruth4_integrate_hamiltonian(hamiltonian,
                                   double[:, ::1] w0,
@@ -80,7 +79,7 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
         ], dtype='f8')
 
         # temporary array containers
-        double[::1] grad = np.zeros(half_ndim)
+        double[:, ::1] grad = np.zeros((half_ndim, n))
 
         # return arrays
         double[:, :, ::1] all_w
@@ -90,29 +89,29 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
     if save_all:
-        all_w = np.zeros((ntimes, n, ndim))
+        all_w = np.zeros((ntimes, ndim, n))
 
         # save initial conditions
-        all_w[0, :, :] = w0.copy()
+        all_w[0, :, :] = w0.T.copy()
 
-    tmp_w = w0.copy()
+    tmp_w = w0.T.copy()
 
     with nogil:
-
         for j in range(1, ntimes, 1):
-            for i in range(n):
-                c_ruth4_step(cp, half_ndim, t[j], dt,
-                             &cs[0], &ds[0],
-                             &tmp_w[i, 0], &grad[0])
+            grad[:] = 0.
+            c_ruth4_step(cp, n, half_ndim, t[j], dt,
+                        &cs[0], &ds[0],
+                        &tmp_w[0, 0], &grad[0, 0])
 
-                if save_all:
-                    for k in range(ndim):
-                        all_w[j, i, k] = tmp_w[i, k]
+            if save_all:
+                for k in range(ndim):
+                    for i in range(n):
+                        all_w[j, k, i] = tmp_w[k, i]
 
     if save_all:
-        return np.asarray(t), np.asarray(all_w)
+        return np.asarray(t), np.asarray(all_w).transpose(0,2,1)
     else:
-        return np.asarray(t[-1:]), np.asarray(tmp_w)
+        return np.asarray(t[-1:]), np.asarray(tmp_w.T, copy=False)
 
 
 # -------------------------------------------------------------------------------------

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -342,6 +342,7 @@ class Hamiltonian(CommonBase):
                     save_all=save_all,
                     err_if_fail=int(Integrator_kwargs.get('err_if_fail', 1)),
                     log_output=int(Integrator_kwargs.get('log_output', 0)),
+                    nbatch=Integrator_kwargs.get('nbatch', 100),
                 )
             else:
                 raise ValueError(f"Cython integration not supported for '{Integrator!r}'")

--- a/gala/potential/hamiltonian/src/chamiltonian.h
+++ b/gala/potential/hamiltonian/src/chamiltonian.h
@@ -3,4 +3,5 @@
 
 extern double hamiltonian_value(CPotential *p, CFrameType *fr, double t, double *q);
 extern void hamiltonian_gradient(CPotential *p, CFrameType *fr, double t, double *q, double *grad);
+extern void hamiltonian_gradient_T(CPotential *p, CFrameType *fr, size_t n, double t, double *q, double *grad);
 extern void hamiltonian_hessian(CPotential *p, CFrameType *fr, double t, double *q, double *hess);

--- a/gala/potential/potential/builtin/exp_fields.cc
+++ b/gala/potential/potential/builtin/exp_fields.cc
@@ -187,7 +187,7 @@ double exp_value(double t, double *pars, double *q, int n_dim, void* state) {
   return field[5];
 }
 
-void exp_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state){
+void exp_gradient(size_t N, double t, double *__restrict__ pars, double *__restrict__ q_in, int n_dim, double *__restrict__ grad_in, void *__restrict__ state){
   gala_exp::State *exp_state = static_cast<gala_exp::State *>(state);
 
   if (!exp_state->is_static) {
@@ -196,11 +196,16 @@ void exp_gradient_single(double t, double *__restrict__ pars, double6ptr q, int 
 
   // TODO: ask Martin/Mike for a way to compute only the force/acceleration - we're wasting
   // computation time here by computing all fields
-  auto field = exp_state->basis->getFields(q[0], q[1], q[2]);
+  double6ptr q = double6ptr{q_in, N};
+  double6ptr grad = double6ptr{grad_in, N};
 
-  grad[0] += -field[6];
-  grad[1] += -field[7];
-  grad[2] += -field[8];
+  for(size_t i = 0; i < N; i++) {
+    auto field = exp_state->basis->getFields(q.x[i], q.y[i], q.z[i]);
+
+    grad.x[i] += -field[6];
+    grad.y[i] += -field[7];
+    grad.z[i] += -field[8];
+  }
 }
 
 double exp_density(double t, double *pars, double *q, int n_dim, void* state) {
@@ -231,7 +236,5 @@ double exp_density(double t, double *pars, double *q, int n_dim, void* state) {
 //     hess[i] += NAN;  // TODO: get hessian from EXP
 //   }
 // }
-
-DEFINE_VECTORIZED_GRADIENT(exp)
 
 #endif  // USE_EXP

--- a/gala/potential/potential/builtin/multipole.cpp
+++ b/gala/potential/potential/builtin/multipole.cpp
@@ -334,8 +334,7 @@ double mp_potential(double t, double *pars, double *q, int n_dim) {
     return val[0];
 }
 
-// TODO: de-scalarize
-void mp_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
+void mp_gradient(size_t N, double t, double *__restrict__ pars, double *__restrict__ q, int n_dim, double *__restrict__ grad, void *__restrict__ state) {
     /*  pars:
         - G (Gravitational constant)
         - lmax
@@ -345,6 +344,28 @@ void mp_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n
         - r_s (length scale)
         [- sin_coeff, cos_coeff]
     */
+    double G = pars[0];
+    int lmax = (int)pars[1];
+    int num_coeff = (int)pars[2];
+    int inner = (int)pars[3];
+    double M = pars[4];
+    double r_s = pars[5];
+
+    double Slm[num_coeff], Tlm[num_coeff];
+    for(int i=0; i<num_coeff; i++){
+        Slm[i] = pars[6 + 2*i];
+        Tlm[i] = pars[7 + 2*i];
+    }
+
+    mp_gradient_helper(double6ptr{q, N}, N,
+                       G, M, r_s,
+                       &Slm[0], &Tlm[0],
+                       lmax, inner, double6ptr{grad, N});
+}
+
+void _mp_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
+    // This is a helper used by axisym_cylspline_gradient, but not by mp_gradient.
+
     double G = pars[0];
     int lmax = (int)pars[1];
     int num_coeff = (int)pars[2];
@@ -467,7 +488,7 @@ double mpetd_potential(double t, double *pars, double *q, int n_dim) {
     return val[0];
 }
 
-void mpetd_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
+void mpetd_gradient(size_t N, double t, double *__restrict__ pars, double *__restrict__ q, int n_dim, double *__restrict__ grad, void *__restrict__ state) {
     /*  pars:
         - G (Gravitational constant)
         - lmax
@@ -510,10 +531,10 @@ void mpetd_gradient_single(double t, double *__restrict__ pars, double6ptr q, in
 
 
 
-    mp_gradient_helper(q, 1,
+    mp_gradient_helper(double6ptr{q, N}, N,
                         G, M, r_s,
                         &alm[0], &blm[0],
-                        lmax, 1, grad);
+                        lmax, 1, double6ptr{grad, N});
 }
 
 double mpetd_density(double t, double *pars, double *q, int n_dim) {
@@ -658,17 +679,12 @@ double axisym_cylspline_value(double t, double *pars, double *q, int n_dim) {
     return Phi;
 }
 
-void axisym_cylspline_gradient_single(double t, double *__restrict__ pars, double6ptr q, int n_dim, double6ptr grad, void *__restrict__ state) {
+void axisym_cylspline_gradient(size_t N, double t, double *__restrict__ pars, double *__restrict__ q_in, int n_dim, double *__restrict__ grad_in, void *__restrict__ state) {
 
     int logScaling = (int)pars[1];
     double Rscale = pars[2];
     int nR = (int)pars[3];
     int nz = (int)pars[4];
-
-    double Phi, dPhi_dR, dPhi_dz;
-    double R = sqrt(q[0]*q[0] + q[1]*q[1]);
-    double Rasinh = asinh(R / Rscale);
-    double zasinh = asinh(q[2] / Rscale);
 
     double gridR[nR];
     double gridz[nz];
@@ -686,43 +702,46 @@ void axisym_cylspline_gradient_single(double t, double *__restrict__ pars, doubl
     gsl_interp_accel *xacc = gsl_interp_accel_alloc();
     gsl_interp_accel *yacc = gsl_interp_accel_alloc();
 
-    // TODO: interpolation is very slow I think because this setup is done every
-    // time the function is called...
+    /* initialize interpolation */
+    gsl_spline2d_init(spline, gridR, gridz, gridPhi, nR, nz);
 
-    if ((Rasinh >= gridR[0]) && (Rasinh <= gridR[nR-1]) &&
-        (zasinh >= gridz[0]) && (zasinh <= gridz[nz-1])) { // Use CylSpline
+    double6ptr q = double6ptr{q_in, N};
+    double6ptr grad = double6ptr{grad_in, N};
 
-        /* initialize interpolation */
-        // TODO: define this in wrapper, make all CPotential's have a void
-        // pointer array to store things like this, all these functions then
-        // need to accept one more parameter (or is there a way to do optional
-        // args in C?), ??, profit.
-        gsl_spline2d_init(spline, gridR, gridz, gridPhi, nR, nz);
+    for(size_t i = 0; i < N; i++) {
+        double R = sqrt(q.x[i]*q.x[i] + q.y[i]*q.y[i]);
+        double Rasinh = asinh(R / Rscale);
+        double zasinh = asinh(q.z[i] / Rscale);
 
-        dPhi_dR = gsl_spline2d_eval_deriv_x(spline, Rasinh, zasinh, xacc, yacc);
-        dPhi_dR = dPhi_dR / (Rscale * cosh(Rasinh));
+        if ((Rasinh >= gridR[0]) && (Rasinh <= gridR[nR-1]) &&
+            (zasinh >= gridz[0]) && (zasinh <= gridz[nz-1])) { // Use CylSpline
 
-        dPhi_dz = gsl_spline2d_eval_deriv_y(spline, Rasinh, zasinh, xacc, yacc);
-        dPhi_dz = dPhi_dz / (Rscale * cosh(zasinh));
+            double dPhi_dR = gsl_spline2d_eval_deriv_x(spline, Rasinh, zasinh, xacc, yacc);
+            dPhi_dR = dPhi_dR / (Rscale * cosh(Rasinh));
 
-        if (logScaling) {
-            Phi = gsl_spline2d_eval(spline, Rasinh, zasinh, xacc, yacc);
-            Phi = -exp(Phi);
-            dPhi_dR = dPhi_dR * Phi;
-            dPhi_dz = dPhi_dz * Phi;
+            double dPhi_dz = gsl_spline2d_eval_deriv_y(spline, Rasinh, zasinh, xacc, yacc);
+            dPhi_dz = dPhi_dz / (Rscale * cosh(zasinh));
+
+            if (logScaling) {
+                double Phi = gsl_spline2d_eval(spline, Rasinh, zasinh, xacc, yacc);
+                Phi = -exp(Phi);
+                dPhi_dR = dPhi_dR * Phi;
+                dPhi_dz = dPhi_dz * Phi;
+            }
+
+            if (R > 0) {
+                grad.x[i] += dPhi_dR * q.x[i] / R;
+                grad.y[i] += dPhi_dR * q.y[i] / R;
+                grad.z[i] += dPhi_dz;
+            } else {
+                grad.z[i] += dPhi_dz;
+            }
+
+        } else {  // Use external Multipole
+            _mp_gradient_single(t, &pars[5 + nR + nz + nR * nz], double6ptr{q_in + i, N}, n_dim, double6ptr{grad_in + i, N}, state);
         }
-
-        if (R > 0) {
-            grad[0] = grad[0] + dPhi_dR * q[0] / R;
-            grad[1] = grad[1] + dPhi_dR * q[1] / R;
-            grad[2] = grad[2] + dPhi_dz;
-        } else {
-            grad[2] = grad[2] + dPhi_dz;
-        }
-
-    } else {  // Use external Multipole
-        mp_gradient_single(t, &pars[5 + nR + nz + nR * nz], q, n_dim, grad, state);
     }
+
     gsl_spline2d_free(spline);
     gsl_interp_accel_free(xacc);
     gsl_interp_accel_free(yacc);
@@ -807,9 +826,5 @@ double axisym_cylspline_density(double t, double *pars, double *q, int n_dim) {
 
     return dens;
 }
-
-DEFINE_VECTORIZED_GRADIENT(mp)
-DEFINE_VECTORIZED_GRADIENT(mpetd)
-DEFINE_VECTORIZED_GRADIENT(axisym_cylspline)
 
 #endif  // USE_GSL


### PR DESCRIPTION
### Describe your changes
This PR is a follow-up to #446 with the following changes:
1. applying vectorization to ruth4 and dop853
2. batching dop853 integration
3. specializing multipole and EXP gradient vectorization

The ruth4 and dop853 vectorization essentially means transposing the orbit arrays during integration. The ruth4 change is basically identical to leapfrog; dop853 is a bit different. Since it's used from a few places in Gala, some of which can't easily use the vectorization (e.g. N-body), I essentially just added a fast/transposed path (`Fwrapper_T`) while not touching the other paths.

Additionally, while benchmarking dop853, I noticed that it had an odd performance peak at intermediate numbers of orbits (both main and vectorized):

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/f44dbcbd-6479-4285-a17a-a61ab2188304" />

In looking at the dop853 source, it seems to be using a large number of intermediate arrays, so I think the performance decreases when these arrays start spilling cache. But as far as I can tell, the orbits are completely independent, so we can just do the integration in small, cache-sized batches:

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/ed4adf3c-bbd8-4de7-a51d-ba740512b155" />

Maybe this helps with #439.

And just to put all the improvements together on one plot:

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/15d4c610-e511-4447-a828-57d3aff59951" />

I also folded in "specialized" gradient vectorization for the multipole and EXP potentials. This just means writing the vectorized version of the gradient directly, rather than writing the single-particle version and letting the template wrapper generate the vectorized version. The benefit is that you can manually lift repeated computations out of the orbit loop. For EXP, for example, this lets us interpolate the coefficients once per timestep, instead of once per particle. I only did a cursory performance test, but it was something like 25% faster (and may matter more after EXP-code/EXP#157). It didn't seem to matter much for the `CylSplinePotential`, but I'm also not sure I was using it correctly.

I'll un-mark this as a draft once the first PR is merged, so we can target `main`.

### Checklist

- [ ] Did you add tests? (No, unless we want to add performance tests)
- [x] Did you add documentation for your changes? (Added in previous PR)
- [x] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`) (Added in previous PR)
- [ ] Are the CI tests passing?
- [ ] Is the milestone set?
