### PR TITLE
[WIP] support SDE integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 # add a non-generated .c extension, use `git add -f filename.c`.
 # *.c
 src/gala/_compiler.c
+src/gala/dynamics/diffusion/cydiffusion.cpp
 src/gala/dynamics/lyapunov/dop853_lyapunov.cpp
 src/gala/dynamics/mockstream/_coord.cpp
 src/gala/dynamics/mockstream/mockstream.cpp

--- a/setup.py
+++ b/setup.py
@@ -309,6 +309,20 @@ def get_all_extensions():
     )
     extensions.append(Extension("gala.integrate.cyintegrators.ruth4", **cfg))
 
+    # ===== gala.dynamics extensions =====
+
+    #     diffusion (trial SDE / diffusion integrator)
+    cfg = base_cfg()
+    cfg["include_dirs"].extend(["src/gala", "src/gala/potential"])
+    cfg["sources"].extend(
+        [
+            "src/gala/dynamics/diffusion/cydiffusion.pyx",
+            "src/gala/dynamics/diffusion/src/diffusion.cpp",
+            "src/gala/potential/potential/src/cpotential.cpp",
+        ]
+    )
+    extensions.append(Extension("gala.dynamics.diffusion.cydiffusion", **cfg))
+
     # ===== gala.potential extensions =====
 
     #     cpotential
@@ -459,9 +473,11 @@ for ext in extensions:
     ext.extra_compile_args.extend(["-Ofast"])
     ext.extra_link_args.extend(["-Ofast"])
 
-    if ("potential.potential" in ext.name or "scf" in ext.name) and (
-        gsl_version is not None
-    ):
+    if (
+        "potential.potential" in ext.name
+        or "scf" in ext.name
+        or "diffusion" in ext.name
+    ) and (gsl_version is not None):
         if "gsl" not in ext.libraries:
             ext.libraries.append("gsl")
             ext.library_dirs.append(os.path.join(gsl_prefix, "lib"))

--- a/src/gala/dynamics/__init__.py
+++ b/src/gala/dynamics/__init__.py
@@ -1,5 +1,6 @@
 from .actionangle import *
 from .core import PhaseSpacePosition
+from .diffusion import *
 from .mockstream import *
 from .nbody import *
 from .nonlinear import *

--- a/src/gala/dynamics/diffusion/__init__.py
+++ b/src/gala/dynamics/diffusion/__init__.py
@@ -1,0 +1,2 @@
+from .core import *
+from .diffusion_models import *

--- a/src/gala/dynamics/diffusion/core.py
+++ b/src/gala/dynamics/diffusion/core.py
@@ -1,0 +1,143 @@
+"""
+A standalone orchestrator (modeled on ``DirectNBody``) that integrates orbits
+with an added stochastic velocity-diffusion term, using a fixed-step leapfrog +
+Euler-Maruyama scheme implemented in Cython.
+"""
+
+import astropy.units as u
+import numpy as np
+
+from ...integrate.timespec import parse_time_specification
+from ...potential import Hamiltonian, StaticFrame
+from ...units import UnitSystem
+from ...util import atleast_2d
+from ..core import PhaseSpacePosition
+from ..orbit import Orbit
+from .cydiffusion import stochastic_leapfrog_integrate
+from .diffusion_models import DiffusionBase
+
+__all__ = ["StochasticOrbitIntegrator"]
+
+
+class StochasticOrbitIntegrator:
+    """Integrate tracer orbits with stochastic (diffusive) velocity kicks.
+
+    This is a trial implementation of an SDE integrator: the deterministic
+    dynamics come from a (static-frame) potential and are advanced with a
+    symplectic leapfrog step, and a stochastic velocity kick set by a diffusion
+    model is added each step (Euler-Maruyama). With a zero diffusion model this
+    reduces to ordinary leapfrog integration.
+
+    Parameters
+    ----------
+    potential : `~gala.potential.PotentialBase` subclass instance
+        The (C-enabled) background potential the orbits are integrated in.
+    diffusion : `~gala.dynamics.diffusion.DiffusionBase` subclass instance
+        The velocity-space diffusion model.
+    frame : `~gala.potential.frame.FrameBase` subclass (optional)
+        The reference frame. Only static frames are currently supported.
+    units : `~gala.units.UnitSystem` (optional)
+        The unit system to work in. If not provided, taken from the potential.
+    seed : int (optional)
+        Seed for the random number generator, for reproducibility. If not
+        provided, a random seed is drawn.
+    """
+
+    def __init__(self, potential, diffusion, frame=None, units=None, seed=None):
+        if units is None:
+            units = getattr(potential, "units", None)
+        if units is None:
+            units = getattr(diffusion, "units", None)
+        if units is None:
+            raise ValueError(
+                "Could not determine units from input! Pass in a unit system "
+                "with `units`, or use a potential with a valid unit system."
+            )
+        if not isinstance(units, UnitSystem):
+            units = UnitSystem(units)
+        self.units = units
+
+        if not isinstance(diffusion, DiffusionBase):
+            raise TypeError(
+                "`diffusion` must be a "
+                "gala.dynamics.diffusion.DiffusionBase instance, not "
+                f"'{type(diffusion).__name__}'"
+            )
+        if diffusion.units != self.units:
+            diffusion = diffusion.replace_units(self.units)
+        self.diffusion = diffusion
+
+        if getattr(potential, "units", None) != self.units:
+            potential = potential.replace_units(self.units)
+        self.potential = potential
+
+        if frame is None:
+            frame = StaticFrame(self.units)
+        elif not isinstance(frame, StaticFrame):
+            raise ValueError(
+                "The diffusion integrator currently only supports static "
+                f"frames, not '{type(frame).__name__}'."
+            )
+        self.frame = frame
+
+        self.H = Hamiltonian(self.potential, frame=self.frame)
+        if not self.H.c_enabled:
+            raise ValueError(
+                "Input potential must be C-enabled: one or more components in "
+                "the input potential are Python-only."
+            )
+
+        if seed is None:
+            seed = int(np.random.default_rng().integers(0, 2**63 - 1))
+        self.seed = int(seed)
+
+    def __repr__(self):
+        return (
+            f"<StochasticOrbitIntegrator potential={self.potential!r}, "
+            f"diffusion={self.diffusion!r}>"
+        )
+
+    def integrate_orbit(self, w0, save_all=True, **time_spec):
+        """Integrate the initial conditions with stochastic velocity kicks.
+
+        Parameters
+        ----------
+        w0 : `~gala.dynamics.PhaseSpacePosition`, array_like
+            Initial conditions.
+        save_all : bool (optional)
+            Save the phase-space position at all timesteps. If False, only the
+            final state is returned.
+        **time_spec
+            Time specification, e.g. ``dt`` and ``n_steps``. Must produce a
+            fixed timestep. See
+            `~gala.integrate.parse_time_specification`.
+
+        Returns
+        -------
+        orbit : `~gala.dynamics.Orbit`
+        """
+        if isinstance(w0, PhaseSpacePosition):
+            arr_w0 = w0.w(self.units)
+        else:
+            arr_w0 = np.asarray(w0)
+        arr_w0 = atleast_2d(arr_w0, insert_axis=1)
+        arr_w0 = np.ascontiguousarray(arr_w0, dtype=np.float64)
+
+        t = np.ascontiguousarray(parse_time_specification(self.units, **time_spec))
+
+        t, w = stochastic_leapfrog_integrate(
+            self.H, arr_w0, t, self.diffusion, self.seed, int(save_all)
+        )
+
+        if w.shape[-1] == 1:
+            w = w[..., 0]
+        if not save_all:
+            w = w[:, None]
+
+        try:
+            tunit = self.units["time"]
+        except (TypeError, AttributeError):
+            tunit = u.dimensionless_unscaled
+        t = u.Quantity(t, tunit, copy=False)
+
+        return Orbit.from_w(w=w, units=self.units, t=t, hamiltonian=self.H)

