### PR TITLE
potential: keep track of which parameters were set by the user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Bug fixes
 - Fixed a deprecation warning with astropy>=v7.1.
 - Fixed a matplotlib warning when plotting an orbit with ``plot()`` and
   ``autolim=True`` related to using ``aspect="equal"``.
+- ``replicate()`` and ``replace_units`` now work with ``EXPPotential``.
 
 API changes
 -----------

--- a/gala/potential/common.py
+++ b/gala/potential/common.py
@@ -118,6 +118,7 @@ class CommonBase:
             )
 
         parameter_values = {}
+        parameter_is_default = set()
 
         # Get any parameters passed as positional arguments
         i = 0
@@ -129,7 +130,11 @@ class CommonBase:
 
         # Get parameters passed in as keyword arguments:
         for k in expected_parameter_keys[i:]:
-            val = kwargs.pop(k, self._parameters[k].default)
+            if k in kwargs:
+                val = kwargs.pop(k)
+            else:
+                val = self._parameters[k].default
+                parameter_is_default.add(k)
             parameter_values[k] = val
 
         if kwargs:
@@ -138,7 +143,7 @@ class CommonBase:
                 f"argument(s): {list(kwargs.keys())}"
             )
 
-        return parameter_values
+        return parameter_values, parameter_is_default
 
     @classmethod
     def _prepare_parameters(cls, parameters, units):

--- a/gala/potential/frame/builtin/frames.pyx
+++ b/gala/potential/frame/builtin/frames.pyx
@@ -127,8 +127,8 @@ class ConstantRotatingFrame(CFrameBase):
     Omega = PotentialParameter('Omega', physical_type='frequency',
                                equivalencies=u.dimensionless_angles())
 
-    def _setup_frame(self, parameters, units=None):
-        super()._setup_frame(parameters, units=units)
+    def _setup_frame(self, parameters, parameter_is_default, units=None):
+        super()._setup_frame(parameters, parameter_is_default, units=units)
 
         Omega = np.atleast_1d(self.parameters['Omega'])
 

--- a/gala/potential/frame/core.py
+++ b/gala/potential/frame/core.py
@@ -8,9 +8,16 @@ class FrameBase(CommonBase):
     ndim = 3
 
     def __init__(self, *args, units=None, **kwargs):
-        parameter_values = self._parse_parameter_values(*args, **kwargs)
-        self._setup_frame(parameters=parameter_values, units=units)
+        parameter_values, parameter_is_default = self._parse_parameter_values(
+            *args, **kwargs
+        )
+        self._setup_frame(
+            parameters=parameter_values,
+            parameter_is_default=parameter_is_default,
+            units=units,
+        )
 
-    def _setup_frame(self, parameters, units=None):
+    def _setup_frame(self, parameters, parameter_is_default, units=None):
         self.units = self._validate_units(units)
         self.parameters = self._prepare_parameters(parameters, self.units)
+        self.parameter_is_default = set(parameter_is_default)

--- a/gala/potential/potential/builtin/core.py
+++ b/gala/potential/potential/builtin/core.py
@@ -700,9 +700,12 @@ class NFWPotential(CPotentialBase):
     b = PotentialParameter("b", physical_type="dimensionless", default=1.0)
     c = PotentialParameter("c", physical_type="dimensionless", default=1.0)
 
-    def _setup_potential(self, parameters, origin=None, R=None, units=None):
-        super()._setup_potential(parameters, origin=origin, R=R, units=units)
-
+    def _setup_potential(
+        self, parameters, parameter_is_default, origin=None, R=None, units=None
+    ):
+        super()._setup_potential(
+            parameters, parameter_is_default, origin=origin, R=R, units=units
+        )
         a = self.parameters["a"]
         b = self.parameters["b"]
         c = self.parameters["c"]

--- a/gala/potential/potential/builtin/pybuiltin.py
+++ b/gala/potential/potential/builtin/pybuiltin.py
@@ -26,9 +26,13 @@ class HarmonicOscillatorPotential(PotentialBase):
 
     omega = PotentialParameter("omega", physical_type="frequency")
 
-    def _setup_potential(self, parameters, origin=None, R=None, units=None):
+    def _setup_potential(
+        self, parameters, parameter_is_default, origin=None, R=None, units=None
+    ):
         parameters["omega"] = np.atleast_1d(parameters["omega"])
-        super()._setup_potential(parameters, origin=origin, R=R, units=units)
+        super()._setup_potential(
+            parameters, parameter_is_default, origin=origin, R=R, units=units
+        )
         self.ndim = len(self.parameters["omega"])
 
     def _energy(self, q, t=0.0):

--- a/gala/potential/potential/cpotential.pyx
+++ b/gala/potential/potential/cpotential.pyx
@@ -425,5 +425,10 @@ class CPotentialBase(PotentialBase):
             raise ValueError("Cannot replace a dimensionless unit system with "
                              "a unit system with physical units, or vice versa")
 
-        return self.__class__(**self.parameters, units=units,
-                              R=self.R, origin=self.origin)
+        parameters = {
+            k: v for k, v in self.parameters.items() if k not in self.parameter_is_default
+        }
+
+        return self.__class__(**parameters, units=units,
+                              R=self.R, origin=self.origin,
+                              )


### PR DESCRIPTION
### Describe your changes

In `EXPPotential`, we either accept `tmin`/`tmax` or `snapshot_index`, but not both. If one is given, the other is set to a default. This works fine until we try to do `exp_pot.replicate()` or `exp_pot.replace_units()`, because those try to pass all parameters, so we fail input validation, leading to #463.

This PR is one way of solving the problem, which is to track which parameters were set by default (in a set called `parameter_is_default`), and only pass non-default parameters when reconstituting a potential.

@adrn, not sure if this is the best way to solve the problem! It seems tracking which parameters are defaults could be generally useful, though.

Fixes #463.

### Checklist

- [x] Did you add tests?
- [ ] Did you add documentation for your changes?
- [x] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`)
- [x] Are the CI tests passing?
- [x] Is the milestone set?
