### PR TITLE
docs: update macos openmp instructions

### DIFF
--- a/docs/tutorials/exp.rst
+++ b/docs/tutorials/exp.rst
@@ -42,11 +42,20 @@ Here is another recipe using modules that has been found to work on Flatiron Ins
 
 EXP also builds on Mac by installing the dependencies with Homebrew::
 
-    brew install cmake eigen@3 fftw hdf5 open-mpi git ninja llvm libomp
+    brew install cmake eigen@3 fftw hdf5 open-mpi git ninja libomp
 
-Note that building Gala-EXP requires OpenMP support, and the Apple Clang compiler shipped with MacOS does
-not support OpenMP. Therefore, the above command installs ``llvm`` and ``libomp``, which are the LLVM Clang
-compiler and OpenMP runtime.
+Note that building Gala-EXP requires OpenMP support. The Apple Clang compiler shipped
+with macOS does not support ``-fopenmp`` directly, but Gala's build system will
+automatically use the correct flags (``-Xpreprocessor -fopenmp`` with ``libomp`` from
+Homebrew). This works with both Apple Clang and LLVM Clang from Homebrew.
+
+By default, the build expects ``libomp`` at ``/opt/homebrew/opt/libomp``. If it is
+installed elsewhere, set the ``LIBOMP_PREFIX`` environment variable::
+
+    export LIBOMP_PREFIX=/path/to/libomp
+
+Installing ``llvm`` from Homebrew is not required for building Gala, but may be needed
+for building EXP itself.
 
 After installing the dependencies, one can download and build EXP on Linux with::
 

--- a/setup.py
+++ b/setup.py
@@ -485,8 +485,21 @@ for ext in extensions:
             if extra_incl_flags is not None:
                 ext.extra_compile_args.extend(extra_incl_flags)
 
-            ext.extra_compile_args.extend(["-fopenmp"])
-            ext.extra_link_args.extend(["-fopenmp"])
+            # OpenMP support: macOS with Apple Clang requires different flags
+            if sys.platform == "darwin":
+                # Apple Clang doesn't support -fopenmp directly; use
+                # -Xpreprocessor -fopenmp with libomp from Homebrew. This also
+                # works with LLVM Clang from Homebrew.
+                libomp_prefix = os.environ.get(
+                    "LIBOMP_PREFIX", "/opt/homebrew/opt/libomp"
+                )
+                ext.include_dirs.append(os.path.join(libomp_prefix, "include"))
+                ext.library_dirs.append(os.path.join(libomp_prefix, "lib"))
+                ext.extra_compile_args.extend(["-Xpreprocessor", "-fopenmp"])
+                ext.extra_link_args.extend(["-lomp"])
+            else:
+                ext.extra_compile_args.extend(["-fopenmp"])
+                ext.extra_link_args.extend(["-fopenmp"])
 
             if "exp" not in ext.libraries:
                 ext.libraries.extend(


### PR DESCRIPTION
Not sure if we also need to instruct people to set `CC` and `CXX` to the LLVM compiler, or if it will be the default. @adrn maybe you could test this?