--- a/src/gala/dynamics/diffusion/core.py
+++ b/src/gala/dynamics/diffusion/core.py
@@ -1,6 +1,6 @@
 """
 A standalone orchestrator (modeled on ``DirectNBody``) that integrates orbits
-with an added stochastic velocity-diffusion term, using a fixed-step leapfrog +
+with an added stochastic velocity-diffusion term, using a fixed-step
 Euler-Maruyama scheme implemented in Cython.
 """
 
@@ -13,7 +13,7 @@ from ...units import UnitSystem
 from ...util import atleast_2d
 from ..core import PhaseSpacePosition
 from ..orbit import Orbit
-from .cydiffusion import stochastic_leapfrog_integrate
+from .cydiffusion import euler_maruyama_integrate
 from .diffusion_models import DiffusionBase
 
 __all__ = ["StochasticOrbitIntegrator"]
@@ -22,11 +22,12 @@ __all__ = ["StochasticOrbitIntegrator"]
 class StochasticOrbitIntegrator:
     """Integrate tracer orbits with stochastic (diffusive) velocity kicks.
 
-    This is a trial implementation of an SDE integrator: the deterministic
-    dynamics come from a (static-frame) potential and are advanced with a
-    symplectic leapfrog step, and a stochastic velocity kick set by a diffusion
-    model is added each step (Euler-Maruyama). With a zero diffusion model this
-    reduces to ordinary leapfrog integration.
+    This is a trial implementation of an SDE integrator using a fixed-step
+    Euler-Maruyama scheme: each step, positions and velocities are advanced by
+    the deterministic (static-frame) dynamics and a stochastic velocity kick set
+    by a diffusion model is added. With a zero diffusion model this reduces to
+    deterministic forward-Euler integration. This is a low-order scheme; a
+    higher-order scheme may be added in the future.
 
     Parameters
     ----------
@@ -125,7 +126,7 @@ class StochasticOrbitIntegrator:
 
         t = np.ascontiguousarray(parse_time_specification(self.units, **time_spec))
 
-        t, w = stochastic_leapfrog_integrate(
+        t, w = euler_maruyama_integrate(
             self.H, arr_w0, t, self.diffusion, self.seed, int(save_all)
         )
 

--- a/src/gala/dynamics/diffusion/cydiffusion.pxd
+++ b/src/gala/dynamics/diffusion/cydiffusion.pxd
@@ -1,0 +1,41 @@
+# cython: language_level=3
+# cython: language=c++
+
+cdef extern from "dynamics/diffusion/src/diffusion.h":
+    ctypedef void (*diffusionfunc)(
+        double t, double *pars, double *q, double *v, int n_dim,
+        double *drift, double *M, void *state
+    ) noexcept nogil
+
+    ctypedef struct CDiffusion:
+        int n_dim
+        int returns_factor
+        int n_params
+        diffusionfunc func
+        double *parameters
+        void *state
+
+    void *gala_diffusion_rng_alloc(unsigned long long seed) nogil
+    double gala_diffusion_rng_gaussian(void *rng) nogil
+    void gala_diffusion_rng_free(void *rng) nogil
+    int gala_diffusion_cholesky(const double *M, int n_dim, double *L) nogil
+
+    void constant_diag_diffusion(
+        double t, double *pars, double *q, double *v, int n_dim,
+        double *drift, double *M, void *state
+    ) noexcept nogil
+    void constant_tensor_diffusion(
+        double t, double *pars, double *q, double *v, int n_dim,
+        double *drift, double *M, void *state
+    ) noexcept nogil
+    void example_radial_diffusion(
+        double t, double *pars, double *q, double *v, int n_dim,
+        double *drift, double *M, void *state
+    ) noexcept nogil
+
+
+cdef class CDiffusionWrapper:
+    cdef CDiffusion diffusion
+    cdef double[::1] _params
+    cpdef init(self, double[::1] parameters, int n_dim, int returns_factor)
+    cdef CDiffusion* get_ptr(self) noexcept nogil

--- a/src/gala/dynamics/diffusion/cydiffusion.pyx
+++ b/src/gala/dynamics/diffusion/cydiffusion.pyx
@@ -1,0 +1,243 @@
+# cython: boundscheck=False
+# cython: nonecheck=False
+# cython: cdivision=True
+# cython: wraparound=False
+# cython: profile=False
+# cython: language_level=3
+# cython: language=c++
+
+"""
+Cython layer for the trial SDE / diffusion integrator.
+
+Provides:
+  - ``CDiffusionWrapper`` and per-model subclasses that hold a ``CDiffusion``
+    struct pointing at a compiled C diffusion model (mirrors the
+    ``CPotentialWrapper`` pattern).
+  - ``stochastic_leapfrog_integrate``: a fixed-step leapfrog integrator with an
+    added Euler-Maruyama stochastic velocity kick each step. The deterministic
+    part is a verbatim copy of the leapfrog step used by
+    ``gala.integrate.cyintegrators.leapfrog`` (cdef functions there are module
+    -static and cannot be shared across extensions, so they are copied here).
+"""
+
+import numpy as np
+cimport numpy as np
+np.import_array()
+
+from libc.math cimport sqrt
+
+from ...potential.potential.cpotential cimport CPotentialWrapper, CPotential, c_gradient
+from ...potential.frame import StaticFrame
+from ..._cconfig cimport USE_GSL
+
+
+# ----------------------------------------------------------------------------
+# Deterministic leapfrog step (copied from integrate/cyintegrators/leapfrog.pyx)
+
+cdef void c_init_velocity(CPotential *p, size_t n, int half_ndim, double t, double dt,
+                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) noexcept nogil:
+    cdef int i, k
+    c_gradient(p, n, t, x_jm1, grad)
+    for k in range(half_ndim):
+        for i in range(n):
+            v_jm1_2[i + k * n] = v_jm1[i + k * n] - grad[i + k * n] * dt / 2.
+
+
+cdef void c_leapfrog_step(CPotential *p, size_t n, int half_ndim, double t, double dt,
+                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) noexcept nogil:
+    cdef int i, k
+
+    # full step the positions
+    for k in range(half_ndim):
+        for i in range(n):
+            x_jm1[i + k * n] = x_jm1[i + k * n] + v_jm1_2[i + k * n] * dt
+
+    c_gradient(p, n, t, x_jm1, grad)  # gradient at new position
+
+    # synchronized velocity (v_jm1) and half-step-ahead velocity (v_jm1_2)
+    for k in range(half_ndim):
+        for i in range(n):
+            v_jm1[i + k * n] = v_jm1_2[i + k * n] - grad[i + k * n] * dt / 2.
+            v_jm1_2[i + k * n] = v_jm1_2[i + k * n] - grad[i + k * n] * dt
+
+
+# ----------------------------------------------------------------------------
+# Stochastic velocity kick (Euler-Maruyama) for a single orbit
+
+cdef void c_apply_kick(CDiffusion *diff, void *rng, double t, int half_ndim, size_t n,
+                       size_t i, double *x_ptr, double *v_sync, double *v_stag,
+                       double dt, double sqrt_dt, double *q_i, double *v_i,
+                       double *drift, double *M, double *L, double *xi) noexcept nogil:
+    cdef int k, l
+    cdef double dv
+
+    # gather this orbit's position / synchronized velocity
+    for k in range(half_ndim):
+        q_i[k] = x_ptr[i + k * n]
+        v_i[k] = v_sync[i + k * n]
+
+    # evaluate the diffusion model at (t, q, v)
+    diff.func(t, diff.parameters, q_i, v_i, half_ndim, drift, M, diff.state)
+
+    # obtain the noise factor L (L L^T = D)
+    if diff.returns_factor == 0:
+        gala_diffusion_cholesky(M, half_ndim, L)
+    else:
+        for k in range(half_ndim * half_ndim):
+            L[k] = M[k]
+
+    # draw standard-normal noise
+    for k in range(half_ndim):
+        xi[k] = gala_diffusion_rng_gaussian(rng)
+
+    # dv = drift * dt + L @ (sqrt(dt) * xi), applied to both velocity copies
+    for k in range(half_ndim):
+        dv = drift[k] * dt
+        for l in range(half_ndim):
+            dv = dv + L[k * half_ndim + l] * sqrt_dt * xi[l]
+        v_sync[i + k * n] = v_sync[i + k * n] + dv
+        v_stag[i + k * n] = v_stag[i + k * n] + dv
+
+
+# ----------------------------------------------------------------------------
+# Diffusion model wrappers
+
+cdef class CDiffusionWrapper:
+    """
+    Cython wrapper holding a ``CDiffusion`` struct. Subclasses assign the C model
+    function pointer (and the ``returns_factor`` flag) in ``__init__``.
+    """
+
+    cpdef init(self, double[::1] parameters, int n_dim, int returns_factor):
+        self._params = np.ascontiguousarray(parameters, dtype=np.float64)
+        self.diffusion.n_dim = n_dim
+        self.diffusion.returns_factor = returns_factor
+        self.diffusion.n_params = self._params.shape[0]
+        if self._params.shape[0] > 0:
+            self.diffusion.parameters = &self._params[0]
+        else:
+            self.diffusion.parameters = NULL
+        self.diffusion.func = NULL
+        self.diffusion.state = NULL
+
+    cdef CDiffusion* get_ptr(self) noexcept nogil:
+        return &self.diffusion
+
+
+cdef class ConstantDiagDiffusionWrapper(CDiffusionWrapper):
+    def __init__(self, parameters, n_dim):
+        self.init(np.ascontiguousarray(parameters, dtype=np.float64), n_dim, 1)
+        self.diffusion.func = <diffusionfunc>constant_diag_diffusion
+
+
+cdef class ConstantTensorDiffusionWrapper(CDiffusionWrapper):
+    def __init__(self, parameters, n_dim):
+        self.init(np.ascontiguousarray(parameters, dtype=np.float64), n_dim, 0)
+        self.diffusion.func = <diffusionfunc>constant_tensor_diffusion
+
+
+cdef class ExampleRadialDiffusionWrapper(CDiffusionWrapper):
+    def __init__(self, parameters, n_dim):
+        self.init(np.ascontiguousarray(parameters, dtype=np.float64), n_dim, 1)
+        self.diffusion.func = <diffusionfunc>example_radial_diffusion
+
+
+# ----------------------------------------------------------------------------
+# The integrator
+
+cpdef stochastic_leapfrog_integrate(hamiltonian, double[:, ::1] w0, double[::1] t,
+                                    diffusion, unsigned long long seed,
+                                    int save_all=1):
+    """
+    w0: shape (ndim, n)  [ndim = full phase-space dimension = 2 * half_ndim]
+    returns: (t, w) with w shape (ndim, [ntimes,] n)
+    """
+    if USE_GSL != 1:
+        raise RuntimeError(
+            "The diffusion / SDE integrator requires GSL support. Please install "
+            "GSL and rebuild gala with GSL support to use this functionality."
+        )
+
+    if not hamiltonian.c_enabled:
+        raise TypeError("Input Hamiltonian object does not support C-level access.")
+
+    if not isinstance(hamiltonian.frame, StaticFrame):
+        raise TypeError(
+            "The diffusion integrator is currently only supported for StaticFrame, "
+            f"not {hamiltonian.frame.__class__.__name__}"
+        )
+
+    cdef:
+        size_t i
+        int j, k
+        int ndim = w0.shape[0]
+        size_t n = w0.shape[1]
+        int half_ndim = ndim // 2
+
+        int ntimes = len(t)
+        double dt = t[1] - t[0]
+        double sqrt_dt = sqrt(dt)
+
+        double[:, ::1] grad_v = np.zeros((half_ndim, n))
+        double[:, ::1] v_jm1_2 = np.zeros((half_ndim, n))
+
+        # per-orbit scratch buffers
+        double[::1] q_i = np.zeros(half_ndim)
+        double[::1] v_i = np.zeros(half_ndim)
+        double[::1] drift = np.zeros(half_ndim)
+        double[::1] M = np.zeros(half_ndim * half_ndim)
+        double[::1] L = np.zeros(half_ndim * half_ndim)
+        double[::1] xi = np.zeros(half_ndim)
+
+        double[:, :, ::1] all_w
+        double[:, ::1] tmp_w
+
+        CPotential* cp = (<CPotentialWrapper>(hamiltonian.potential.c_instance)).cpotential
+        CDiffusion* diff = (<CDiffusionWrapper>(diffusion.c_instance)).get_ptr()
+        void* rng
+
+    if diff.n_dim != half_ndim:
+        raise ValueError(
+            f"Diffusion model dimensionality ({diff.n_dim}) does not match the "
+            f"phase-space dimensionality of the initial conditions ({half_ndim})."
+        )
+
+    if save_all:
+        all_w = np.empty((ndim, ntimes, n))
+        all_w[:, 0, :] = w0
+
+    tmp_w = w0.copy()
+
+    rng = gala_diffusion_rng_alloc(seed)
+    try:
+        with nogil:
+            # prime velocities a half-step behind the positions
+            c_init_velocity(cp, n, half_ndim, t[0], dt,
+                            &tmp_w[0, 0], &tmp_w[half_ndim, 0],
+                            &v_jm1_2[0, 0], &grad_v[0, 0])
+
+            for j in range(1, ntimes, 1):
+                grad_v[:] = 0.
+
+                # deterministic leapfrog drift
+                c_leapfrog_step(cp, n, half_ndim, t[j], dt,
+                                &tmp_w[0, 0], &tmp_w[half_ndim, 0],
+                                &v_jm1_2[0, 0], &grad_v[0, 0])
+
+                # stochastic velocity kick per orbit
+                for i in range(n):
+                    c_apply_kick(diff, rng, t[j], half_ndim, n, i,
+                                 &tmp_w[0, 0], &tmp_w[half_ndim, 0], &v_jm1_2[0, 0],
+                                 dt, sqrt_dt,
+                                 &q_i[0], &v_i[0], &drift[0], &M[0], &L[0], &xi[0])
+
+                if save_all:
+                    for k in range(ndim):
+                        for i in range(n):
+                            all_w[k, j, i] = tmp_w[k, i]
+    finally:
+        gala_diffusion_rng_free(rng)
+
+    if save_all:
+        return np.asarray(t), np.asarray(all_w)
+    return np.asarray(t)[ntimes - 1:], np.asarray(tmp_w)

--- a/src/gala/dynamics/diffusion/cydiffusion.pyx
+++ b/src/gala/dynamics/diffusion/cydiffusion.pyx
@@ -44,7 +44,7 @@ cdef void c_em_step_orbit(CDiffusion *diff, void *rng, double t, int half_ndim,
                           size_t n, size_t i, double *x_ptr, double *v_ptr,
                           double *grad, double dt, double sqrt_dt, double *q_i,
                           double *v_i, double *drift, double *M, double *L,
-                          double *xi) noexcept nogil:
+                          double *zi) noexcept nogil:
     cdef int k, l
     cdef double dv
 
@@ -65,17 +65,17 @@ cdef void c_em_step_orbit(CDiffusion *diff, void *rng, double t, int half_ndim,
 
     # draw standard-normal noise
     for k in range(half_ndim):
-        xi[k] = gala_diffusion_rng_gaussian(rng)
+        zi[k] = gala_diffusion_rng_gaussian(rng)
 
     # Euler-Maruyama update (all terms use the start-of-step state):
     #   x_{n+1} = x_n + v_n dt
-    #   v_{n+1} = v_n + (a + mu) dt + L @ (sqrt(dt) xi),   a = -grad(Phi)
+    #   v_{n+1} = v_n + (a + mu) dt + L @ (sqrt(dt) zi),   a = -grad(Phi)
     for k in range(half_ndim):
         x_ptr[i + k * n] = q_i[k] + v_i[k] * dt
 
         dv = (-grad[i + k * n] + drift[k]) * dt
         for l in range(half_ndim):
-            dv = dv + L[k * half_ndim + l] * sqrt_dt * xi[l]
+            dv = dv + L[k * half_ndim + l] * sqrt_dt * zi[l]
         v_ptr[i + k * n] = v_i[k] + dv
 
 
@@ -117,6 +117,8 @@ cdef class ConstantTensorDiffusionWrapper(CDiffusionWrapper):
 
 
 cdef class ExampleRadialDiffusionWrapper(CDiffusionWrapper):
+    # NOTE: this is just a toy example to demonstrate how to implement a custom
+    # position- or velocity-dependent diffusion model.
     def __init__(self, parameters, n_dim):
         self.init(np.ascontiguousarray(parameters, dtype=np.float64), n_dim, 1)
         self.diffusion.func = <diffusionfunc>example_radial_diffusion
@@ -166,7 +168,7 @@ cpdef euler_maruyama_integrate(hamiltonian, double[:, ::1] w0, double[::1] t,
         double[::1] drift = np.zeros(half_ndim)
         double[::1] M = np.zeros(half_ndim * half_ndim)
         double[::1] L = np.zeros(half_ndim * half_ndim)
-        double[::1] xi = np.zeros(half_ndim)
+        double[::1] zi = np.zeros(half_ndim)
 
         double[:, :, ::1] all_w
         double[:, ::1] tmp_w
@@ -202,7 +204,7 @@ cpdef euler_maruyama_integrate(hamiltonian, double[:, ::1] w0, double[::1] t,
                                     &tmp_w[0, 0], &tmp_w[half_ndim, 0],
                                     &grad_v[0, 0], dt, sqrt_dt,
                                     &q_i[0], &v_i[0], &drift[0], &M[0], &L[0],
-                                    &xi[0])
+                                    &zi[0])
 
                 if save_all:
                     for k in range(ndim):

--- a/src/gala/dynamics/diffusion/cydiffusion.pyx
+++ b/src/gala/dynamics/diffusion/cydiffusion.pyx
@@ -13,11 +13,17 @@ Provides:
   - ``CDiffusionWrapper`` and per-model subclasses that hold a ``CDiffusion``
     struct pointing at a compiled C diffusion model (mirrors the
     ``CPotentialWrapper`` pattern).
-  - ``stochastic_leapfrog_integrate``: a fixed-step leapfrog integrator with an
-    added Euler-Maruyama stochastic velocity kick each step. The deterministic
-    part is a verbatim copy of the leapfrog step used by
-    ``gala.integrate.cyintegrators.leapfrog`` (cdef functions there are module
-    -static and cannot be shared across extensions, so they are copied here).
+  - ``euler_maruyama_integrate``: a fixed-step Euler-Maruyama integrator for the
+    SDE
+
+        dx = v dt
+        dv = a(x) dt + mu(x, v) dt + B(x, v) dW,   dW ~ N(0, dt I),  B B^T = D
+
+    where a = -grad(Phi) is the deterministic acceleration, mu is an optional
+    deterministic velocity drift, and D is the velocity-space diffusion tensor.
+    All coefficients are evaluated at the start of each step (Ito convention).
+    This is deliberately a simple first-order scheme; a higher-order scheme can
+    be added later.
 """
 
 import numpy as np
