### PR TITLE
Raise an error if users try to integrate past interpolation bounds for a `TimeInterpolatedPotential`

### DIFF
--- a/src/gala/potential/potential/builtin/time_interpolated.py
+++ b/src/gala/potential/potential/builtin/time_interpolated.py
@@ -9,10 +9,10 @@ import copy
 
 import numpy as np
 
+from ....integrate.timespec import parse_time_specification
 from ...common import PotentialParameter
 from ..cpotential import CPotentialBase
 from .cytimeinterp import TimeInterpolatedWrapper
-from ....integrate.timespec import parse_time_specification
 
 __all__ = ["TimeInterpolatedPotential"]
 
@@ -347,8 +347,15 @@ class TimeInterpolatedPotential(CPotentialBase, GSL_only=True):
             **new_kwargs,
         )
 
-    def integrate_orbit(self, w0, Integrator=None, Integrator_kwargs={},
-                        cython_if_possible=True, save_all=True, **time_spec):
+    def integrate_orbit(
+        self,
+        w0,
+        Integrator=None,
+        Integrator_kwargs=None,
+        cython_if_possible=True,
+        save_all=True,
+        **time_spec,
+    ):
         """
         Integrate an orbit in the current potential using the integrator class
         provided. Uses same time specification as `Integrator()` -- see
@@ -379,6 +386,8 @@ class TimeInterpolatedPotential(CPotentialBase, GSL_only=True):
         -------
         orbit : `~gala.dynamics.Orbit`
         """
+        if Integrator_kwargs is None:
+            Integrator_kwargs = {}
         t = parse_time_specification(self.units, **time_spec)
 
         # ensure timesteps are within the range of time_knots
@@ -391,10 +400,14 @@ class TimeInterpolatedPotential(CPotentialBase, GSL_only=True):
                 f"your orbit integration range is [{min(t)}, {max(t)}] {self.units['time']}"
             )
 
-        return super().integrate_orbit(w0, Integrator=Integrator,
-                                       Integrator_kwargs=Integrator_kwargs,
-                                       cython_if_possible=cython_if_possible,
-                                       save_all=save_all, t=t)
+        return super().integrate_orbit(
+            w0,
+            Integrator=Integrator,
+            Integrator_kwargs=Integrator_kwargs,
+            cython_if_possible=cython_if_possible,
+            save_all=save_all,
+            t=t,
+        )
 
     def __repr__(self):
         return (

--- a/tests/potential/potential/test_time_interpolated.py
+++ b/tests/potential/potential/test_time_interpolated.py
@@ -505,18 +505,15 @@ def test_integration_outside_interpolation_range():
         units=galactic,
     )
 
-    w0 = gd.PhaseSpacePosition(
-        pos = [8, 0, 0] * u.kpc,
-        vel = [0, 100, 0] * u.km/u.s
-    )
+    w0 = gd.PhaseSpacePosition(pos=[8, 0, 0] * u.kpc, vel=[0, 100, 0] * u.km / u.s)
 
     # Single-element array should raise ValueError (ambiguous: constant or interpolated?)
     with pytest.raises(ValueError, match="Integration times must be within the range"):
         pot.integrate_orbit(
             w0,
             t1=0 * u.Myr,
-            t2=200 * u.Myr,         # max time is beyond max time knots time (100 Myr)
-            dt=1 * u.Myr
+            t2=200 * u.Myr,  # max time is beyond max time knots time (100 Myr)
+            dt=1 * u.Myr,
         )
 
 


### PR DESCRIPTION
### Describe your changes

I added ``integrate_orbit`` to the ``TimeInterpolatedPotential`` class, which first checks the time specification is valid, before passing it to the ``super()`` instance of ``integrate_orbit``

I also fixed the __repr__, it was raising an error before if I tried to print it out in a notebook. @adrn I'd check that bit in particular, I _think_ this is what you wanted printed?

### Checklist

- [x] Did you add tests?
- [x] Did you add documentation for your changes?
- [x] Did you reference any relevant issues?
- [x] Did you add a changelog entry? (see `CHANGES.rst`)
- [x] Are the CI tests passing?
- [x] Is the milestone set?
