### PR TITLE
Fix some frame transforms that need a frame instance not class

### DIFF
--- a/docs/dynamics/mockstreams.rst
+++ b/docs/dynamics/mockstreams.rst
@@ -199,7 +199,7 @@ earliest time, then a stream is generated forward from the past time. This is pa
     ...                         pm_ra_cosdec=-2.296*u.mas/u.yr,
     ...                         pm_dec=-2.257*u.mas/u.yr,
     ...                         radial_velocity=-58.7*u.km/u.s)
-    >>> rep = pal5_c.transform_to(coord.Galactocentric).data
+    >>> rep = pal5_c.transform_to(coord.Galactocentric()).data
     >>> pal5_w0 = gd.PhaseSpacePosition(rep)
     >>> pal5_mass = 2.5e4 * u.Msun
     >>> pal5_pot = gp.PlummerPotential(m=pal5_mass, b=4*u.pc, units=galactic)
@@ -220,7 +220,7 @@ earliest time, then a stream is generated forward from the past time. This is pa
                             pm_ra_cosdec=-2.296*u.mas/u.yr,
                             pm_dec=-2.257*u.mas/u.yr,
                             radial_velocity=-58.7*u.km/u.s)
-    rep = pal5_c.transform_to(coord.Galactocentric).data
+    rep = pal5_c.transform_to(coord.Galactocentric()).data
     pal5_w0 = gd.PhaseSpacePosition(rep)
     pal5_mass = 2.5e4 * u.Msun
     pal5_pot = gp.PlummerPotential(m=pal5_mass, b=4*u.pc, units=galactic)

--- a/docs/dynamics/orbits-in-detail.rst
+++ b/docs/dynamics/orbits-in-detail.rst
@@ -129,7 +129,7 @@ coordinate frames. For example, to transform to
 :class:`~astropy.coordinates.Galactic` coordinates::
 
     >>> from astropy.coordinates import Galactic
-    >>> gal_c = w.to_coord_frame(Galactic)
+    >>> gal_c = w.to_coord_frame(Galactic())
     >>> gal_c # doctest: +FLOAT_CMP
     <Galactic Coordinate: (l, b, distance) in (deg, deg, kpc)
         [(4.40971301e-05, -6.23850462, 9.17891228),

--- a/docs/tutorials/mock-stream-heliocentric.rst
+++ b/docs/tutorials/mock-stream-heliocentric.rst
@@ -49,7 +49,7 @@ example. For the position and velocity of the cluster, we'll use
 
 We'll first convert this position and velocity to Galactocentric coordinates::
 
-   >>> c_gc = c.transform_to(coord.Galactocentric).cartesian
+   >>> c_gc = c.transform_to(coord.Galactocentric()).cartesian
    >>> c_gc
    <CartesianRepresentation (x, y, z) in kpc
       (7.86390455, 0.22748727, 16.41622487)
@@ -112,7 +112,7 @@ Here the negative timestep tells the stream generator to first integrate the orb
                    pm_dec=-2.257 * u.mas/u.yr,
                    radial_velocity=-58.7 * u.km/u.s)
 
-    c_gc = c.transform_to(coord.Galactocentric).cartesian
+    c_gc = c.transform_to(coord.Galactocentric()).cartesian
     pal5_w0 = gd.PhaseSpacePosition(c_gc)
 
     pal5_mass = 2.5e4 * u.Msun
@@ -130,13 +130,13 @@ Galactocentric coordinate frame. To convert these to observable, Heliocentric
 coordinates, we have to specify a desired coordinate frame. We'll convert to the
 ICRS coordinate system and plot some of the Heliocentric kinematic quantities::
 
-   >>> stream_c = pal5_stream.to_coord_frame(coord.ICRS)
+   >>> stream_c = pal5_stream.to_coord_frame(coord.ICRS())
 
 .. plot::
    :align: center
    :context: close-figs
 
-   stream_c = pal5_stream.to_coord_frame(coord.ICRS)
+   stream_c = pal5_stream.to_coord_frame(coord.ICRS())
 
    style = dict(marker='.', s=1, alpha=0.5)
 


### PR DESCRIPTION
### Describe your changes

This fixes a few old-style frame transformations that now require an instance (reported in #461).

### Checklist

- n/a Did you add tests?
- n/a Did you add documentation for your changes?
- [x] Did you reference any relevant issues?
- n/a Did you add a changelog entry? (see `CHANGES.rst`)
- [ ] Are the CI tests passing?
- [x] Is the milestone set?

Fixes #461 