### PR TITLE
integrate: optimize save_all

### DIFF
--- a/gala/dynamics/core.py
+++ b/gala/dynamics/core.py
@@ -81,7 +81,7 @@ class PhaseSpacePosition:
         r.SphericalDifferential
     ]
 
-    def __init__(self, pos, vel=None, frame=None):
+    def __init__(self, pos, vel=None, frame=None, copy=True):
         """
         Represents phase-space positions, i.e. positions and conjugate momenta
         (velocities).
@@ -117,7 +117,10 @@ class PhaseSpacePosition:
             the note above about the assumed meaning of the axes of this object.
         frame : :class:`~gala.potential.FrameBase` (optional)
             The reference frame of the input phase-space positions.
-
+        copy : bool (optional)
+            If `True`, the input position and velocity data is copied. If
+            `False`, the input data is referenced directly (if possible).
+            Default is `True`.
         """
 
         if isinstance(pos, coord.Galactocentric):
@@ -126,7 +129,7 @@ class PhaseSpacePosition:
         if not isinstance(pos, coord.BaseRepresentation):
             # assume Cartesian if not specified
             if not hasattr(pos, "unit"):
-                pos *= u.one
+                pos = u.Quantity(pos, u.one, copy=copy)
 
             # 3D coordinates get special treatment
             ndim = pos.shape[0]
@@ -134,13 +137,13 @@ class PhaseSpacePosition:
                 # TODO: HACK: until this stuff is in astropy core
                 if isinstance(pos, coord.BaseRepresentation):
                     kw = [(k, getattr(pos, k)) for k in pos.components]
-                    pos = getattr(coord, pos.__class__.__name__)(**kw)
+                    pos = getattr(coord, pos.__class__.__name__)(**kw, copy=copy)
 
                 else:
-                    pos = coord.CartesianRepresentation(pos)
+                    pos = coord.CartesianRepresentation(pos, copy=copy)
 
             else:
-                pos = rep_nd.NDCartesianRepresentation(pos)
+                pos = rep_nd.NDCartesianRepresentation(pos, copy=copy)
 
         else:
             ndim = 3
@@ -157,15 +160,15 @@ class PhaseSpacePosition:
         if not isinstance(vel, coord.BaseDifferential):
             # assume representation is same as pos if not specified
             if not hasattr(vel, "unit"):
-                vel *= u.one
+                vel = u.Quantity(vel, u.one, copy=copy)
 
             if ndim == 3:
                 name = pos.__class__.get_name()
                 Diff = coord.representation.DIFFERENTIAL_CLASSES[name]
-                vel = Diff(*vel)
+                vel = Diff(*vel, copy=copy)
             else:
                 Diff = rep_nd.NDCartesianDifferential
-                vel = Diff(vel)
+                vel = Diff(vel, copy=copy)
 
         # make sure shape is the same
         if pos.shape != vel.shape:
@@ -479,7 +482,7 @@ class PhaseSpacePosition:
         return np.vstack((x, v))
 
     @classmethod
-    def from_w(cls, w, units=None, **kwargs):
+    def from_w(cls, w, units=None, copy=True, **kwargs):
         """Create a PhaseSpacePosition from a single array of positions and velocities.
 
         Parameters
@@ -492,6 +495,9 @@ class PhaseSpacePosition:
             The unit system that the input position+velocity array, ``w``,
             is represented in. If not provided, the array is assumed to be
             dimensionless.
+        copy : bool, optional
+            If `True`, the input array is copied. If `False`, the input data
+            is referenced directly (if possible). Default is `True`.
         **kwargs
             Additional keyword arguments passed to the class initializer.
 
@@ -502,7 +508,7 @@ class PhaseSpacePosition:
 
         """
 
-        w = np.array(w)
+        w = np.asarray(w)
 
         ndim = w.shape[0] // 2
         pos = w[:ndim]
@@ -512,10 +518,10 @@ class PhaseSpacePosition:
         # Dimensionless
         if units is not None and not isinstance(units, DimensionlessUnitSystem):
             units = UnitSystem(units)
-            pos *= units["length"]
-            vel = vel * units["length"] / units["time"]  # from _core_units
+            pos = u.Quantity(pos, units["length"], copy=copy)
+            vel = u.Quantity(vel, units["length"] / units["time"], copy=copy)
 
-        return cls(pos=pos, vel=vel, **kwargs)
+        return cls(pos=pos, vel=vel, copy=copy, **kwargs)
 
     # ------------------------------------------------------------------------
     # Input / output

--- a/gala/dynamics/orbit.py
+++ b/gala/dynamics/orbit.py
@@ -65,11 +65,16 @@ class Orbit(PhaseSpacePosition):
         stored as a dimensionless :class:`~astropy.units.Quantity`.
     hamiltonian : `~gala.potential.Hamiltonian` (optional)
         The Hamiltonian that the orbit was integrated in.
