### PR TITLE
Fix legacy DOP853 wrapper to honor nstiff

### DIFF
--- a/src/gala/integrate/cyintegrators/dop853.pyx
+++ b/src/gala/integrate/cyintegrators/dop853.pyx
@@ -61,7 +61,7 @@ cdef void dop853_step(
         dt0,  # h: Initial step size
         nmax,  # nmax: maximum number of integration steps
         0,  # meth
-        1,  # nstiff: frequency of stiffness detect
+        nstiff,  # nstiff: frequency of stiffness detect
         0,  # nrdens: number of components for dense output
         NULL,  # icont: indices for components
         0,  # licont: length of the icont array


### PR DESCRIPTION
This fixes a regression introduced in commit [`d7c69a68`](https://github.com/adrn/gala/commit/d7c69a6896f81f999ac26c519cdf6041d79b45b7) on October 20, 2025 (`add option to disable stiffness check for mockstream (and lyapunov)`).

That change added an `nstiff` argument to the legacy `dop853_step()` wrapper used by Lyapunov and mockstream code paths%