### PR TITLE
reduce transposes in gradient evaluation

### DIFF
--- a/gala/dynamics/mockstream/mockstream.pyx
+++ b/gala/dynamics/mockstream/mockstream.pyx
@@ -129,7 +129,6 @@ cpdef mockstream_dop853(
             atol, rtol, nmax, dt_max,
             nstiff=-1,  # disable stiffness check
             err_if_fail=err_if_fail, log_output=log_output, save_all=1,
-            transposed=0
         )
 
         n = 0

--- a/gala/dynamics/nbody/nbody.pyx
+++ b/gala/dynamics/nbody/nbody.pyx
@@ -106,12 +106,8 @@ cpdef direct_nbody_dop853(
             nstiff=-1,  # disable stiffness check - TODO: note somewhere
             err_if_fail=err_if_fail, log_output=log_output,
             save_all=save_all,
-            transposed=0
         )
-        if save_all:
-            return np.array(w)
-        else:
-            return np.array(w).reshape(nparticles, ndim)
+        return w
 
     finally:
         # Clean up allocated memory

--- a/gala/dynamics/tests/test_nonlinear.py
+++ b/gala/dynamics/tests/test_nonlinear.py
@@ -235,8 +235,8 @@ class TestLogarithmic:
         noffset = 2
 
         def F(t, w):
-            w_T = np.ascontiguousarray(w.T)
-            return self.hamiltonian._gradient(w_T, np.array([t])).T
+            w = np.ascontiguousarray(w)
+            return self.hamiltonian._gradient(w, np.array([t]))
 
         integrator = DOPRI853Integrator(F)
         for _ii, w0 in enumerate(self.w0s):

--- a/gala/integrate/cyintegrators/dop853.pxd
+++ b/gala/integrate/cyintegrators/dop853.pxd
@@ -69,7 +69,6 @@ cdef dop853_helper(
     int nstiff,
     unsigned err_if_fail,
     unsigned log_output,
-    int transposed,
     unsigned save_all=?
 )
 

--- a/gala/integrate/cyintegrators/dop853.pyx
+++ b/gala/integrate/cyintegrators/dop853.pyx
@@ -218,9 +218,9 @@ cpdef dop853_integrate_hamiltonian(
         CFrameType cf = (<CFrameWrapper>(hamiltonian.frame.c_instance)).cframe
 
     if save_all:
-        wres = np.empty((ntimes, norbits, ndim))
+        wres = np.empty((ndim, ntimes, norbits))
     else:
-        wres = np.empty((norbits, ndim))
+        wres = np.empty((ndim, norbits))
 
     for i in range(0, norbits, nbatch):
         # do the integration in batches for performance
@@ -238,9 +238,9 @@ cpdef dop853_integrate_hamiltonian(
             transposed=1
         )
         if save_all:
-            wres[:, i:j, :] = wout
+            wres[:, :, i:j] = wout.transpose((2,0,1))
         else:
-            wres[i:j, :] = wout
+            wres[:, i:j] = wout.T
 
     if save_all:
         return np.asarray(t), np.asarray(wres)

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -91,10 +91,10 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
     if save_all:
-        all_w = np.zeros((ntimes, ndim, n))
+        all_w = np.empty((ndim, ntimes, n))
 
         # save initial conditions
-        all_w[0, :, :] = w0.T.copy()
+        all_w[:, 0, :] = w0.T
 
     tmp_w = w0.T.copy()
 
@@ -115,12 +115,12 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
             if save_all:
                 for k in range(ndim):
                     for i in range(n):
-                        all_w[j, k, i] = tmp_w[k, i]
+                        all_w[k, j, i] = tmp_w[k, i]
 
     if save_all:
-        return np.asarray(t), np.asarray(all_w).transpose(0,2,1)
+        return np.asarray(t), np.asarray(all_w)
     else:
-        return np.asarray(t[-1:]), np.array(tmp_w.T, copy=False)
+        return np.asarray(t[-1:]), np.asarray(tmp_w)
 
 # -------------------------------------------------------------------------------------
 # N-body stuff - TODO: to be moved, because this is a HACK!

--- a/gala/integrate/cyintegrators/leapfrog.pyx
+++ b/gala/integrate/cyintegrators/leapfrog.pyx
@@ -54,9 +54,8 @@ cdef void c_leapfrog_step(CPotential *p, size_t n, int half_ndim, double t, doub
 cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1] t,
                                      int save_all=1):
     """
-    CAUTION: Interpretation of axes is different here! We need the
-    arrays to be C ordered and easy to iterate over, so here the
-    axes are (norbits, ndim).
+    w0: shape (ndim, n)
+    returns: shape (ndim, [ntimes,] n)
     """
 
     if not hamiltonian.c_enabled:
@@ -71,15 +70,14 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
     cdef:
         # temporary scalars
         int i, j, k
-        int n = w0.shape[0]
-        int ndim = w0.shape[1]
+        int ndim = w0.shape[0]
+        int n = w0.shape[1]
         int half_ndim = ndim // 2
 
         int ntimes = len(t)
         double dt = t[1]-t[0]
 
         # temporary array containers
-        # Input is (n, ndim), which we will transpose for vectorization
         double[:, ::1] grad_v = np.zeros((half_ndim, n))
         double[:, ::1] v_jm1_2 = np.zeros((half_ndim, n))
 
@@ -94,9 +92,9 @@ cpdef leapfrog_integrate_hamiltonian(hamiltonian, double [:, ::1] w0, double[::1
         all_w = np.empty((ndim, ntimes, n))
 
         # save initial conditions
-        all_w[:, 0, :] = w0.T
+        all_w[:, 0, :] = w0
 
-    tmp_w = w0.T.copy()
+    tmp_w = w0.copy()
 
     with nogil:
         # first initialize the velocities so they are evolved by a

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -89,10 +89,10 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
         CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
 
     if save_all:
-        all_w = np.zeros((ntimes, ndim, n))
+        all_w = np.empty((ndim, ntimes, n))
 
         # save initial conditions
-        all_w[0, :, :] = w0.T.copy()
+        all_w[:, 0, :] = w0.T
 
     tmp_w = w0.T.copy()
 
@@ -106,12 +106,12 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
             if save_all:
                 for k in range(ndim):
                     for i in range(n):
-                        all_w[j, k, i] = tmp_w[k, i]
+                        all_w[k, j, i] = tmp_w[k, i]
 
     if save_all:
-        return np.asarray(t), np.asarray(all_w).transpose(0,2,1)
+        return np.asarray(t), np.asarray(all_w)
     else:
-        return np.asarray(t[-1:]), np.array(tmp_w.T, copy=False)
+        return np.asarray(t[-1:]), np.asarray(tmp_w)
 
 
 # -------------------------------------------------------------------------------------

--- a/gala/integrate/cyintegrators/ruth4.pyx
+++ b/gala/integrate/cyintegrators/ruth4.pyx
@@ -39,9 +39,8 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
                                   double[::1] t,
                                   int save_all=1):
     """
-    CAUTION: Interpretation of axes is different here! We need the
-    arrays to be C ordered and easy to iterate over, so here the
-    axes are (norbits, ndim).
+    w0: shape (ndim, n)
+    returns: shape (ndim, [ntimes,] n)
     """
 
     if not hamiltonian.c_enabled:
@@ -55,8 +54,8 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
     cdef:
         # temporary scalars
         int i, j, k
-        int n = w0.shape[0]
-        int ndim = w0.shape[1]
+        int ndim = w0.shape[0]
+        int n = w0.shape[1]
         int half_ndim = ndim // 2
 
         int ntimes = len(t)
@@ -92,9 +91,9 @@ cpdef ruth4_integrate_hamiltonian(hamiltonian,
         all_w = np.empty((ndim, ntimes, n))
 
         # save initial conditions
-        all_w[:, 0, :] = w0.T
+        all_w[:, 0, :] = w0
 
-    tmp_w = w0.T.copy()
+    tmp_w = w0.copy()
 
     with nogil:
         for j in range(1, ntimes, 1):

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -51,7 +51,6 @@ def test_compare_to_py(Integrator, integrate_func, dt):
     t = np.linspace(0, dt * n_steps, n_steps + 1)
 
     cy_t, cy_w = integrate_func(H, cy_w0, t)
-    cy_w = np.rollaxis(cy_w, -1)
 
     integrator = Integrator(F)
     orbit = integrator(py_w0, dt=dt, n_steps=n_steps)
@@ -84,7 +83,7 @@ def test_save_all(integrate_func, dt):
     t_f, w_f = integrate_func(H, w0, t, save_all=False)
 
     assert t_all[-1] == t_f[0]
-    assert np.allclose(w_all[-1], w_f)
+    assert np.allclose(w_all[:, -1], w_f)
 
 
 # TODO: move this to only run if a flag like --remote-data is passed, like

--- a/gala/integrate/tests/test_cyintegrators.py
+++ b/gala/integrate/tests/test_cyintegrators.py
@@ -35,8 +35,8 @@ def test_compare_to_py(Integrator, integrate_func, dt):
     H = Hamiltonian(potential=p)
 
     def F(t, w):
-        w_T = np.ascontiguousarray(w.T)
-        return H._gradient(w_T, np.array([0.0])).T
+        w = np.ascontiguousarray(w)
+        return H._gradient(w, np.array([0.0]))
 
     cy_w0 = np.array(
         [
@@ -45,7 +45,8 @@ def test_compare_to_py(Integrator, integrate_func, dt):
             [0.0, 10.0, 0.0, 0.0, 0.0, 0.2],
         ]
     )
-    py_w0 = np.ascontiguousarray(cy_w0.T)
+    cy_w0 = np.ascontiguousarray(cy_w0.T)
+    py_w0 = cy_w0.copy()
 
     n_steps = 1024
     t = np.linspace(0, dt * n_steps, n_steps + 1)
@@ -56,7 +57,7 @@ def test_compare_to_py(Integrator, integrate_func, dt):
     orbit = integrator(py_w0, dt=dt, n_steps=n_steps)
 
     py_t = orbit.t.value
-    py_w = orbit.w()
+    py_w = orbit.w()  # (ndim, ntimes, n)
 
     assert py_w.shape == cy_w.shape
     assert np.allclose(cy_w[:, -1], py_w[:, -1])
@@ -75,6 +76,7 @@ def test_save_all(integrate_func, dt):
             [0.0, 10.0, 0.0, 0.0, 0.0, 0.2],
         ]
     )