@@ -32,49 +38,20 @@ from ..._cconfig cimport USE_GSL
 
 
 # ----------------------------------------------------------------------------
-# Deterministic leapfrog step (copied from integrate/cyintegrators/leapfrog.pyx)
+# Single-orbit Euler-Maruyama update
 
-cdef void c_init_velocity(CPotential *p, size_t n, int half_ndim, double t, double dt,
-                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) noexcept nogil:
-    cdef int i, k
-    c_gradient(p, n, t, x_jm1, grad)
-    for k in range(half_ndim):
-        for i in range(n):
-            v_jm1_2[i + k * n] = v_jm1[i + k * n] - grad[i + k * n] * dt / 2.
-
-
-cdef void c_leapfrog_step(CPotential *p, size_t n, int half_ndim, double t, double dt,
-                          double *x_jm1, double *v_jm1, double *v_jm1_2, double *grad) noexcept nogil:
-    cdef int i, k
-
-    # full step the positions
-    for k in range(half_ndim):
-        for i in range(n):
-            x_jm1[i + k * n] = x_jm1[i + k * n] + v_jm1_2[i + k * n] * dt
-
-    c_gradient(p, n, t, x_jm1, grad)  # gradient at new position
-
-    # synchronized velocity (v_jm1) and half-step-ahead velocity (v_jm1_2)
-    for k in range(half_ndim):
-        for i in range(n):
-            v_jm1[i + k * n] = v_jm1_2[i + k * n] - grad[i + k * n] * dt / 2.
-            v_jm1_2[i + k * n] = v_jm1_2[i + k * n] - grad[i + k * n] * dt
-
-
-# ----------------------------------------------------------------------------
-# Stochastic velocity kick (Euler-Maruyama) for a single orbit
-
-cdef void c_apply_kick(CDiffusion *diff, void *rng, double t, int half_ndim, size_t n,
-                       size_t i, double *x_ptr, double *v_sync, double *v_stag,
-                       double dt, double sqrt_dt, double *q_i, double *v_i,
-                       double *drift, double *M, double *L, double *xi) noexcept nogil:
+cdef void c_em_step_orbit(CDiffusion *diff, void *rng, double t, int half_ndim,
+                          size_t n, size_t i, double *x_ptr, double *v_ptr,
+                          double *grad, double dt, double sqrt_dt, double *q_i,
+                          double *v_i, double *drift, double *M, double *L,
+                          double *xi) noexcept nogil:
     cdef int k, l
     cdef double dv
 
