### PR TITLE
ci: test against main and devel weekly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,12 @@ on:
     tags:
       - "*"
   pull_request:
-  schedule:
-    - cron: "0 10 * * 1"  # Mondays @ 6AM Eastern
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to test (branch, tag, or SHA). Empty = the ref that triggered the run."
+        type: string
+        default: ""
 
 jobs:
   check_skip_flags:
@@ -22,7 +26,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          ref: ${{ env.GITHUB_SHA }}
+          ref: ${{ inputs.ref || env.GITHUB_SHA }}
       - name: Get head commit message
         id: get_head_commit_message
         run: echo "HEAD_COMMIT_MESSAGE=$(git show -s --format=%s)" >> "$GITHUB_OUTPUT"
@@ -40,7 +44,7 @@ jobs:
       !contains(needs.check_skip_flags.outputs.head-commit-message, '[skip tests]') }}
     env:
       # Run tests against a tagged EXP version, unless this is the devel branch or a PR into devel, in which case test against EXP devel
-      EXP_REF: ${{ (github.ref == 'refs/heads/devel' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devel')) && 'devel' || 'v7.10.0' }}
+      EXP_REF: ${{ (inputs.ref == 'devel' || github.ref == 'refs/heads/devel' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devel')) && 'devel' || 'v7.10.0' }}
       MACOSX_DEPLOYMENT_TARGET: "15.0"
     strategy:
       fail-fast: true
@@ -106,6 +110,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,18 @@
+name: Weekly Tests
+
+on:
+  schedule:
+    - cron: "0 10 * * 1"  # Mondays @ 6AM Eastern
+  workflow_dispatch:  # allow manual triggering for testing
+
+jobs:
+  weekly:
+    name: Weekly tests on ${{ matrix.branch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, devel]
+    uses: ./.github/workflows/tests.yml
+    with:
+      ref: ${{ matrix.branch }}
+    secrets: inherit


### PR DESCRIPTION
### Describe your changes

We want to make sure that Gala remains compatible with `EXP/devel`, so we'll schedule our `devel` tests (which use `EXP/devel`) to run weekly. Tests in our `main` continue to run weekly against a tagged EXP version.

To my/Claude's understanding, scheduled GitHub tests only run on the default branch. So what this PR does is set up the default branch weekly tests as a matrix of `[main, devel]` and check out the appropriate one once the run has kicked off.

Follow-up to #593.

---

Relatedly: @adrn thanks for restoring the `devel` branch. I think you can add a branch protection rule to prevent it from being deleted again: https://github.com/adrn/gala/settings/rules/new?target=branch

(Apologies if you already did so; `gh ruleset check` says it's not protected, but I'm not sure if I have permission to see all rulesets.)

### Checklist

- [ ] Did you add tests?
- [ ] Did you add documentation for your changes?
- [ ] Did you reference any relevant issues?
- [ ] Did you add a changelog entry? (see `CHANGES.rst`)
- [ ] Are the CI tests passing?
- [ ] Is the milestone set?