+    w0 = np.ascontiguousarray(w0.T)
 
     # 1024 steps
     t = np.linspace(0, dt * 1024, 1024 + 1)

--- a/gala/potential/common.py
+++ b/gala/potential/common.py
@@ -204,15 +204,32 @@ class CommonBase:
 
         return atleast_2d(x, insert_axis=1).astype(np.float64)
 
-    def _get_c_valid_arr(self, x):
+    def _get_c_valid_arr(self, x, transpose=True):
         """
-        Warning! Interpretation of axes is different for C code.
+        Prepare an array for passing to C: make sure it's 2D and contiguous.
+
+        Parameters
+        ----------
+        x : array-like
+            The input array.
+        transpose : bool (optional)
+            If True, transpose the array so that shape is (N, ndim). Default is True.
+
+        Returns
+        -------
+        orig_shape : tuple
+            The original shape of the input array.
+        x : ndarray
+            The reshaped, contiguous array.
         """
         orig_shape = x.shape
-        x = np.ascontiguousarray(x.reshape(orig_shape[0], -1).T)
+        x = x.reshape(orig_shape[0], -1)  # 2D
+        if transpose:
+            x = x.T
+        x = np.ascontiguousarray(x)
         return orig_shape, x
 
-    def _validate_prepare_time(self, t, pos_c):
+    def _validate_prepare_time(self, t, N_pos):
         """
         Make sure that t is a 1D array and compatible with the C position array.
         """
@@ -224,7 +241,7 @@ class CommonBase:
 
         t = np.ascontiguousarray(t.ravel())
 