-    # gather this orbit's position / synchronized velocity
+    # gather this orbit's state at the start of the step
     for k in range(half_ndim):
         q_i[k] = x_ptr[i + k * n]
-        v_i[k] = v_sync[i + k * n]
+        v_i[k] = v_ptr[i + k * n]
 
     # evaluate the diffusion model at (t, q, v)
     diff.func(t, diff.parameters, q_i, v_i, half_ndim, drift, M, diff.state)
@@ -90,13 +67,16 @@ cdef void c_apply_kick(CDiffusion *diff, void *rng, double t, int half_ndim, siz
     for k in range(half_ndim):
         xi[k] = gala_diffusion_rng_gaussian(rng)
 
-    # dv = drift * dt + L @ (sqrt(dt) * xi), applied to both velocity copies
+    # Euler-Maruyama update (all terms use the start-of-step state):
+    #   x_{n+1} = x_n + v_n dt
+    #   v_{n+1} = v_n + (a + mu) dt + L @ (sqrt(dt) xi),   a = -grad(Phi)
     for k in range(half_ndim):
-        dv = drift[k] * dt
+        x_ptr[i + k * n] = q_i[k] + v_i[k] * dt
+
+        dv = (-grad[i + k * n] + drift[k]) * dt
         for l in range(half_ndim):
             dv = dv + L[k * half_ndim + l] * sqrt_dt * xi[l]
-        v_sync[i + k * n] = v_sync[i + k * n] + dv
-        v_stag[i + k * n] = v_stag[i + k * n] + dv
+        v_ptr[i + k * n] = v_i[k] + dv
 
 
 # ----------------------------------------------------------------------------
@@ -145,9 +125,9 @@ cdef class ExampleRadialDiffusionWrapper(CDiffusionWrapper):
 # ----------------------------------------------------------------------------
 # The integrator
 
-cpdef stochastic_leapfrog_integrate(hamiltonian, double[:, ::1] w0, double[::1] t,
-                                    diffusion, unsigned long long seed,
-                                    int save_all=1):
+cpdef euler_maruyama_integrate(hamiltonian, double[:, ::1] w0, double[::1] t,
+                               diffusion, unsigned long long seed,
+                               int save_all=1):
     """
     w0: shape (ndim, n)  [ndim = full phase-space dimension = 2 * half_ndim]
     returns: (t, w) with w shape (ndim, [ntimes,] n)
@@ -179,7 +159,6 @@ cpdef stochastic_leapfrog_integrate(hamiltonian, double[:, ::1] w0, double[::1] 
         double sqrt_dt = sqrt(dt)
 
         double[:, ::1] grad_v = np.zeros((half_ndim, n))
-        double[:, ::1] v_jm1_2 = np.zeros((half_ndim, n))
 
         # per-orbit scratch buffers
         double[::1] q_i = np.zeros(half_ndim)
@@ -211,25 +190,19 @@ cpdef stochastic_leapfrog_integrate(hamiltonian, double[:, ::1] w0, double[::1] 
     rng = gala_diffusion_rng_alloc(seed)
     try:
         with nogil:
-            # prime velocities a half-step behind the positions
-            c_init_velocity(cp, n, half_ndim, t[0], dt,
-                            &tmp_w[0, 0], &tmp_w[half_ndim, 0],
-                            &v_jm1_2[0, 0], &grad_v[0, 0])
-
             for j in range(1, ntimes, 1):
                 grad_v[:] = 0.
 
-                # deterministic leapfrog drift
-                c_leapfrog_step(cp, n, half_ndim, t[j], dt,
-                                &tmp_w[0, 0], &tmp_w[half_ndim, 0],
-                                &v_jm1_2[0, 0], &grad_v[0, 0])
+                # deterministic acceleration at the current positions
+                c_gradient(cp, n, t[j - 1], &tmp_w[0, 0], &grad_v[0, 0])
 
-                # stochastic velocity kick per orbit
+                # Euler-Maruyama update (drift + stochastic kick) per orbit
                 for i in range(n):
-                    c_apply_kick(diff, rng, t[j], half_ndim, n, i,
-                                 &tmp_w[0, 0], &tmp_w[half_ndim, 0], &v_jm1_2[0, 0],
-                                 dt, sqrt_dt,
-                                 &q_i[0], &v_i[0], &drift[0], &M[0], &L[0], &xi[0])
+                    c_em_step_orbit(diff, rng, t[j - 1], half_ndim, n, i,
+                                    &tmp_w[0, 0], &tmp_w[half_ndim, 0],
+                                    &grad_v[0, 0], dt, sqrt_dt,
+                                    &q_i[0], &v_i[0], &drift[0], &M[0], &L[0],
+                                    &xi[0])
 
                 if save_all:
                     for k in range(ndim):

--- a/src/gala/dynamics/diffusion/diffusion_models.py
+++ b/src/gala/dynamics/diffusion/diffusion_models.py
@@ -1,0 +1,166 @@
+"""
+Python-facing diffusion-coefficient model classes for the trial SDE integrator.
+
+Each class declares its parameters with :class:`~gala.potential.common.PotentialParameter`
+(reusing gala's parameter/unit machinery) and links to a compiled Cython
+``*Wrapper`` that points at a C diffusion model function.
+
+Unit convention
+---------------
+Diffusion coefficients have units of ``velocity**2 / time`` (a diffusion tensor)
+which is not a named astropy physical type, so parameters are handled directly:
+pass an astropy :class:`~astropy.units.Quantity` (decomposed into the model's unit
+system) or a plain number already expressed in that unit system. For example, in
+``galactic`` units a diffusion rate is in ``(kpc/Myr)**2 / Myr``.
+"""
+
+import numpy as np
+
+from ...potential.common import CommonBase, PotentialParameter
+from .cydiffusion import (
+    ConstantDiagDiffusionWrapper,
+    ConstantTensorDiffusionWrapper,
+    ExampleRadialDiffusionWrapper,
+)
+
+__all__ = [
+    "ConstantDiffusion",
+    "ConstantTensorDiffusion",
+    "DiffusionBase",
+    "ExampleRadialDiffusion",
+]
+
+
+class DiffusionBase(CommonBase):
+    """Base class for velocity-space diffusion models.
+
+    Subclasses declare parameters as class-level
+    :class:`~gala.potential.common.PotentialParameter` descriptors and set the
+    ``Wrapper`` attribute to the corresponding Cython wrapper class.
+    """
+
+    ndim = 3
+    Wrapper = None
+    # expected length of the flattened C parameter array (None to skip the check)
+    _n_c_params = None
+
+    def __init__(self, *args, units=None, **kwargs):
+        parameter_values, parameter_is_default = self._parse_parameter_values(
+            *args, **kwargs
+        )
+        self._units = self._validate_units(units)
+        self.parameters = parameter_values
+        self.parameter_is_default = set(parameter_is_default)
+        self._setup_wrapper()
+
+    @property
+    def units(self):
+        return self._units
+
+    def _param_value_in_units(self, v):
+        if hasattr(v, "unit"):
+            return np.atleast_1d(v.decompose(self.units).value).ravel()
+        return np.atleast_1d(np.asarray(v, dtype=float)).ravel()
+
+    def _setup_wrapper(self):
+        if self.Wrapper is None:
+            raise ValueError(
+                f"Diffusion wrapper class not defined for {self.__class__}"
+            )
+
+        arrs = []
+        for k, v in self.parameters.items():
+            if self._parameters[k].python_only:
+                continue
+            arrs.append(self._param_value_in_units(v))
+
+        c_parameters = np.concatenate(arrs) if arrs else np.array([], dtype=float)
+
+        if self._n_c_params is not None and len(c_parameters) != self._n_c_params:
+            raise ValueError(
+                f"{self.__class__.__name__} expected {self._n_c_params} C "
+                f"parameter value(s) but got {len(c_parameters)}. Check the "
+                "shape of the parameter(s) you passed in."
+            )
+
+        self.c_parameters = np.ascontiguousarray(c_parameters, dtype=np.float64)
+        self.c_instance = self.Wrapper(self.c_parameters, self.ndim)
+
+    def replace_units(self, units):
+        """Return a copy of this diffusion model in a new unit system."""
+        params = {
+            k: v
+            for k, v in self.parameters.items()
+            if k not in self.parameter_is_default
+        }
+        return self.__class__(**params, units=units)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: {dict(self.parameters)}>"
+
+
+class ConstantDiffusion(DiffusionBase):
+    r"""Constant, diagonal velocity-space diffusion.
+
+    Each velocity component :math:`i` diffuses independently with rate
+    :math:`D_i`, so that the per-step velocity kick has covariance
+    :math:`\mathrm{diag}(D)\,\Delta t`.
+
+    Parameters
+    ----------
+    D : array_like or `~astropy.units.Quantity`
+        Length-``ndim`` (=3) vector of per-component diffusion rates, in units
+        of ``velocity**2 / time``.
+    units : `~gala.units.UnitSystem`
+        The unit system the coefficients are expressed in.
+    """
+
+    D = PotentialParameter("D", physical_type=None, ndim=1)
+    Wrapper = ConstantDiagDiffusionWrapper
+    _n_c_params = 3
+
+
+class ConstantTensorDiffusion(DiffusionBase):
+    r"""Constant, full-tensor velocity-space diffusion.
+
+    The per-step velocity kick has covariance :math:`D\,\Delta t`, where
+    :math:`D` is a symmetric positive-semidefinite ``ndim x ndim`` diffusion
+    tensor.
+
+    Parameters
+    ----------
+    D : array_like or `~astropy.units.Quantity`
+        Symmetric ``ndim x ndim`` (=3x3) diffusion tensor, in units of
+        ``velocity**2 / time``.
+    units : `~gala.units.UnitSystem`
+        The unit system the coefficients are expressed in.
+    """
+
+    D = PotentialParameter("D", physical_type=None, ndim=2)
+    Wrapper = ConstantTensorDiffusionWrapper
+    _n_c_params = 9
+
+
+class ExampleRadialDiffusion(DiffusionBase):
+    r"""Example position-dependent diagonal diffusion (a TEMPLATE).
+
+    Demonstrates a model whose amplitude depends on position: the diagonal
+    diffusion factor is scaled by :math:`\exp(-|q| / r_s)`. This is an
+    illustration of the pattern for adding real, spatially varying prescriptions
+    (e.g. ISM or impulsive-kick diffusion) -- it is not a physical model.
+
+    Parameters
+    ----------
+    D : array_like or `~astropy.units.Quantity`
+        Length-``ndim`` (=3) vector of central per-component diffusion rates, in
+        units of ``velocity**2 / time``.
+    r_s : `~astropy.units.Quantity` or float
+        Scale radius over which the diffusion amplitude decays, in length units.
+    units : `~gala.units.UnitSystem`
+        The unit system the coefficients are expressed in.
+    """
+
+    D = PotentialParameter("D", physical_type=None, ndim=1)
+    r_s = PotentialParameter("r_s", physical_type="length", ndim=0)
+    Wrapper = ExampleRadialDiffusionWrapper
+    _n_c_params = 4

--- a/src/gala/dynamics/diffusion/src/diffusion.cpp
+++ b/src/gala/dynamics/diffusion/src/diffusion.cpp
@@ -109,6 +109,9 @@ void constant_tensor_diffusion(double t, double *pars, double *q, double *v,
 
 void example_radial_diffusion(double t, double *pars, double *q, double *v,
                               int n_dim, double *drift, double *M, void *state) {
+    /*
+    NOTE: this is just a toy example to demonstrate how to implement a custom position- or velocity-dependent diffusion model.
+    */
     (void)t;
     (void)v;
     (void)state;

--- a/src/gala/dynamics/diffusion/src/diffusion.cpp
+++ b/src/gala/dynamics/diffusion/src/diffusion.cpp
@@ -1,0 +1,137 @@
+/*
+    Implementation of the diffusion RNG helpers, Cholesky factorization, and the
+    builtin C diffusion models declared in diffusion.h.
+
+    GSL is only touched inside the RNG helpers, guarded by USE_GSL, so that the
+    Cython layer never needs to see GSL headers.
+*/
+#include "extra_compile_macros.h"
+#include <cmath>
+#include <cstdlib>
+#include "diffusion.h"
+
+#if USE_GSL == 1
+#include "gsl/gsl_rng.h"
+#include "gsl/gsl_randist.h"
+#endif
+
+extern "C" {
+
+void *gala_diffusion_rng_alloc(unsigned long long seed) {
+#if USE_GSL == 1
+    gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
+    gsl_rng_set(r, (unsigned long)seed);
+    return (void *)r;
+#else
+    (void)seed;
+    return NULL;
+#endif
+}
+
+double gala_diffusion_rng_gaussian(void *rng) {
+#if USE_GSL == 1
+    return gsl_ran_ugaussian((gsl_rng *)rng);
+#else
+    (void)rng;
+    return 0.0;
+#endif
+}
+
+void gala_diffusion_rng_free(void *rng) {
+#if USE_GSL == 1
+    if (rng != NULL) {
+        gsl_rng_free((gsl_rng *)rng);
+    }
+#else
+    (void)rng;
+#endif
+}
+
+int gala_diffusion_cholesky(const double *M, int n_dim, double *L) {
+    // Standard lower-triangular Cholesky (row-major). Non-positive-definite
+    // directions are clamped to zero so that positive-semidefinite (including
+    // all-zero) inputs still produce a usable factor.
+    for (int i = 0; i < n_dim * n_dim; i++) {
+        L[i] = 0.0;
+    }
+    for (int i = 0; i < n_dim; i++) {
+        for (int j = 0; j <= i; j++) {
+            double s = M[i * n_dim + j];
+            for (int k = 0; k < j; k++) {
+                s -= L[i * n_dim + k] * L[j * n_dim + k];
+            }
+            if (i == j) {
+                L[i * n_dim + j] = (s > 0.0) ? sqrt(s) : 0.0;
+            } else {
+                double Ljj = L[j * n_dim + j];
+                L[i * n_dim + j] = (Ljj != 0.0) ? (s / Ljj) : 0.0;
+            }
+        }
+    }
+    return 0;
+}
+
+// ---- builtin diffusion models ----
+
+void constant_diag_diffusion(double t, double *pars, double *q, double *v,
+                             int n_dim, double *drift, double *M, void *state) {
+    (void)t;
+    (void)q;
+    (void)v;
+    (void)state;
+    for (int i = 0; i < n_dim; i++) {
+        drift[i] = 0.0;
+    }
+    for (int i = 0; i < n_dim * n_dim; i++) {
+        M[i] = 0.0;
+    }
+    // returns_factor = 1: fill the factor B = diag(sqrt(D_i))
+    for (int i = 0; i < n_dim; i++) {
+        double Di = pars[i];
+        M[i * n_dim + i] = (Di > 0.0) ? sqrt(Di) : 0.0;
+    }
+}
+
+void constant_tensor_diffusion(double t, double *pars, double *q, double *v,
+                               int n_dim, double *drift, double *M, void *state) {
+    (void)t;
+    (void)q;
+    (void)v;
+    (void)state;
+    for (int i = 0; i < n_dim; i++) {
+        drift[i] = 0.0;
+    }
+    // returns_factor = 0: M is the (symmetric) diffusion tensor D itself
+    for (int i = 0; i < n_dim * n_dim; i++) {
+        M[i] = pars[i];
+    }
+}
+
+void example_radial_diffusion(double t, double *pars, double *q, double *v,
+                              int n_dim, double *drift, double *M, void *state) {
+    (void)t;
+    (void)v;
+    (void)state;
+    // pars = [D_0, ..., D_{n_dim-1}, r_s]
+    double r2 = 0.0;
+    for (int i = 0; i < n_dim; i++) {
+        r2 += q[i] * q[i];
+    }
+    double r = sqrt(r2);
+    double r_s = pars[n_dim];
+    double scale = exp(-r / r_s); // amplitude decays with radius; TEMPLATE only
+
+    for (int i = 0; i < n_dim; i++) {
+        drift[i] = 0.0;
+    }
+    for (int i = 0; i < n_dim * n_dim; i++) {
+        M[i] = 0.0;
+    }
+    // returns_factor = 1: fill factor B = diag(sqrt(D_i)) * scale
+    for (int i = 0; i < n_dim; i++) {
+        double Di = pars[i];
+        M[i * n_dim + i] = ((Di > 0.0) ? sqrt(Di) : 0.0) * scale;
+    }
+}
+
+} // extern "C"

--- a/src/gala/dynamics/diffusion/src/diffusion.h
+++ b/src/gala/dynamics/diffusion/src/diffusion.h
@@ -1,0 +1,101 @@
+/*
+    C-level scaffolding for velocity-space diffusion models used by the trial
+    SDE / diffusion integrator (see gala.dynamics.diffusion).
+
+    A "diffusion model" is a compiled C function that, given a time, position,
+    and velocity, fills in a (velocity) drift vector and an n_dim x n_dim matrix
+    describing the local diffusion. This mirrors the function-pointer + parameter
+    array pattern used by gala's builtin C potentials (see funcdefs.h /
+    cpotential.h), but for diffusion coefficients rather than forces.
+*/
+#ifndef _GALA_DIFFUSION_H
+#define _GALA_DIFFUSION_H
+
+#include <stddef.h>
+
+/*
+    Diffusion coefficient function pointer type.
+
+    Arguments:
+        t       - time
+        pars    - parameter array (pars[0]... ; NOTE: no G, unlike potentials)
+        q       - position, length n_dim
+        v       - velocity, length n_dim
+        n_dim   - number of spatial dimensions (typically 3)
+        drift   - OUTPUT: deterministic velocity drift, length n_dim. Fill with
+                  0 for pure diffusion; use for a noise-induced / Fokker-Planck
+                  drift-correction term.
+        M       - OUTPUT: n_dim x n_dim matrix (row-major). Interpreted as either
+                  the diffusion tensor D or a pre-computed factor B depending on
+                  the CDiffusion.returns_factor flag (see below).
+        state   - opaque per-model state (may be NULL).
+*/
+typedef void (*diffusionfunc)(double t, double *pars, double *q, double *v,
+                              int n_dim, double *drift, double *M, void *state);
+
+typedef struct _CDiffusion CDiffusion;
+struct _CDiffusion {
+    int n_dim;          // spatial dimensionality (velocity-space dimension)
+    int returns_factor; // 0 => M is the diffusion tensor D (needs Cholesky)
+                        // 1 => M is a factor B with B B^T = D (applied directly)
+    int n_params;       // number of entries in `parameters`
+    diffusionfunc func; // the model function
+    double *parameters; // parameter array (owned by the Cython wrapper)
+    void *state;        // opaque model state (may be NULL)
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+    Random number generation. Backed by GSL (gsl_rng / gsl_ran_ugaussian) when
+    gala is compiled with GSL; otherwise these are no-ops and the Python layer
+    refuses to run. The RNG pointer is opaque to the caller.
+*/
+void *gala_diffusion_rng_alloc(unsigned long long seed);
+double gala_diffusion_rng_gaussian(void *rng); /* draw ~ N(0, 1) */
+void gala_diffusion_rng_free(void *rng);
+
+/*
+    Lower-triangular Cholesky factorization of a symmetric n_dim x n_dim matrix
+    M (row-major) into L (row-major, lower triangular) so that L L^T = M. Degenerate
+    / non-positive-definite directions are handled by clamping to zero variance,
+    so a positive-semidefinite (including zero) M produces a valid best-effort
+    factor. Returns 0 (reserved for future error signaling).
+*/
+int gala_diffusion_cholesky(const double *M, int n_dim, double *L);
+
+/* ---- builtin diffusion models ---- */
+
+/*
+    Constant, diagonal velocity diffusion. Declared with returns_factor=1:
+        pars = [D_0, ..., D_{n_dim-1}]  (per-component diffusion rates)
+    fills drift=0 and B = diag(sqrt(D_i)), so Cov(kick) = diag(D_i) * dt.
+*/
+void constant_diag_diffusion(double t, double *pars, double *q, double *v,
+                             int n_dim, double *drift, double *M, void *state);
+
+/*
+    Constant, full-tensor velocity diffusion. Declared with returns_factor=0:
+        pars = flattened n_dim x n_dim symmetric diffusion tensor D (row-major)
+    fills drift=0 and M = D; the integrator Choleskys it. Cov(kick) = D * dt.
+*/
+void constant_tensor_diffusion(double t, double *pars, double *q, double *v,
+                               int n_dim, double *drift, double *M, void *state);
+
+/*
+    Example position-dependent diagonal diffusion (a TEMPLATE demonstrating how a
+    model can depend on q/v). Declared with returns_factor=1:
+        pars = [D_0, ..., D_{n_dim-1}, r_s]
+    fills B = diag(sqrt(D_i)) * exp(-|q| / r_s). Replace with real ISM / impulsive
+    -kick prescriptions following this same shape.
+*/
+void example_radial_diffusion(double t, double *pars, double *q, double *v,
+                              int n_dim, double *drift, double *M, void *state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/dynamics/test_diffusion.py
+++ b/tests/dynamics/test_diffusion.py
@@ -23,26 +23,34 @@ from gala.dynamics.diffusion import (
 )
 
 
-def test_diffusion_off_matches_leapfrog():
-    """With zero diffusion the integrator must reproduce plain leapfrog exactly."""
+def test_diffusion_off_matches_forward_euler():
+    """With zero diffusion the integrator must reduce to forward-Euler exactly."""
     pot = gp.HernquistPotential(m=1e11, c=10, units=galactic)
     diff = ConstantDiffusion(D=[0.0, 0.0, 0.0], units=galactic)
     soi = StochasticOrbitIntegrator(pot, diff, seed=42)
 
     w0 = gd.PhaseSpacePosition(pos=[10.0, 0, 0] * u.kpc, vel=[0, 150.0, 0] * u.km / u.s)
 
-    orbit = soi.integrate_orbit(w0, dt=1.0, n_steps=500)
+    dt, n_steps = 1.0, 500
+    orbit = soi.integrate_orbit(w0, dt=dt, n_steps=n_steps)
 
-    ref = gp.Hamiltonian(pot).integrate_orbit(
-        w0, dt=1.0, n_steps=500, Integrator="leapfrog"
-    )
+    # Independent forward-Euler reference using the same (C) gradient:
+    #   x_{n+1} = x_n + v_n dt ;  v_{n+1} = v_n - grad(x_n) dt
+    x = w0.xyz.decompose(galactic).value.reshape(3, 1).copy()
+    v = w0.v_xyz.decompose(galactic).value.reshape(3, 1).copy()
+    xs = [x.ravel().copy()]
+    vs = [v.ravel().copy()]
+    for _ in range(n_steps):
+        grad = pot._gradient(np.ascontiguousarray(x), t=np.array([0.0]))
+        x = x + v * dt
+        v = v - grad * dt
+        xs.append(x.ravel().copy())
+        vs.append(v.ravel().copy())
+    xs = np.array(xs).T  # (3, n_steps+1)
+    vs = np.array(vs).T
 
-    assert np.allclose(orbit.xyz.to_value(u.kpc), ref.xyz.to_value(u.kpc), atol=1e-12)
-    assert np.allclose(
-        orbit.v_xyz.to_value(u.kpc / u.Myr),
-        ref.v_xyz.to_value(u.kpc / u.Myr),
-        atol=1e-12,
-    )
+    assert np.allclose(orbit.xyz.to_value(u.kpc), xs, rtol=0, atol=1e-9)
+    assert np.allclose(orbit.v_xyz.to_value(u.kpc / u.Myr), vs, rtol=0, atol=1e-9)
 
 
 def test_reproducibility():

--- a/tests/dynamics/test_diffusion.py
+++ b/tests/dynamics/test_diffusion.py
@@ -1,0 +1,172 @@
+"""Tests for the trial SDE / diffusion integrator (gala.dynamics.diffusion)."""
+
+import astropy.units as u
+import numpy as np
+import pytest
+from gala._cconfig import GSL_ENABLED
+
+import gala.dynamics as gd
+import gala.potential as gp
+from gala.units import galactic
+
+if not GSL_ENABLED:
+    pytest.skip(
+        "skipping diffusion integrator tests: they depend on GSL",
+        allow_module_level=True,
+    )
+
+from gala.dynamics.diffusion import (
+    ConstantDiffusion,
+    ConstantTensorDiffusion,
+    ExampleRadialDiffusion,
+    StochasticOrbitIntegrator,
+)
+
+
+def test_diffusion_off_matches_leapfrog():
+    """With zero diffusion the integrator must reproduce plain leapfrog exactly."""
+    pot = gp.HernquistPotential(m=1e11, c=10, units=galactic)
+    diff = ConstantDiffusion(D=[0.0, 0.0, 0.0], units=galactic)
+    soi = StochasticOrbitIntegrator(pot, diff, seed=42)
+
+    w0 = gd.PhaseSpacePosition(pos=[10.0, 0, 0] * u.kpc, vel=[0, 150.0, 0] * u.km / u.s)
+
+    orbit = soi.integrate_orbit(w0, dt=1.0, n_steps=500)
+
+    ref = gp.Hamiltonian(pot).integrate_orbit(
+        w0, dt=1.0, n_steps=500, Integrator="leapfrog"
+    )
+
+    assert np.allclose(orbit.xyz.to_value(u.kpc), ref.xyz.to_value(u.kpc), atol=1e-12)
+    assert np.allclose(
+        orbit.v_xyz.to_value(u.kpc / u.Myr),
+        ref.v_xyz.to_value(u.kpc / u.Myr),
+        atol=1e-12,
+    )
+
+
+def test_reproducibility():
+    """Same seed -> identical orbits; different seed -> different orbits."""
+    pot = gp.NullPotential(units=galactic)
+    diff = ConstantDiffusion(D=[1e-4, 1e-4, 1e-4], units=galactic)
+    w0 = gd.PhaseSpacePosition(pos=[0, 0, 0] * u.kpc, vel=[0, 0, 0] * u.kpc / u.Myr)
+
+    o_a = StochasticOrbitIntegrator(pot, diff, seed=555).integrate_orbit(
+        w0, dt=1.0, n_steps=100
+    )
+    o_b = StochasticOrbitIntegrator(pot, diff, seed=555).integrate_orbit(
+        w0, dt=1.0, n_steps=100
+    )
+    o_c = StochasticOrbitIntegrator(pot, diff, seed=556).integrate_orbit(
+        w0, dt=1.0, n_steps=100
+    )
+
+    assert np.array_equal(o_a.xyz.value, o_b.xyz.value)
+    assert np.array_equal(o_a.v_xyz.value, o_b.v_xyz.value)
+    assert not np.array_equal(o_a.v_xyz.value, o_c.v_xyz.value)
+
+
+def test_velocity_variance_growth():
+    """Free particle + constant diagonal D: Var(v_i) should grow as D_i * T."""
+    N = 4000
+    D = np.array([1e-4, 4e-4, 2.5e-4])  # (kpc/Myr)^2 / Myr
+    pot = gp.NullPotential(units=galactic)
+    diff = ConstantDiffusion(D=D, units=galactic)
+    soi = StochasticOrbitIntegrator(pot, diff, seed=123)
+
+    w0 = gd.PhaseSpacePosition(
+        pos=np.zeros((3, N)) * u.kpc, vel=np.zeros((3, N)) * u.kpc / u.Myr
+    )
+    dt, n_steps = 0.5, 200
+    T = dt * n_steps
+
+    orbit = soi.integrate_orbit(w0, dt=dt, n_steps=n_steps)
+    var = orbit[-1].v_xyz.to_value(u.kpc / u.Myr).var(axis=1)
+
+    # ~1/sqrt(N) statistical tolerance
+    assert np.allclose(var, D * T, rtol=0.1)
+
+
+def test_full_tensor_covariance():
+    """Free particle + full tensor D: ensemble velocity covariance ~ D * T."""
+    N = 6000
+    D = np.array(
+        [
+            [3e-4, 1e-4, 0.0],
+            [1e-4, 2e-4, 0.0],
+            [0.0, 0.0, 1e-4],
+        ]
+    )
+    pot = gp.NullPotential(units=galactic)
+    diff = ConstantTensorDiffusion(D=D, units=galactic)
+    soi = StochasticOrbitIntegrator(pot, diff, seed=7)
+
+    w0 = gd.PhaseSpacePosition(
+        pos=np.zeros((3, N)) * u.kpc, vel=np.zeros((3, N)) * u.kpc / u.Myr
+    )
+    dt, n_steps = 0.5, 200
+    T = dt * n_steps
+
+    orbit = soi.integrate_orbit(w0, dt=dt, n_steps=n_steps)
+    cov = np.cov(orbit[-1].v_xyz.to_value(u.kpc / u.Myr))
+
+    target = D * T
+    mask = target != 0
+    assert np.max(np.abs((cov - target)[mask] / target[mask])) < 0.1
+    # near-zero entries stay small
+    assert np.all(np.abs(cov[~mask]) < 0.1 * target[mask].min())
+
+
+def test_shapes_and_save_all():
+    """Integrating N orbits at once and save_all=False return sane shapes."""
+    N = 5
+    pot = gp.HernquistPotential(m=1e11, c=10, units=galactic)
+    diff = ConstantDiffusion(D=[1e-5, 1e-5, 1e-5], units=galactic)
+    soi = StochasticOrbitIntegrator(pot, diff, seed=99)
+
+    pos = np.zeros((3, N)) * u.kpc
+    pos[0] = np.linspace(8, 12, N) * u.kpc
+    vel = np.zeros((3, N)) * u.km / u.s
+    vel[1] = np.linspace(150, 200, N) * u.km / u.s
+    w0 = gd.PhaseSpacePosition(pos=pos, vel=vel)
+
+    orbit = soi.integrate_orbit(w0, dt=1.0, n_steps=100)
+    assert orbit.shape == (101, N)
+
+    orbit_final = soi.integrate_orbit(w0, dt=1.0, n_steps=100, save_all=False)
+    assert orbit_final.shape == (1, N)
+
+
+def test_position_dependent_diffusion_runs():
+    """The template position-dependent model integrates and heats the orbit."""
+    N = 2000
+    pot = gp.HernquistPotential(m=1e11, c=10, units=galactic)
+    diff = ExampleRadialDiffusion(
+        D=[1e-4, 1e-4, 1e-4], r_s=10.0 * u.kpc, units=galactic
+    )
+    soi = StochasticOrbitIntegrator(pot, diff, seed=321)
+
+    pos = np.tile([[8.0], [0.0], [0.0]], (1, N)) * u.kpc
+    vel = np.tile([[0.0], [180.0], [0.0]], (1, N)) * u.km / u.s
+    w0 = gd.PhaseSpacePosition(pos=pos, vel=vel)
+
+    orbit = soi.integrate_orbit(w0, dt=1.0, n_steps=500)
+
+    # velocity dispersion should grow relative to the (identical) initial state
+    v0 = orbit[0].v_xyz.to_value(u.kpc / u.Myr).std(axis=1)
+    vf = orbit[-1].v_xyz.to_value(u.kpc / u.Myr).std(axis=1)
+    assert np.all(v0 < 1e-12)  # started identical
+    assert np.all(vf > 0)
+
+
+def test_requires_diffusion_base():
+    """Passing a non-DiffusionBase object raises a clear error."""
+    pot = gp.NullPotential(units=galactic)
+    with pytest.raises(TypeError):
+        StochasticOrbitIntegrator(pot, diffusion="not a model")
+
+
+def test_bad_parameter_shape():
+    """A wrongly shaped diffusion parameter raises a clear error."""
+    with pytest.raises(ValueError):
+        ConstantDiffusion(D=[1e-4, 1e-4], units=galactic)  # needs length 3


### PR DESCRIPTION
### Describe your changes

First off: This is a work in progress. But also, I see this as a temporary solution. In the long run, I'll refactor the `DirectNBody` / `Hamiltonian` machinery to replace with a generic `Simulation` class, and in that framework we'll be able to specify generic extra forces (including stochastic terms like these). In the mean time, this is a solution modeleed after `DirectNBody`. 

This is my first time using claude code for any significant development within Gala, so here was my prompt (for posterity).

> Implement support for supporting stochastic diffusion in Gala. This is a trial implementation to get something working with the existing package design. The SDE forces will be added to background forces from an external potential specified through the standard Gala potential machinery, similar to how DirectNBody is implemented. You will need to implement a Cython wrapper for the diffusion forces and a new integration scheme based on Euler-Maruyama to integrate the orbits. The implementation should work at the C/Cython layer of Gala for speed. The interface should support constant diffusion coefficients / tensors, but also demonstrate how one could implement a position- or velocity-dependent diffusion model. The interface should also support saving the diffusion forces at each time step. Git commit smaller chunks of work as you go.

Note: this still needs documentation and a tutorial!

### Checklist

- [x] Did you add tests?
- [ ] Did you add documentation for your changes?
- n/a Did you reference any relevant issues?
- [ ] Did you add a changelog entry? (see `CHANGES.rst`)
- [ ] Are the CI tests passing?
- [ ] Is the milestone set?