+    copy : bool, optional
+        If `True`, the input arrays are copied. If `False`, the input data
+        is referenced directly (if possible). Default is `True`.
 
     """
 
-    def __init__(self, pos, vel, t=None, hamiltonian=None, potential=None, frame=None):
-        super().__init__(pos=pos, vel=vel)
+    def __init__(
+        self, pos, vel, t=None, hamiltonian=None, potential=None, frame=None, copy=True
+    ):
+        super().__init__(pos=pos, vel=vel, copy=copy)
 
         if self.pos.ndim < 1:
             self.pos = self.pos.reshape(1)

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -218,9 +218,9 @@ cpdef dop853_integrate_hamiltonian(
         CFrameType cf = (<CFrameWrapper>(hamiltonian.frame.c_instance)).cframe
 
     if save_all:
-        wres = np.empty((ntimes, norbits, ndim))
+        wres = np.empty((ndim, ntimes, norbits))
     else:
-        wres = np.empty((norbits, ndim))
+        wres = np.empty((ndim, norbits))
 
     for i in range(0, norbits, nbatch):
         # do the integration in batches for performance
@@ -238,9 +238,9 @@ cpdef dop853_integrate_hamiltonian(
             transposed=1
         )
         if save_all:
-            wres[:, i:j, :] = wout
+            wres[:, :, i:j] = wout.transpose((2,0,1))
         else:
-            wres[i:j, :] = wout
+            wres[:, i:j] = wout.T
 
     if save_all:
         return np.asarray(t), np.asarray(wres)

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -91,10 +91,10 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
     if save_all:
-        all_w = np.zeros((ntimes, ndim, n))
+        all_w = np.empty((ndim, ntimes, n))
 
         # save initial conditions
-        all_w[0, :, :] = w0.T.copy()
+        all_w[:, 0, :] = w0.T
 
     tmp_w = w0.T.copy()
 
@@ -115,12 +115,12 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
             if save_all:
                 for k in range(ndim):
                     for i in range(n):
-                        all_w[j, k, i] = tmp_w[k, i]
+                        all_w[k, j, i] = tmp_w[k, i]
 
     if save_all:
-        return np.asarray(t), np.asarray(all_w).transpose(0,2,1)
+        return np.asarray(t), np.asarray(all_w)
     else:
-        return np.asarray(t[-1:]), np.array(tmp_w.T, copy=False)
+        return np.asarray(t[-1:]), np.asarray(tmp_w)
 
 # -------------------------------------------------------------------------------------
 # N-body stuff - TODO: to be moved, because this is a HACK!

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -89,10 +89,10 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
     if save_all:
-        all_w = np.zeros((ntimes, ndim, n))
+        all_w = np.empty((ndim, ntimes, n))
 
         # save initial conditions
-        all_w[0, :, :] = w0.T.copy()
+        all_w[:, 0, :] = w0.T
 
     tmp_w = w0.T.copy()
 
@@ -106,12 +106,12 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
             if save_all:
                 for k in range(ndim):
                     for i in range(n):
-                        all_w[j, k, i] = tmp_w[k, i]
+                        all_w[k, j, i] = tmp_w[k, i]
 
     if save_all:
-        return np.asarray(t), np.asarray(all_w).transpose(0,2,1)
+        return np.asarray(t), np.asarray(all_w)
     else:
-        return np.asarray(t[-1:]), np.asarray(tmp_w.T, copy=False)
+        return np.asarray(t[-1:]), np.asarray(tmp_w)
 
 
 # -------------------------------------------------------------------------------------

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -51,7 +51,6 @@ def test_compare_to_py(Integrator, integrate_func, dt):
     t = np.linspace(0, dt * n_steps, n_steps + 1)
 
     cy_t, cy_w = integrate_func(H, cy_w0, t)
-    cy_w = np.rollaxis(cy_w, -1)
 
     integrator = Integrator(F)
     orbit = integrator(py_w0, dt=dt, n_steps=n_steps)
@@ -84,7 +83,7 @@ def test_save_all(integrate_func, dt):
     t_f, w_f = integrate_func(H, w0, t, save_all=False)
 
     assert t_all[-1] == t_f[0]
-    assert np.allclose(w_all[-1], w_f)
+    assert np.allclose(w_all[:, -1], w_f)
 
 
 # TODO: move this to only run if a flag like --remote-data is passed, like

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -347,8 +347,6 @@ class Hamiltonian(CommonBase):
             else:
                 raise ValueError(f"Cython integration not supported for '{Integrator!r}'")
 
-            # because shape is different from normal integrator return
-            w = np.rollaxis(w, -1)
             if w.shape[-1] == 1:
                 w = w[..., 0]
 

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -369,8 +369,10 @@ class Hamiltonian(CommonBase):
         except (TypeError, AttributeError):
             tunit = u.dimensionless_unscaled
 
-        return Orbit.from_w(w=w, units=self.units, t=t*tunit,
-                            hamiltonian=self)
+        t = u.Quantity(t, tunit, copy=False)
+
+        return Orbit.from_w(w=w, units=self.units, t=t,
+                            hamiltonian=self, copy=False)
 
     # def save(self, f):
     #     """


### PR DESCRIPTION
### Describe your changes
This is a relatively small change to optimize orbit integrations with `save_all=True`. In general, turning on this option has resulting in puzzlingly slow integrations. Part of the bottleneck turns out to be making copies of the pos/vel arrays when wrapping them in `Quantity` objects during the output stage. This PR adds a `copy` kwarg to `PhaseSpacePosition` and `Orbit` to allow arrays to be passed though without copies.

The performance improvement is about 1.3x-2.5x, modest but worthwhile:

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/8d14ff9b-3fea-4924-9444-9eefdcf5c578" />

Note that the absolute performance is still lower than in #447 (`save_all=False`), but we do expect there to be some overhead to saving relatively large orbit arrays.


There is also a small change (not user-facing) to simplify the axis ordering of the output arrays. It avoids an unnecessary transpose then un-transpose.

This doesn't strictly require #447 but is easier to implement if merge that first. Will retarget main when that is done.

### Checklist

- [ ] Did you add tests? (No, changes are performance-only)
- [x] Did you add documentation for your changes? (Docstrings)
- [x] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`) (piggybacking on changelog entries from previous PRs)
- [ ] Are the CI tests passing?
- [ ] Is the milestone set?