-        if len(t) > 1 and len(t) != pos_c.shape[0]:
+        if len(t) > 1 and len(t) != N_pos:
             raise ValueError(
                 "If passing in an array of times, it must have a shape "
                 "compatible with the input position(s)."

--- a/gala/potential/frame/cframe.pxd
+++ b/gala/potential/frame/cframe.pxd
@@ -13,7 +13,7 @@ cdef extern from "frame/src/cframe.h":
         double *parameters
 
     double frame_hamiltonian(CFrameType *fr, double t, double *qp, int n_dim) except + nogil
-    void frame_gradient(CFrameType *fr, double t, double *qp, int n_dim, double *dH) except + nogil
+    void frame_gradient(CFrameType *fr, double t, double *qp, int n_dim, size_t N, double *dH) except + nogil
     void frame_hessian(CFrameType *fr, double t, double *qp, int n_dim, double *d2H) except + nogil
 
 cdef class CFrameWrapper:

--- a/gala/potential/frame/cframe.pyx
+++ b/gala/potential/frame/cframe.pyx
@@ -57,11 +57,10 @@ cdef class CFrameWrapper:
 
         cdef double[:, ::1] dH = np.zeros((ndim, n))
         if len(t) == 1:
-            for i in range(n):
-                frame_gradient(&cf, t[0], &w[i, 0], ndim//2, &dH[i, 0])
+            frame_gradient(&cf, t[0], &w[0, 0], ndim//2, n, &dH[0, 0])
         else:
             for i in range(n):
-                frame_gradient(&cf, t[i], &w[i, 0], ndim//2, &dH[i, 0])
+                frame_gradient(&cf, t[i], &w[0, i], ndim//2, 1, &dH[0, i])
 
 
         return np.array(dH)

--- a/gala/potential/frame/cframe.pyx
+++ b/gala/potential/frame/cframe.pyx
@@ -48,14 +48,14 @@ cdef class CFrameWrapper:
 
     cpdef gradient(self, double[:, ::1] w, double[::1] t):
         """
-        w should have shape (n, ndim).
+        w should have shape (ndim, n).
         """
         cdef:
             int n, ndim, i
             CFrameType cf = self.cframe
-        n, ndim = _validate_pos_arr(w)
+        ndim, n = _validate_pos_arr(w)
 
-        cdef double[:, ::1] dH = np.zeros((n, ndim))
+        cdef double[:, ::1] dH = np.zeros((ndim, n))
         if len(t) == 1:
             for i in range(n):
                 frame_gradient(&cf, t[0], &w[i, 0], ndim//2, &dH[i, 0])

--- a/gala/potential/frame/src/cframe.cpp
+++ b/gala/potential/frame/src/cframe.cpp
@@ -7,8 +7,8 @@ double frame_hamiltonian(CFrameType *fr, double t, double *qp, int n_dim) {
     return v;
 }
 
-void frame_gradient(CFrameType *fr, double t, double *qp, int n_dim, double *dH) {
-    (fr->gradient)(t, (fr->parameters), qp, n_dim, 1, dH, NULL);
+void frame_gradient(CFrameType *fr, double t, double *qp, int n_dim, size_t N, double *dH) {
+    (fr->gradient)(t, (fr->parameters), qp, n_dim, N, dH, NULL);
 }
 
 void frame_hessian(CFrameType *fr, double t, double *qp, int n_dim, double *d2H) {

--- a/gala/potential/frame/src/cframe.h
+++ b/gala/potential/frame/src/cframe.h
@@ -18,5 +18,5 @@
 #endif
 
 extern double frame_hamiltonian(CFrameType *fr, double t, double *qp, int n_dim);
-extern void frame_gradient(CFrameType *fr, double t, double *qp, int n_dim, double *dH);
+extern void frame_gradient(CFrameType *fr, double t, double *qp, int n_dim, size_t N, double *dH);
 extern void frame_hessian(CFrameType *fr, double t, double *qp, int n_dim, double *d2H);

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -86,15 +86,15 @@ class Hamiltonian(CommonBase):
         return pot_E + other_E
 
     def _gradient(self, w, t):
-        q = np.ascontiguousarray(w[:, :self._pot_ndim])
+        q = np.ascontiguousarray(w[:self._pot_ndim])
 
         dH = np.zeros_like(w)
 
         # extra terms from the frame
         dH += self.frame._gradient(w, t=t)
-        dH[:, self._pot_ndim:] += self.potential._gradient(q, t=t)
+        dH[self._pot_ndim:] += self.potential._gradient(q, t=t)
         for i in range(self._pot_ndim):
-            dH[:, self._pot_ndim+i] = -dH[:, self._pot_ndim+i]
+            dH[self._pot_ndim+i] = -dH[self._pot_ndim+i]
 
         return dH
 
@@ -124,7 +124,7 @@ class Hamiltonian(CommonBase):
         """
         w = self._remove_units_prepare_shape(w)
         orig_shape, w = self._get_c_valid_arr(w)
-        t = self._validate_prepare_time(t, w)
+        t = self._validate_prepare_time(t, len(w))
         return self._energy(w, t=t).T.reshape(orig_shape[1:]) * self.units['energy'] / self.units['mass']
 
     def gradient(self, w, t=0.):
@@ -146,12 +146,15 @@ class Hamiltonian(CommonBase):
             the input phase-space position, ``w``.
         """
         w = self._remove_units_prepare_shape(w)
-        orig_shape, w = self._get_c_valid_arr(w)
-        t = self._validate_prepare_time(t, w)
+
+        # transpose=False because the gradient functions expect (ndim, N) arrays
+        orig_shape, w = self._get_c_valid_arr(w, transpose=False)
+
+        t = self._validate_prepare_time(t, w.shape[1])
 
         # TODO: wat do about units here?
         # ret_unit = self.units['length'] / self.units['time']**2
-        return self._gradient(w, t=t).T.reshape(orig_shape)
+        return self._gradient(w, t=t).reshape(orig_shape)
 
     def hessian(self, w, t=0.):
         """
@@ -188,7 +191,7 @@ class Hamiltonian(CommonBase):
 
     #     w = self._remove_units_prepare_shape(w)
     #     orig_shape, w = self._get_c_valid_arr(w)
-    #     t = self._validate_prepare_time(t, w)
+    #     t = self._validate_prepare_time(t, len(w))
 
     #     E = self._energy(w, t=t).T.reshape(orig_shape[1:])
     #     L = np.cross(w[:, :3], w[:, 3:])
@@ -316,7 +319,9 @@ class Hamiltonian(CommonBase):
         ndim = w0.ndim
         arr_w0 = w0.w(self.units)
         arr_w0 = self._remove_units_prepare_shape(arr_w0)
-        orig_shape, arr_w0 = self._get_c_valid_arr(arr_w0)
+
+        # transpose=False because the gradient functions expect (ndim, N) arrays
+        orig_shape, arr_w0 = self._get_c_valid_arr(arr_w0, transpose=False)
 
         if self.c_enabled and cython_if_possible:
             # array of times
@@ -352,11 +357,10 @@ class Hamiltonian(CommonBase):
 
         else:
             def F(t, w):
-                # TODO: these Transposes are shitty and probably make it much slower?
-                w_T = np.ascontiguousarray(w.T)
-                return self._gradient(w_T, t=np.array([t])).T
+                w = np.ascontiguousarray(w)
+                return self._gradient(w, t=np.array([t]))
             integrator = Integrator(F, func_units=self.units, **Integrator_kwargs)
-            orbit = integrator(arr_w0.T, **time_spec)
+            orbit = integrator(arr_w0, **time_spec)
             orbit.potential = self.potential
             orbit.frame = self.frame
             return orbit

--- a/gala/potential/hamiltonian/chamiltonian.pyx
+++ b/gala/potential/hamiltonian/chamiltonian.pyx
@@ -347,8 +347,6 @@ class Hamiltonian(CommonBase):
             else:
                 raise ValueError(f"Cython integration not supported for '{Integrator!r}'")
 
-            # because shape is different from normal integrator return
-            w = np.rollaxis(w, -1)
             if w.shape[-1] == 1:
                 w = w[..., 0]
 

--- a/gala/potential/potential/builtin/pybuiltin.py
+++ b/gala/potential/potential/builtin/pybuiltin.py
@@ -36,8 +36,9 @@ class HarmonicOscillatorPotential(PotentialBase):
         return np.sum(0.5 * om[None] ** 2 * q**2, axis=1)
 
     def _gradient(self, q, t=0.0):
-        om = np.atleast_1d(self.parameters["omega"].value)
-        return om[None] ** 2 * q
+        om = self.parameters["omega"].value
+        om = np.atleast_2d(om).T
+        return om**2 * q
 
     def _hessian(self, q, t=0.0):
         om = np.atleast_1d(self.parameters["omega"].value)

--- a/gala/potential/potential/core.py
+++ b/gala/potential/potential/core.py
@@ -255,13 +255,14 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
 
         return x
 
-    def _reapply_units_and_shape(self, x, ptype, shape, conv_unit=None):
+    def _reapply_units_and_shape(self, x, ptype, shape, conv_unit=None, transpose=True):
         """
         This is the inverse of _remove_units_prepare_shape. It takes the output of one
         of the C functions below and reapplies units and the original shape.
         ptype is an Astropy PhysicalType object
         """
-        x = np.moveaxis(x, 0, -1)
+        if transpose:
+            x = np.moveaxis(x, 0, -1)
         if isinstance(ptype, u.PhysicalType):
             uu = self.units[ptype]
         elif isinstance(ptype, str):
@@ -314,7 +315,7 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
         """
         q = self._remove_units_prepare_shape(q)
         orig_shape, q = self._get_c_valid_arr(q)
-        t = self._validate_prepare_time(t, q)
+        t = self._validate_prepare_time(t, len(q))
         return self._reapply_units_and_shape(
             self._energy(q, t=t),
             ptype=u.get_physical_type("energy") / u.get_physical_type("mass"),
@@ -356,10 +357,16 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
             \\vec{a} = -\\nabla \\phi = -\\frac{\\partial \\phi}{\\partial \\vec{q}}
         """
         q = self._remove_units_prepare_shape(q)
-        orig_shape, q = self._get_c_valid_arr(q)
-        t = self._validate_prepare_time(t, q)
+
+        # transpose=False because the gradient functions expect (ndim, N) arrays
+        orig_shape, q = self._get_c_valid_arr(q, transpose=False)
+
+        t = self._validate_prepare_time(t, q.shape[1])
         return self._reapply_units_and_shape(
-            self._gradient(q, t=t), u.get_physical_type("acceleration"), orig_shape
+            self._gradient(q, t=t),
+            u.get_physical_type("acceleration"),
+            orig_shape,
+            transpose=False,
         )
 
     def density(self, q, t=0.0):
@@ -405,7 +412,7 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
         """
         q = self._remove_units_prepare_shape(q)
         orig_shape, q = self._get_c_valid_arr(q)
-        t = self._validate_prepare_time(t, q)
+        t = self._validate_prepare_time(t, len(q))
         return self._reapply_units_and_shape(
             self._density(q, t=t), u.get_physical_type("mass density"), orig_shape[1:]
         )
@@ -466,7 +473,7 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
             )
         q = self._remove_units_prepare_shape(q)
         orig_shape, q = self._get_c_valid_arr(q)
-        t = self._validate_prepare_time(t, q)
+        t = self._validate_prepare_time(t, len(q))
         return self._reapply_units_and_shape(
             self._hessian(q, t=t),
             u.get_physical_type("frequency drift"),
@@ -552,7 +559,7 @@ class PotentialBase(CommonBase, metaclass=abc.ABCMeta):
         """
         q = self._remove_units_prepare_shape(q)
         orig_shape, q = self._get_c_valid_arr(q)
-        t = self._validate_prepare_time(t, q)
+        t = self._validate_prepare_time(t, len(q))
 
         # small step-size in direction of q
         h = 1e-3  # MAGIC NUMBER

--- a/gala/potential/potential/tests/helpers.py
+++ b/gala/potential/potential/tests/helpers.py
@@ -317,7 +317,9 @@ class PotentialTestBase:
                     for dim_ix in range(self.w0.size // 2)
                 ]
             )
-        grad = self.potential._gradient(xyz, t=np.array([0.0]))
+        grad = self.potential._gradient(
+            np.ascontiguousarray(xyz.T), t=np.array([0.0])
+        ).T
         np.testing.assert_allclose(grad, num_grad, rtol=self.tol, atol=1e-8)
 
     def test_orbit_integration(self, t1=0.0, t2=1000.0, nsteps=10000):

--- a/gala/potential/potential/tests/test_composite.py
+++ b/gala/potential/potential/tests/test_composite.py
@@ -133,8 +133,9 @@ class MyPotential(gp.PotentialBase):
     def _gradient(self, x, t):
         m = self.parameters["m"]
         x0 = self.parameters["x0"]
-        r = np.sqrt(np.sum((x - x0[None]) ** 2, axis=1))
-        return m * (x - x0[None]) / r**3
+        x0 = np.atleast_2d(x0).T
+        r = np.sqrt(np.sum((x - x0) ** 2, axis=0))
+        return m * (x - x0) / r**3
 
 
 def test_add():

--- a/gala/potential/potential/tests/test_core.py
+++ b/gala/potential/potential/tests/test_core.py
@@ -57,8 +57,9 @@ class MyPotential(PotentialBase):
     def _gradient(self, x, t):
         m = self.parameters["m"].value
         x0 = self.parameters["x0"].value
-        r = np.sqrt(np.sum((x - x0[None]) ** 2, axis=1))
-        return m * (x - x0[None]) / r**3
+        x0 = np.atleast_2d(x0).T
+        r = np.sqrt(np.sum((x - x0) ** 2, axis=0))
+        return m * (x - x0) / r**3
 
 
 def test_init_potential():

--- a/gala/potential/potential/util.py
+++ b/gala/potential/potential/util.py
@@ -118,10 +118,9 @@ def from_equation(expr, vars, pars, name=None, hessian=False):
                 kw[k] = v.value
 
             for i, name in enumerate(var_names):
-                kw[name] = w[:, i]
+                kw[name] = w[i, :]
 
-            grad = np.vstack([f(**kw)[np.newaxis] for f in gradfuncs])
-            return grad.T
+            return np.vstack([f(**kw)[np.newaxis] for f in gradfuncs])
 
     if name is not None:
         # name = _classnamify(name)


### PR DESCRIPTION
### Describe your changes
In #446, we modified the gradient functions to make them vectorization-friendly. As part of this, we transposed the input arrays to shape `(ndim, n)` before passing them to the C level. However, as pointed out by @adrn, the arrays actually start in this shape when the user constructs a `PhaseSpacePosition` at the Python level! So the right thing to do is to just keep the arrays in that shape as we pass them to the C level. That is what this PR implements.

The major changes are:
- `_get_c_valid_arr()` now takes a `transpose` kwarg. `gradient()` in `PotentialBase` sets this to `False` (likewise for `_reapply_units_and_shape` for the output).
- All of the `_gradient()` internal functions called by `gradient()` now use shape `(ndim, n)`
- The frame gradients were likewise updated to use this shape (probably could have been done before, but it would have involved more transposes)
- leapfrog and ruth4 avoid a transpose of the inputs and outputs
- dop853 has the same change, although in detail the integrator doesn't care about the ordering of the axes; the interpretation is up to the Fwrapper function. `dop853_helper` will now at least return the result in the same shape as the input.

One potentially confusing aspect going forward is that the gradient path now uses different shapes than the energy/density/hessian paths. I tried to add shape annotations to the internal gradient functions to make this clear. None of these changes should be user-facing, but this might come up during development/maintenance.

Integration performance gains are about 20-30% in the limit of many particles and few time steps.

### Checklist

- [x] Did you add tests? (Didn't add any tests, but updated existing ones where they were using internal `_gradient()` functions)
- [ ] Did you add documentation for your changes? (Not user-facing)
- [x] Did you reference any relevant issues?
- [ ] Did you add a changelog entry? (see `CHANGES.rst`)
- [ ] Are the CI tests passing?
- [ ] Is the milestone set?
